### PR TITLE
NullPointerException in case of permission denied errors

### DIFF
--- a/src/main/java/com/amazonaws/services/glacier/transfer/ArchiveTransferManager.java
+++ b/src/main/java/com/amazonaws/services/glacier/transfer/ArchiveTransferManager.java
@@ -338,9 +338,11 @@ public class ArchiveTransferManager {
     			.withAccountId(accountId)
     			.withVaultName(vaultName)
     			.withJobId(jobId));
-    	} finally {
-    		jobStatusMonitor.shutdown();
-    	}
+    	}  finally {
+            if (jobStatusMonitor!=null) {
+                jobStatusMonitor.shutdown();
+            }
+        }
 
     	downloadJobOutput(jobOutputResult, file);
     }


### PR DESCRIPTION
There are cases that the instantiation of the JobStatusMonitor class will fail, for example, if the credentials used don't have permissions to access the required resources.

If the instantiation of the JobStatusMonitor fail (lines 320 or 322 of the ArchiveTransferManager.java file), an exception describing the error will be thrown. But the finally clause at the end of the method will call shutdown() on an null object, resulting in a new NullPointerException. This new exception makes hard to the user to know what failed during the API execution.

This change checks if the jobStatusMonitor variable is not null before calling shutdown(). This way, if an error occurs, the exception with a clear message can be caught by the user.
