### PR TITLE
Http client extension

### DIFF
--- a/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -57,9 +57,27 @@ public abstract class AmazonWebServiceClient {
      */
     public AmazonWebServiceClient(ClientConfiguration clientConfiguration) {
         this.clientConfiguration = clientConfiguration;
-        client = new AmazonHttpClient(clientConfiguration);
+        client = createHttpClient( clientConfiguration );
         requestHandlers = Collections.synchronizedList(new LinkedList<RequestHandler>());
     }
+
+	/**
+	 * Constructs the HTTP client instance to be used in this web service
+	 * client. The default implementation returns an instance of
+	 * {@link AmazonHttpClient} but derived classes may override this method in
+	 * order to customize the actual HTTP client to a subclass of
+	 * {@link AmazonHttpClient}.
+	 * 
+	 * @param clientConfiguration
+	 *            The client configuration for this client.
+	 * 
+	 * @return an instance of {@link AmazonHttpClient} or a subclass thereof,
+	 *         initialized with the given client configuration
+	 */
+	protected AmazonHttpClient createHttpClient(ClientConfiguration clientConfiguration)
+	{
+		return new AmazonHttpClient(clientConfiguration);
+	}
 
     /**
      * Overrides the default endpoint for this client. Callers can use this
@@ -107,7 +125,7 @@ public abstract class AmazonWebServiceClient {
 
     public void setConfiguration(ClientConfiguration clientConfiguration) {
         this.clientConfiguration = clientConfiguration;
-        client = new AmazonHttpClient(clientConfiguration);
+        client = createHttpClient( clientConfiguration );
     }
 
     /**

--- a/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -358,7 +358,7 @@ public class AmazonHttpClient {
      *
      * @return True if the failed request should be retried.
      */
-    private boolean shouldRetry(HttpRequestBase method, Exception exception, int retries) {
+    protected boolean shouldRetry(HttpRequestBase method, Exception exception, int retries) {
         if (retries > config.getMaxErrorRetry()) return false;
 
         if (method instanceof HttpEntityEnclosingRequest) {
@@ -621,7 +621,7 @@ public class AmazonHttpClient {
      * @return True if the exception resulted from a throttling error message
      *         from a service, otherwise false.
      */
-    private boolean isThrottlingException(AmazonServiceException ase) {
+    protected boolean isThrottlingException(AmazonServiceException ase) {
         if (ase == null) return false;
         return "Throttling".equals(ase.getErrorCode())
             || "ThrottlingException".equals(ase.getErrorCode())


### PR DESCRIPTION
It would be nice if users of the SDK could customize the HTTP client by subclassing AmazonHttpClient. This pull request has the minimum changes to make this possible. It changes certain methods in AmazonHttpClient from private to protected and it adds a factory method to AmazonWebServiceClient such that concrete clients can customize the AmazonHttpClient instance to be used in the client.

We currently use a custom AmazonHttpClient to use different retry limits based on the exception. For example, we need a high retry limit (say, 20 retries) for "throttling" exceptions, and a low retry limit (like 3) for everything else. Sub-classing AmazonHttpClient lets us do all that.

The amount of customization made possible with this pull-request is still rather limited because most of the state that accumulates during request execution is located on the stack. If there is interest I would be willing to come up with a more substantial refactoring that allows for more extensive customization by encapsulating the request execution state in a separate strategy class.