### PR TITLE
Fix DynamoDBReflector to treat empty strings like null strings

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBReflector.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBReflector.java
@@ -655,6 +655,9 @@ public class DynamoDBReflector {
 
                                 @Override
                                 public AttributeValue marshall(Object obj) {
+                                	if(((String) obj).length() == 0)
+                                		obj = null;
+                                		
                                     return new AttributeValue().withS(String.valueOf(obj));
                                 }
                             };


### PR DESCRIPTION
Dynamo doesn't like empty strings, so the reflector should set empty strings to null, so that they get handled the same way as null strings, rather than resulting in a error.
