### PR TITLE
SecurityGroup can't be set in ImportInstanceLaunchSpecification

### DIFF
--- a/src/main/java/com/amazonaws/services/ec2/model/transform/ImportInstanceRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/ec2/model/transform/ImportInstanceRequestMarshaller.java
@@ -54,7 +54,7 @@ public class ImportInstanceRequestMarshaller implements Marshaller<Request<Impor
 
             for (String securityGroupsListValue : securityGroupsList) {
                 if (securityGroupsListValue != null) {
-                    request.addParameter("LaunchSpecification.SecurityGroup." + securityGroupsListIndex, StringUtils.fromString(securityGroupsListValue));
+                    request.addParameter("LaunchSpecification.GroupName." + securityGroupsListIndex, StringUtils.fromString(securityGroupsListValue));
                 }
 
                 securityGroupsListIndex++;


### PR DESCRIPTION
Fix of "The parameter SecurityGroup is not recognized." when with/setSecurityGroups method is called in the ImportInstanceLaunchSpecification.

More details: https://forums.aws.amazon.com/thread.jspa?threadID=115231
