### PR TITLE
Fixes to signature v2 and v4 for endpoints with paths.

### DIFF
--- a/src/main/java/com/amazonaws/auth/AWS3Signer.java
+++ b/src/main/java/com/amazonaws/auth/AWS3Signer.java
@@ -100,6 +100,7 @@ public class AWS3Signer extends AbstractAWSSigner {
                 throw new AmazonClientException("Unable to serialize string to bytes: " + e.getMessage(), e);
             }
         } else {
+            String path = HttpUtils.appendUri(request.getEndpoint().getPath(), request.getResourcePath());
             /*
              * AWS3 requires all query params to be listed on the third line of
              * the string to sign, even if those query params will be sent in
@@ -107,7 +108,7 @@ public class AWS3Signer extends AbstractAWSSigner {
              * params should *NOT* be included in the request payload.
              */
             stringToSign = request.getHttpMethod().toString() + "\n"
-                    + getCanonicalizedResourcePath(request.getResourcePath()) + "\n"
+                    + getCanonicalizedResourcePath(path) + "\n"
                     + getCanonicalizedQueryString(request.getParameters()) + "\n"
                     + getCanonicalizedHeadersForStringToSign(request) + "\n"
                     + getRequestPayloadWithoutQueryParams(request);

--- a/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -205,9 +205,10 @@ public class AWS4Signer extends AbstractAWSSigner {
     }
 
     protected String getCanonicalRequest(Request<?> request, String contentSha256) {
+        String path = HttpUtils.appendUri(request.getEndpoint().getPath(), request.getResourcePath());
         String canonicalRequest =
                 request.getHttpMethod().toString() + "\n" +
-                        getCanonicalizedResourcePath(request.getResourcePath()) + "\n" +
+                        getCanonicalizedResourcePath(path) + "\n" +
                         getCanonicalizedQueryString(request) + "\n" +
                         getCanonicalizedHeaderString(request) + "\n" +
                         getSignedHeadersString(request) + "\n" +

--- a/src/main/java/com/amazonaws/auth/QueryStringSigner.java
+++ b/src/main/java/com/amazonaws/auth/QueryStringSigner.java
@@ -154,6 +154,8 @@ public class QueryStringSigner extends AbstractAWSSigner implements Signer {
             }
 
             resourcePath += request.getResourcePath();
+        } else if ( !resourcePath.endsWith("/") ) {
+          resourcePath += "/";
         }
 
         if (!resourcePath.startsWith("/")) {

--- a/src/main/java/com/amazonaws/http/HttpRequestFactory.java
+++ b/src/main/java/com/amazonaws/http/HttpRequestFactory.java
@@ -57,20 +57,7 @@ class HttpRequestFactory {
      */
     HttpRequestBase createHttpRequest(Request<?> request, ClientConfiguration clientConfiguration, HttpEntity previousEntity, ExecutionContext context) {
         URI endpoint = request.getEndpoint();
-        String uri = endpoint.toString();
-        if (request.getResourcePath() != null && request.getResourcePath().length() > 0) {
-            if (request.getResourcePath().startsWith("/")) {
-                if (uri.endsWith("/")) {
-                    uri = uri.substring(0, uri.length() - 1);
-                }
-            } else if (!uri.endsWith("/")) {
-                    uri += "/";
-            }
-            uri += HttpUtils.urlEncode(request.getResourcePath(), true);
-        } else if (!uri.endsWith("/")) {
-            uri += "/";
-        }
-
+        String uri = HttpUtils.appendUri(endpoint.toString(), request.getResourcePath());
         String encodedParams = HttpUtils.encodeParameters(request);
 
         /*

--- a/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
@@ -66,8 +66,6 @@ public class S3Signer extends AbstractAWSSigner {
      * Constructs a new S3Signer to sign requests based on the
      * AWS credentials, HTTP method and canonical S3 resource path.
      *
-     * @param credentials
-     *            The AWS credentials to use to sign the request.
      * @param httpVerb
      *            The HTTP verb (GET, PUT, POST, HEAD, DELETE) the request is
      *            using.
@@ -94,8 +92,8 @@ public class S3Signer extends AbstractAWSSigner {
             addSessionCredentials(request, (AWSSessionCredentials) sanitizedCredentials);
         }
 
-        String encodedResourcePath = HttpUtils.urlEncode(resourcePath, true);
-        
+        String encodedResourcePath = HttpUtils.appendUri(request.getEndpoint().getPath(), resourcePath);
+
         int timeOffset = getTimeOffset(request);
         Date date = getSignatureDate(timeOffset);
         request.addHeader(Headers.DATE, ServiceUtils.formatRfc822Date(date));

--- a/src/main/java/com/amazonaws/util/HttpUtils.java
+++ b/src/main/java/com/amazonaws/util/HttpUtils.java
@@ -156,4 +156,32 @@ public class HttpUtils {
         return encodedParams;
     }
 
+    /**
+     * Append the given path to the given baseUri.
+     * 
+     * <p>This method will encode the given path but not the given
+     * baseUri.</p>
+     * 
+     * @param baseUri The URI to append to (required, may be relative)
+     * @param path The path to append (may be null or empty)
+     * @return The baseUri with the (encoded) path appended
+     */
+    public static String appendUri( final String baseUri,
+                                    final String path ) {
+      String resultUri = baseUri;
+      if (path != null && path.length() > 0) {
+        if (path.startsWith("/")) {
+          if (resultUri.endsWith("/")) {
+            resultUri = resultUri.substring(0, resultUri.length() - 1);
+          }
+        } else if (!resultUri.endsWith("/")) {
+          resultUri += "/";
+        }
+        resultUri += HttpUtils.urlEncode( path, true );
+      } else if (!resultUri.endsWith("/")) {
+        resultUri += "/";
+      }
+
+      return resultUri; 
+    }
 }


### PR DESCRIPTION
This is a fix for the issue discussed here:

  https://forums.aws.amazon.com/thread.jspa?threadID=110659&tstart=0

plus an additional issue with v2 signatures as outlined below.

The fix for signature v2 ensures that the canonicalized resource path
ends with a '/' in the case when the path is from the service endpoint.
The HttpRequestFactory adds a trailing '/' in this case and this was
causing a mismatch between the canonical and actual path.

The fix for signature v4 ensures that the AWS4Signer takes the endpoint
path into account then creating the canonical resource path. The common
functionality for calculation of the resource path is moved from
HttpRequestFactory to HttpUtils.

Please let me know if there are any changes I can make to help this fix get into a release.
