### PR TITLE
For listObjects wit no prefix, insert a "/" as the path (HTTP compliance)

### DIFF
--- a/src/main/java/com/amazonaws/http/HttpRequestFactory.java
+++ b/src/main/java/com/amazonaws/http/HttpRequestFactory.java
@@ -63,6 +63,8 @@ class HttpRequestFactory {
 				uri += "/";
 			}
 			uri += request.getResourcePath();
+		} else {
+			uri += "/";
 		}
 
 		String encodedParams = HttpUtils.encodeParameters(request);


### PR DESCRIPTION
We at the Climate Corporation have discovered that for a .listObjects
call with no prefix, the sdk produces an invalid HTTP request.

For example:

[Quoted from Nathan Mehl of Climate Corporation, 1/24/2012]

"GET http://com.weatherbill.staging.dynamo.s3.amazonaws.com?prefix=activations HTTP/1.1"

This is invalid HTTP and as a result nginx (or any other valid http cache)
will immediately respond with a 400 error. The problem is that per
RFC2616, a path segment is required between the host and query segments.
Compare and contrast:

valid: GET http://foo/?foo=bar HTTP/1.1
invalid: GET http://foo?foo=bar HTTP/1/1
valid: GET /?foo=bar HTTP/1.1
invalid: GET ?foo=bar HTTP/1.1

The invalid queries will produce errors against nginx, apache mod_proxy,
squid or any other compliant http proxy. They are, however, accepted as
## valid by the http server at s3.amazonaws.com.

This patch simply appends a "/" to the uri when no prefix is supplied.
