### PR TITLE
Glacier linear checkums

### DIFF
--- a/src/main/java/com/amazonaws/services/glacier/model/UploadArchiveRequest.java
+++ b/src/main/java/com/amazonaws/services/glacier/model/UploadArchiveRequest.java
@@ -85,6 +85,11 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
     private String treeChecksum;
 
     /**
+     * The SHA256 checksum (a tree hash) of the payload.
+     */
+    private String linearChecksum;
+
+    /**
      * The data to upload.
      */
     private java.io.InputStream body;
@@ -336,6 +341,40 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
     
     
     /**
+     * The SHA256 checksum (a linear hash) of the payload.
+     *
+     * @return The SHA256 checksum (a linear hash) of the payload.
+     */
+    public String getLinearChecksum() {
+        return linearChecksum;
+    }
+    
+    /**
+     * The SHA256 checksum (a linear hash) of the payload.
+     *
+     * @param linearChecksum The SHA256 checksum (a linear hash) of the payload.
+     */
+    public void setLinearChecksum(String linearChecksum) {
+        this.linearChecksum = linearChecksum;
+    }
+    
+    /**
+     * The SHA256 checksum (a linear hash) of the payload.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     *
+     * @param treeChecksum The SHA256 checksum (a linear hash) of the payload.
+     *
+     * @return A reference to this updated object so that method calls can be chained 
+     *         together. 
+     */
+    public UploadArchiveRequest withLinearChecksum(String linearChecksum) {
+        this.linearChecksum = linearChecksum;
+        return this;
+    }
+    
+    
+    /**
      * The data to upload.
      *
      * @return The data to upload.
@@ -386,6 +425,7 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
         if (accountId != null) sb.append("AccountId: " + accountId + ", ");
         if (archiveDescription != null) sb.append("ArchiveDescription: " + archiveDescription + ", ");
         if (treeChecksum != null) sb.append("Tree checksum: " + treeChecksum + ", ");
+        if (linearChecksum != null) sb.append("Linear checksum: " + linearChecksum + ", ");
         if (body != null) sb.append("Body: " + body + ", ");
         sb.append("}");
         return sb.toString();
@@ -401,6 +441,7 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
         hashCode = prime * hashCode + ((getAccountId() == null) ? 0 : getAccountId().hashCode()); 
         hashCode = prime * hashCode + ((getArchiveDescription() == null) ? 0 : getArchiveDescription().hashCode()); 
         hashCode = prime * hashCode + ((getChecksum() == null) ? 0 : getChecksum().hashCode()); 
+        hashCode = prime * hashCode + ((getLinearChecksum() == null) ? 0 : getLinearChecksum().hashCode()); 
         hashCode = prime * hashCode + ((getBody() == null) ? 0 : getBody().hashCode()); 
         return hashCode;
     }
@@ -423,6 +464,8 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
         if (other.getArchiveDescription() != null && other.getArchiveDescription().equals(this.getArchiveDescription()) == false) return false; 
         if (other.getChecksum() == null ^ this.getChecksum() == null) return false;
         if (other.getChecksum() != null && other.getChecksum().equals(this.getChecksum()) == false) return false; 
+        if (other.getLinearChecksum() == null ^ this.getLinearChecksum() == null) return false;
+        if (other.getLinearChecksum() != null && other.getLinearChecksum().equals(this.getLinearChecksum()) == false) return false; 
         if (other.getBody() == null ^ this.getBody() == null) return false;
         if (other.getBody() != null && other.getBody().equals(this.getBody()) == false) return false; 
         return true;

--- a/src/main/java/com/amazonaws/services/glacier/model/UploadArchiveRequest.java
+++ b/src/main/java/com/amazonaws/services/glacier/model/UploadArchiveRequest.java
@@ -80,9 +80,9 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
     private String archiveDescription;
 
     /**
-     * The SHA256 checksum (a linear hash) of the payload.
+     * The SHA256 checksum (a tree hash) of the payload.
      */
-    private String checksum;
+    private String treeChecksum;
 
     /**
      * The data to upload.
@@ -103,13 +103,13 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
      * @param vaultName The name of the vault.
      * @param archiveDescription The optional description of the archive you
      * are uploading.
-     * @param checksum The SHA256 checksum (a linear hash) of the payload.
+     * @param treeChecksum The SHA256 checksum (a tree hash) of the payload.
      * @param body The data to upload.
      */
