### PR TITLE
Adds constructor STSSessionCredentialsProvider to take ClientConfiguration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <artifactId>aws-java-sdk</artifactId>
     <packaging>jar</packaging>
     <name>AWS SDK for Java</name>
-    <version>1.3.0</version>
+    <version>1.3.1</version>
     <description>The Amazon Web Services SDK for Java provides Java APIs for building software on AWS’ cost-effective, scalable, and reliable infrastructure products. The AWS Java SDK allows developers to code against APIs for all of Amazon's infrastructure web services (Amazon S3, Amazon EC2, Amazon SQS, Amazon Relational Database Service, Amazon AutoScaling, etc).</description>
     <url>http://aws.amazon.com/sdkforjava</url>
 
@@ -42,6 +42,13 @@
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
             <version>[1.4,)</version>
+            <type>jar</type>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.codehaus.jackson</groupId>
+            <artifactId>jackson-mapper-asl</artifactId>
+            <version>[1.5.1,)</version>
             <type>jar</type>
             <scope>compile</scope>
         </dependency>

--- a/src/main/java/com/amazonaws/auth/STSSessionCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/auth/STSSessionCredentialsProvider.java
@@ -17,6 +17,7 @@ package com.amazonaws.auth;
 
 import java.util.Date;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.auth.AWSSessionCredentials;
@@ -57,7 +58,24 @@ public class STSSessionCredentialsProvider implements AWSCredentialsProvider {
      *            The main AWS credentials for a user's account.
      */
     public STSSessionCredentialsProvider(AWSCredentials longLivedCredentials) {
-        securityTokenService = new AWSSecurityTokenServiceClient(longLivedCredentials);
+        this(longLivedCredentials, new ClientConfiguration());
+    }
+    
+    /**
+     * Constructs a new STSSessionCredentialsProvider, which will use the
+     * specified long lived AWS credentials to make a request to the AWS
+     * Security Token Service (STS) to request short lived session credentials,
+     * which will then be returned by this class's {@link #getCredentials()}
+     * method.
+     *
+     * @param longLivedCredentials
+     *            The main AWS credentials for a user's account.
+     *            
+     * @param clientConfiguration
+     *            Client configuration connection parameters.
+     */
+    public STSSessionCredentialsProvider(AWSCredentials longLivedCredentials, ClientConfiguration clientConfiguration) {
+        securityTokenService = new AWSSecurityTokenServiceClient(longLivedCredentials, clientConfiguration);
     }
 
     /**

--- a/src/main/java/com/amazonaws/services/dynamodb/AmazonDynamoDBClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/AmazonDynamoDBClient.java
@@ -118,7 +118,7 @@ public class AmazonDynamoDBClient extends AmazonWebServiceClient implements Amaz
             awsCredentials instanceof NoSessionSupportCredentials) {
             this.awsCredentialsProvider = new StaticCredentialsProvider(awsCredentials);
         } else {
-            this.awsCredentialsProvider = new com.amazonaws.auth.STSSessionCredentialsProvider(awsCredentials);
+            this.awsCredentialsProvider = new com.amazonaws.auth.STSSessionCredentialsProvider(awsCredentials, clientConfiguration);
         }
         
         init();


### PR DESCRIPTION
This allows AmazonDynamoDBClient to connect behind a proxy.
Also adds a missing dependency in pom.xml for jackson-mapper-asl.
