### PR TITLE
Avoid spurious warning when uploading empty file using an InputStream.

### DIFF
--- a/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -944,7 +944,8 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
             request.addHeader(Headers.STORAGE_CLASS, putObjectRequest.getStorageClass());
         }
 
-        if (metadata.getContentLength() <= 0) {
+        // Use internal interface to differentiate 0 from unset.
+        if (metadata.getRawMetadata().get(Headers.CONTENT_LENGTH) == null) {
             /*
              * There's nothing we can do except for let the HTTP client buffer
              * the input stream contents if the caller doesn't tell us how much


### PR DESCRIPTION
Differentiate between 0 and unset content length when deciding whether to warm about stream buffering in memory. (See https://forums.aws.amazon.com/thread.jspa?threadID=75265&tstart=0)
