### PR TITLE
Adds the missing org.codehaus.jackson.mapper to the META-INF/MANIFEST.MF

### DIFF
--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -8,6 +8,7 @@ Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Require-Bundle: org.apache.commons.codec;bundle-version="1.3.0",
  org.apache.commons.logging;bundle-version="1.1.1";visibility:=reexport,
  org.codehaus.jackson.core;bundle-version="1.6.0",
+ org.codehaus.jackson.mapper;bundle-version="1.6.0",
  javax.mail;bundle-version="1.4.0",
  org.apache.httpcomponents.httpcore;bundle-version="4.1.0",
  org.apache.httpcomponents.httpclient;bundle-version="4.1.0"


### PR DESCRIPTION
Apparently this entry was forgotten. The bundle doesn't work properly without it.
