### PR TITLE
Fix DynamoDBReflector to treat empty strings like null strings

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBReflector.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/datamodeling/DynamoDBReflector.java
@@ -656,7 +656,7 @@ public class DynamoDBReflector {
                                 @Override
                                 public AttributeValue marshall(Object obj) {
                                 	if(((String) obj).length() == 0)
-                                		obj = null;
+                                		return null;
                                 		
                                     return new AttributeValue().withS(String.valueOf(obj));
                                 }


### PR DESCRIPTION
Take 2: dynamo doesn't like empty strings, so the reflector should set empty strings to null, so that they get handled the same way as null strings, rather than resulting in a error.