-    public UploadArchiveRequest(String vaultName, String archiveDescription, String checksum, java.io.InputStream body) {
+    public UploadArchiveRequest(String vaultName, String archiveDescription, String treeChecksum, java.io.InputStream body) {
         this.vaultName = vaultName;
         this.archiveDescription = archiveDescription;
-        this.checksum = checksum;
+        this.treeChecksum = treeChecksum;
         this.body = body;
     }
 
@@ -128,14 +128,14 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
      * do not include hyphens in it.
      * @param archiveDescription The optional description of the archive you
      * are uploading.
-     * @param checksum The SHA256 checksum (a linear hash) of the payload.
+     * @param treeChecksum The SHA256 checksum (a tree hash) of the payload.
      * @param body The data to upload.
      */
-    public UploadArchiveRequest(String vaultName, String accountId, String archiveDescription, String checksum, java.io.InputStream body) {
+    public UploadArchiveRequest(String vaultName, String accountId, String archiveDescription, String treeChecksum, java.io.InputStream body) {
         this.vaultName = vaultName;
         this.accountId = accountId;
         this.archiveDescription = archiveDescription;
-        this.checksum = checksum;
+        this.treeChecksum = treeChecksum;
         this.body = body;
     }
 
@@ -302,35 +302,35 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
     
     
     /**
-     * The SHA256 checksum (a linear hash) of the payload.
+     * The SHA256 checksum (a tree hash) of the payload.
      *
-     * @return The SHA256 checksum (a linear hash) of the payload.
+     * @return The SHA256 checksum (a tree hash) of the payload.
      */
     public String getChecksum() {
-        return checksum;
+        return treeChecksum;
     }
     
     /**
-     * The SHA256 checksum (a linear hash) of the payload.
+     * The SHA256 checksum (a tree hash) of the payload.
      *
-     * @param checksum The SHA256 checksum (a linear hash) of the payload.
+     * @param treeChecksum The SHA256 checksum (a tree hash) of the payload.
      */
-    public void setChecksum(String checksum) {
-        this.checksum = checksum;
+    public void setChecksum(String treeChecksum) {
+        this.treeChecksum = treeChecksum;
     }
     
     /**
-     * The SHA256 checksum (a linear hash) of the payload.
+     * The SHA256 checksum (a tree hash) of the payload.
      * <p>
      * Returns a reference to this object so that method calls can be chained together.
      *
-     * @param checksum The SHA256 checksum (a linear hash) of the payload.
+     * @param treeChecksum The SHA256 checksum (a tree hash) of the payload.
      *
      * @return A reference to this updated object so that method calls can be chained 
      *         together. 
      */
-    public UploadArchiveRequest withChecksum(String checksum) {
-        this.checksum = checksum;
+    public UploadArchiveRequest withChecksum(String treeChecksum) {
+        this.treeChecksum = treeChecksum;
         return this;
     }
     
@@ -385,7 +385,7 @@ public class UploadArchiveRequest extends AmazonWebServiceRequest {
         if (vaultName != null) sb.append("VaultName: " + vaultName + ", ");
         if (accountId != null) sb.append("AccountId: " + accountId + ", ");
         if (archiveDescription != null) sb.append("ArchiveDescription: " + archiveDescription + ", ");
-        if (checksum != null) sb.append("Checksum: " + checksum + ", ");
+        if (treeChecksum != null) sb.append("Tree checksum: " + treeChecksum + ", ");
         if (body != null) sb.append("Body: " + body + ", ");
         sb.append("}");
         return sb.toString();

--- a/src/main/java/com/amazonaws/services/glacier/model/UploadMultipartPartRequest.java
+++ b/src/main/java/com/amazonaws/services/glacier/model/UploadMultipartPartRequest.java
@@ -93,6 +93,11 @@ public class UploadMultipartPartRequest extends AmazonWebServiceRequest {
     private String checksum;
 
     /**
+     * The SHA256 linear hash of the data being uploaded.
+     */
+    private String linearChecksum;
+
+    /**
      * Identifies the range of bytes in the assembled archive that will be
      * uploaded in this part. Amazon Glacier uses this information to
      * assemble the archive in the proper sequence. The format of this header
@@ -329,6 +334,39 @@ public class UploadMultipartPartRequest extends AmazonWebServiceRequest {
     
     
     /**
+     * The SHA256 linear hash of the data being uploaded.
+     *
+     * @return The SHA256 linear hash of the data being uploaded.
+     */
+    public String getLinearChecksum() {
+        return linearChecksum;
+    }
+    
+    /**
+     * The SHA256 linear hash of the data being uploaded.
+     *
+     * @param linearChecksum The SHA256 linear hash of the data being uploaded.
+     */
+    public void setLinearChecksum(String linearChecksum) {
+        this.linearChecksum = linearChecksum;
+    }
+    
+    /**
+     * The SHA256 linear hash of the data being uploaded.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     *
+     * @param linearChecksum The SHA256 linear hash of the data being uploaded.
+     *
+     * @return A reference to this updated object so that method calls can be chained 
+     *         together. 
+     */
+    public UploadMultipartPartRequest withChecksum(String linearChecksum) {
+        this.linearChecksum = linearChecksum;
+        return this;
+    }
+    
+    /**
      * Identifies the range of bytes in the assembled archive that will be
      * uploaded in this part. Amazon Glacier uses this information to
      * assemble the archive in the proper sequence. The format of this header
@@ -436,6 +474,7 @@ public class UploadMultipartPartRequest extends AmazonWebServiceRequest {
         if (vaultName != null) sb.append("VaultName: " + vaultName + ", ");
         if (uploadId != null) sb.append("UploadId: " + uploadId + ", ");
         if (checksum != null) sb.append("Checksum: " + checksum + ", ");
+        if (linearChecksum != null) sb.append("Linear checksum: " + linearChecksum + ", ");
         if (range != null) sb.append("Range: " + range + ", ");
         if (body != null) sb.append("Body: " + body + ", ");
         sb.append("}");
@@ -451,6 +490,7 @@ public class UploadMultipartPartRequest extends AmazonWebServiceRequest {
         hashCode = prime * hashCode + ((getVaultName() == null) ? 0 : getVaultName().hashCode()); 
         hashCode = prime * hashCode + ((getUploadId() == null) ? 0 : getUploadId().hashCode()); 
         hashCode = prime * hashCode + ((getChecksum() == null) ? 0 : getChecksum().hashCode()); 
+        hashCode = prime * hashCode + ((getLinearChecksum() == null) ? 0 : getLinearChecksum().hashCode()); 
         hashCode = prime * hashCode + ((getRange() == null) ? 0 : getRange().hashCode()); 
         hashCode = prime * hashCode + ((getBody() == null) ? 0 : getBody().hashCode()); 
         return hashCode;
@@ -472,6 +512,8 @@ public class UploadMultipartPartRequest extends AmazonWebServiceRequest {
         if (other.getUploadId() != null && other.getUploadId().equals(this.getUploadId()) == false) return false; 
         if (other.getChecksum() == null ^ this.getChecksum() == null) return false;
         if (other.getChecksum() != null && other.getChecksum().equals(this.getChecksum()) == false) return false; 
+        if (other.getLinearChecksum() == null ^ this.getLinearChecksum() == null) return false;
+        if (other.getLinearChecksum() != null && other.getLinearChecksum().equals(this.getLinearChecksum()) == false) return false; 
         if (other.getRange() == null ^ this.getRange() == null) return false;
         if (other.getRange() != null && other.getRange().equals(this.getRange()) == false) return false; 
         if (other.getBody() == null ^ this.getBody() == null) return false;

--- a/src/main/java/com/amazonaws/services/glacier/model/transform/UploadArchiveRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/glacier/model/transform/UploadArchiveRequestMarshaller.java
@@ -61,6 +61,9 @@ public class UploadArchiveRequestMarshaller implements Marshaller<Request<Upload
         if (uploadArchiveRequest.getChecksum() != null)
         	request.addHeader("x-amz-sha256-tree-hash", StringUtils.fromString(uploadArchiveRequest.getChecksum()));
         
+        if (uploadArchiveRequest.getLinearChecksum() != null)
+        	request.addHeader("x-amz-content-sha256", StringUtils.fromString(uploadArchiveRequest.getLinearChecksum()));
+        
 
 
         String uriResourcePath = "/{accountId}/vaults/{vaultName}/archives"; 

--- a/src/main/java/com/amazonaws/services/glacier/model/transform/UploadMultipartPartRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/glacier/model/transform/UploadMultipartPartRequestMarshaller.java
@@ -54,6 +54,9 @@ public class UploadMultipartPartRequestMarshaller implements Marshaller<Request<
         request.setHttpMethod(HttpMethodName.PUT);
         if (uploadMultipartPartRequest.getChecksum() != null)
         	request.addHeader("x-amz-sha256-tree-hash", StringUtils.fromString(uploadMultipartPartRequest.getChecksum()));
+
+        if (uploadMultipartPartRequest.getLinearChecksum() != null)
+        	request.addHeader("x-amz-content-sha256", StringUtils.fromString(uploadMultipartPartRequest.getLinearChecksum()));
         
         if (uploadMultipartPartRequest.getRange() != null)
         	request.addHeader("Content-Range", StringUtils.fromString(uploadMultipartPartRequest.getRange()));


### PR DESCRIPTION
The existing Glacier upload support does not expose the `x-amz-content-sha256` header. My application uses SHA-256 when transporting data already; ideally, I'd be able to push these precomputed hashes to Glacier and ensure that the stored content matches my expectations, in addition to whatever checksums might be computed locally. Thus, 100ceeccbd0bcaa70c21bcd95b01ca005448018b and 09a0c93a4902784706de3300cee4a153ee0e43b8 add `get`/`set`/`withLinearChecksum` methods to com.amazonaws.services.glacier.model.Upload{Archive,MultipartPart}Request and the corresponding marshalling to `x-amz-content-sha256`.

A separate issue is that UploadArchiveRequest's Javadocs claim over and over again that checksum is a linear checksum. This was a source of confusion -- despite documentation to the contrary, this field is in fact sent as a tree checksum, not a linear checksum. This is addressed in 66c97639b75e0ef01ab4e93cd23b249322505b07.