### PR TITLE
explicit inheritance of com.amazonaws.AmazonWebServiceClient's methods fo

### DIFF
--- a/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -33,7 +33,7 @@ import com.amazonaws.http.HttpRequest;
  * Responsible for basic client capabilities that are the same across all AWS
  * SDK Java clients (ex: setting the client endpoint).
  */
-public abstract class AmazonWebServiceClient {
+public abstract class AmazonWebServiceClient implements AmazonWebServicesClientInf {
 
     /** The service endpoint to which this client will send requests. */
     protected URI endpoint;

--- a/src/main/java/com/amazonaws/AmazonWebServicesClientInf.java
+++ b/src/main/java/com/amazonaws/AmazonWebServicesClientInf.java
@@ -1,0 +1,15 @@
+package com.amazonaws;
+
+import com.amazonaws.handlers.RequestHandler;
+
+public interface AmazonWebServicesClientInf {
+
+	public void setEndpoint(String endpoint) throws IllegalArgumentException;
+
+	public void shutdown();
+
+	public void addRequestHandler(RequestHandler requestHandler);
+
+	public void removeRequestHandler(RequestHandler requestHandler);
+
+}

--- a/src/main/java/com/amazonaws/services/autoscaling/AmazonAutoScaling.java
+++ b/src/main/java/com/amazonaws/services/autoscaling/AmazonAutoScaling.java
@@ -52,7 +52,7 @@ import com.amazonaws.services.autoscaling.model.*;
  * Reference.
  * </p>
  */
-public interface AmazonAutoScaling {
+public interface AmazonAutoScaling extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://autoscaling.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/cloudformation/AmazonCloudFormation.java
+++ b/src/main/java/com/amazonaws/services/cloudformation/AmazonCloudFormation.java
@@ -72,7 +72,7 @@ import com.amazonaws.services.cloudformation.model.*;
  * http://aws.amazon.com/documentation/ </a> .
  * </p>
  */
-public interface AmazonCloudFormation {
+public interface AmazonCloudFormation extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://cloudformation.us-east-1.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/cloudwatch/AmazonCloudWatch.java
+++ b/src/main/java/com/amazonaws/services/cloudwatch/AmazonCloudWatch.java
@@ -68,7 +68,7 @@ import com.amazonaws.services.cloudwatch.model.*;
  * 
  * </ul>
  */
-public interface AmazonCloudWatch {
+public interface AmazonCloudWatch extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://monitoring.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/ec2/AmazonEC2.java
+++ b/src/main/java/com/amazonaws/services/ec2/AmazonEC2.java
@@ -42,7 +42,7 @@ import com.amazonaws.services.ec2.model.*;
  * http://aws.amazon.com/ec2/ </a> for more information.
  * </p>
  */
-public interface AmazonEC2 {
+public interface AmazonEC2 extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://ec2.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/elasticache/AmazonElastiCache.java
+++ b/src/main/java/com/amazonaws/services/elasticache/AmazonElastiCache.java
@@ -38,7 +38,7 @@ import com.amazonaws.services.elasticache.model.*;
  * hot.
  * </p>
  */
-public interface AmazonElastiCache {
+public interface AmazonElastiCache extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://elasticache.us-east-1.amazonaws.com/").

--- a/src/main/java/com/amazonaws/services/elasticbeanstalk/AWSElasticBeanstalk.java
+++ b/src/main/java/com/amazonaws/services/elasticbeanstalk/AWSElasticBeanstalk.java
@@ -51,7 +51,7 @@ import com.amazonaws.services.elasticbeanstalk.model.*;
  * 
  * </ul>
  */
-public interface AWSElasticBeanstalk {
+public interface AWSElasticBeanstalk extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://elasticbeanstalk.us-east-1.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/elasticloadbalancing/AmazonElasticLoadBalancing.java
+++ b/src/main/java/com/amazonaws/services/elasticloadbalancing/AmazonElasticLoadBalancing.java
@@ -29,7 +29,7 @@ import com.amazonaws.services.elasticloadbalancing.model.*;
  * application.
  * </p>
  */
-public interface AmazonElasticLoadBalancing {
+public interface AmazonElasticLoadBalancing extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://elasticloadbalancing.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/elasticmapreduce/AmazonElasticMapReduce.java
+++ b/src/main/java/com/amazonaws/services/elasticmapreduce/AmazonElasticMapReduce.java
@@ -33,7 +33,7 @@ import com.amazonaws.services.elasticmapreduce.model.*;
  * scientific simulation, and data warehousing.
  * </p>
  */
-public interface AmazonElasticMapReduce {
+public interface AmazonElasticMapReduce extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://elasticmapreduce.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/identitymanagement/AmazonIdentityManagement.java
+++ b/src/main/java/com/amazonaws/services/identitymanagement/AmazonIdentityManagement.java
@@ -49,7 +49,7 @@ import com.amazonaws.services.identitymanagement.model.*;
  * apply.
  * </p>
  */
-public interface AmazonIdentityManagement {
+public interface AmazonIdentityManagement extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://iam.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/importexport/AmazonImportExport.java
+++ b/src/main/java/com/amazonaws/services/importexport/AmazonImportExport.java
@@ -30,7 +30,7 @@ import com.amazonaws.services.importexport.model.*;
  * upgrading your connectivity.
  * </p>
  */
-public interface AmazonImportExport {
+public interface AmazonImportExport extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://importexport.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/rds/AmazonRDS.java
+++ b/src/main/java/com/amazonaws/services/rds/AmazonRDS.java
@@ -41,7 +41,7 @@ import com.amazonaws.services.rds.model.*;
  * you use.
  * </p>
  */
-public interface AmazonRDS {
+public interface AmazonRDS extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://rds.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/s3/AmazonS3.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3.java
@@ -24,6 +24,7 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.HttpMethod;
+import com.amazonaws.AmazonWebServicesClientInf;
 import com.amazonaws.services.s3.internal.Constants;
 import com.amazonaws.services.s3.model.AbortMultipartUploadRequest;
 import com.amazonaws.services.s3.model.AccessControlList;
@@ -104,7 +105,7 @@ import com.amazonaws.services.s3.model.VersionListing;
  * http://aws.amazon.com/s3</a>
  * </p>
  */
-public interface AmazonS3 {
+public interface AmazonS3 extends AmazonWebServicesClientInf {
 
     /**
      * <p>

--- a/src/main/java/com/amazonaws/services/securitytoken/AWSSecurityTokenService.java
+++ b/src/main/java/com/amazonaws/services/securitytoken/AWSSecurityTokenService.java
@@ -54,7 +54,7 @@ import com.amazonaws.services.securitytoken.model.*;
  * apply.
  * </p>
  */
-public interface AWSSecurityTokenService {
+public interface AWSSecurityTokenService extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://sts.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/simpledb/AmazonSimpleDB.java
+++ b/src/main/java/com/amazonaws/services/simpledb/AmazonSimpleDB.java
@@ -43,7 +43,7 @@ import com.amazonaws.services.simpledb.model.*;
  * http://aws.amazon.com/simpledb/ </a> for more information.
  * </p>
  */
-public interface AmazonSimpleDB {
+public interface AmazonSimpleDB extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://sdb.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/simpleemail/AmazonSimpleEmailService.java
+++ b/src/main/java/com/amazonaws/services/simpleemail/AmazonSimpleEmailService.java
@@ -33,7 +33,7 @@ import com.amazonaws.services.simpleemail.model.*;
  * Amazon SES Developer Guide </a> .
  * </p>
  */
-public interface AmazonSimpleEmailService {
+public interface AmazonSimpleEmailService extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://email.us-east-1.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/sns/AmazonSNS.java
+++ b/src/main/java/com/amazonaws/services/sns/AmazonSNS.java
@@ -22,7 +22,7 @@ import com.amazonaws.services.sns.model.*;
  * Interface for accessing AmazonSNS.
  * Amazon Simple Notification Service
  */
-public interface AmazonSNS {
+public interface AmazonSNS extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://sns.us-east-1.amazonaws.com").

--- a/src/main/java/com/amazonaws/services/sqs/AmazonSQS.java
+++ b/src/main/java/com/amazonaws/services/sqs/AmazonSQS.java
@@ -43,7 +43,7 @@ import com.amazonaws.services.sqs.model.*;
  * </a> for more information.
  * </p>
  */
-public interface AmazonSQS {
+public interface AmazonSQS extends AmazonWebServicesClientInf {
 
     /**
      * Overrides the default endpoint for this client ("https://queue.amazonaws.com").


### PR DESCRIPTION
explicit inheritance of com.amazonaws.AmazonWebServiceClient's methods for all aws service interfaces, like com.amazonaws.services.s3.AmazonS3.

in particular, this exposes the method "addRequestHandler," which is convenient for "requester pays buckets" where
you use a com.amazonaws.handlers.RequestHandler to add the "x-amz-request-payer: requester" header. without this new feature,
one is forced to use class com.amazonaws.services.s3.AmazonS3Client, instead of interface com.amazonaws.services.s3.AmazonS3;
the latter is sort of preferred from basic object-oriented programming principles.

for instance: here's how i now can access a request-pays bucket:

```
    AmazonS3 s3 = ................;

    s3.addRequestHandler(new AbstractRequestHandler() {
        @Override
        public void beforeRequest(Request<?> request) {
            request.addHeader("x-amz-request-payer", "requester");
            System.out.println("added request payer: " + request);
        }
    });

    for (S3ObjectSummary s : s3.listObjects("commoncrawl-crawl-002").getObjectSummaries()) {
        System.out.println(s.getKey());
    }
```
