### PR TITLE
Errors from the DynamoDB service seems to (also) use the key "Message" (...

### DIFF
--- a/src/main/java/com/amazonaws/transform/JsonErrorUnmarshaller.java
+++ b/src/main/java/com/amazonaws/transform/JsonErrorUnmarshaller.java
@@ -43,6 +43,9 @@ public class JsonErrorUnmarshaller extends AbstractErrorUnmarshaller<JSONObject>
         if (json.has("message")) {
             message = json.getString("message");
         }
+        else if (json.has("Message")) {
+            message = json.getString("Message");
+        }
         return message;
     }
 


### PR DESCRIPTION
...uppercase initial letter) to communicate descriptive error messages.
