### PR TITLE
Fix TimingInfo class to use nanoseconds everywhere

### DIFF
--- a/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -149,7 +149,7 @@ public class AmazonHttpClient {
             HttpResponseHandler<AmazonWebServiceResponse<T>> responseHandler,
             HttpResponseHandler<AmazonServiceException> errorResponseHandler,
             ExecutionContext executionContext) throws AmazonClientException, AmazonServiceException {
-        long startTime = System.currentTimeMillis();
+        long startTime = System.nanoTime();
 
         if (executionContext == null) throw new AmazonClientException("Internal SDK Error: No execution context parameter specified.");
         List<RequestHandler> requestHandlers = executionContext.getRequestHandlers();
@@ -163,7 +163,7 @@ public class AmazonHttpClient {
         try {
             TimingInfo timingInfo = new TimingInfo(startTime);
             T t = executeHelper(request, responseHandler, errorResponseHandler, executionContext);
-            timingInfo.setEndTime(System.currentTimeMillis());
+            timingInfo.setEndTime(System.nanoTime());
 
             for (RequestHandler handler : requestHandlers) {
                 try {

--- a/src/main/java/com/amazonaws/util/TimingInfo.java
+++ b/src/main/java/com/amazonaws/util/TimingInfo.java
@@ -28,27 +28,44 @@ public class TimingInfo {
     private final Map<String, Number> countersByName = new HashMap<String, Number>();
 
     public TimingInfo() {
-        this(System.currentTimeMillis(), -1);
+        this(System.nanoTime(), -1);
     }
 
+    /**
+     * @param startTime the time in nanoseconds at which this timing period started, as returned by
+     * {@link java.lang.System#nanoTime() System.nanoTime()}.
+     */
     public TimingInfo(long startTime) {
         this(startTime, -1);
     }
 
+    /**
+     * @param startTime the time in nanoseconds at which this timing period started, as returned by
+     * {@link java.lang.System#nanoTime() System.nanoTime()}.
+     * @param endTime the time in nanoseconds at which this timing period ended, as returned by
+     * {@link java.lang.System#nanoTime() System.nanoTime()}.
+     */
     public TimingInfo(long startTime, long endTime) {
         this.startTime = startTime;
         this.endTime = endTime;
     }
 
     /**
-     * Returns the time, in epoch milliseconds, at which this timing period started.
+     * Returns the time at which this timing period started.
      * 
-     * @return the time, in epoch milliseconds, at which this timing period started.
+     * @return the time in nanoseconds at which this timing period started, as returned by
+     * {@link java.lang.System#nanoTime() System.nanoTime()}.
      */
     public long getStartTime() {
         return startTime;
     }
 
+    /**
+     * Returns the time at which this timing period ended.
+     *
+     * @return the time in nanoseconds at which this timing period ended, as returned by
+     * {@link java.lang.System#nanoTime() System.nanoTime()}.
+     */
     public long getEndTime() {
         return endTime;
     }


### PR DESCRIPTION
Millis and Nanoseconds were being used with this class interchangeably.

It was tricky to work out /which/ this class should be using, of either nanos or millis, but nanos certainly _are_ better for measuring elapsed time. The getTimeTakenMillis() method also expects the class to be using nanos internally:

https://github.com/aws/aws-sdk-java/blob/4a138d46/src/main/java/com/amazonaws/util/TimingInfo.java#L59-L61

As does the AWSRequestMetrics class:

https://github.com/aws/aws-sdk-java/blob/4a138d46/src/main/java/com/amazonaws/util/AWSRequestMetrics.java#L112

This is some nice background on the various system clocks available in the JVM:

https://blogs.oracle.com/dholmes/entry/inside_the_hotspot_vm_clocks
