### PR TITLE
Fix scan and query operations to honor table name override

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBMapper.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBMapper.java
@@ -742,7 +742,7 @@ public class DynamoDBMapper {
         DynamoDBTable table = reflector.getTable(clazz);
 
         ScanRequest scanRequest = new ScanRequest();
-        scanRequest.setTableName(table.tableName());
+        scanRequest.setTableName(getTableName(clazz, config));
         scanRequest.setScanFilter(scanExpression.getScanFilter());
 
         return scanRequest;
@@ -753,7 +753,7 @@ public class DynamoDBMapper {
 
         QueryRequest queryRequest = new QueryRequest();
         queryRequest.setConsistentRead(queryExpression.isConsistentRead());
-        queryRequest.setTableName(table.tableName());
+        queryRequest.setTableName(getTableName(clazz, config));
         queryRequest.setHashKeyValue(queryExpression.getHashKeyValue());
         queryRequest.setScanIndexForward(queryExpression.isScanIndexForward());
         queryRequest.setRangeKeyCondition(queryExpression.getRangeKeyCondition());


### PR DESCRIPTION
The scan and query operations in DynamoDBMapper were not using the getTableName() helper method, thus causing any table name overrides to get discarded.

This change fixes that issue.
