### PR TITLE
Add S3 client options allowing configuration of path-style access.

### DIFF
--- a/src/main/java/com/amazonaws/services/s3/AmazonS3.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3.java
@@ -137,6 +137,15 @@ public interface AmazonS3 {
 
     /**
      * <p>
+     * Override the default S3 client options for this client.
+     * </p>
+     * @param clientOptions
+     *            The S3 client options to use.
+     */
+    public void setS3ClientOptions(S3ClientOptions clientOptions);
+  
+    /**
+     * <p>
      * Changes the Amazon S3 storage class for a specified object. Amazon S3
      * offers multiple storage classes for developers' different needs.
      * </p>

--- a/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -204,6 +204,9 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
     /** Shared factory for converting configuration objects to XML */
     private static final BucketConfigurationXmlFactory bucketConfigurationXmlFactory = new BucketConfigurationXmlFactory();
 
+    /** S3 specific client configuration options */
+    private S3ClientOptions clientOptions = new S3ClientOptions();
+  
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
@@ -334,6 +337,17 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
                 "/com/amazonaws/services/s3/request.handlers"));
     }
 
+    /**
+     * <p>
+     * Override the default S3 client options for this client.
+     * </p>
+     * @param clientOptions
+     *            The S3 client options to use.
+     */
+    public void setS3ClientOptions(S3ClientOptions clientOptions) {
+      this.clientOptions = new S3ClientOptions(clientOptions);      
+    }
+  
     /**
      * Appends a request handler to the list of registered handlers that are run
      * as part of a request's lifecycle.
@@ -2873,7 +2887,8 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         boolean sslCertMismatch = endpoint.getScheme().equalsIgnoreCase("https") &&
                                   bucketName != null && bucketName.contains(".");
 
-        if (bucketNameUtils.isDNSBucketName(bucketName) && !validIP(endpoint.getHost()) && !sslCertMismatch) {
+        if (!clientOptions.isPathStyleAccess() && bucketNameUtils.isDNSBucketName(bucketName) && 
+              !validIP(endpoint.getHost()) && !sslCertMismatch) {
             request.setEndpoint(convertToVirtualHostEndpoint(bucketName));
             request.setResourcePath(ServiceUtils.urlEncode(key));
         } else {

--- a/src/main/java/com/amazonaws/services/s3/S3ClientOptions.java
+++ b/src/main/java/com/amazonaws/services/s3/S3ClientOptions.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.s3;
+
+/**
+ * S3 client configuration options such as the request access style.
+ */
+public class S3ClientOptions {
+  
+    /** The default setting for use of path-style access */
+    public static final boolean DEFAULT_PATH_STYLE_ACCESS = false;
+  
+    /** Flag for use of path-style access */
+    private boolean pathStyleAccess = DEFAULT_PATH_STYLE_ACCESS;
+    
+    public S3ClientOptions() {}
+  
+    public S3ClientOptions( S3ClientOptions other ) {
+        this.pathStyleAccess = other.pathStyleAccess;
+    }
+
+    /**
+     * <p>
+     * Returns whether the client uses path-style access for all requests.
+     * </p>
+     * <p>
+     * Amazon S3 supports virtual-hosted-style and path-style access in all
+     * Regions. The path-style syntax, however, requires that you use the
+     * region-specific endpoint when attempting to access a bucket.
+     * </p>
+     * <p>
+     * The default behaviour is to detect which access style to use based on
+     * the configured endpoint (an IP will result in path-style access) and
+     * the bucket being accessed (some buckets are not valid DNS names).
+     * Setting this flag will result in path-style access being used for all
+     * requests.
+     * </p>
+     * @return True is the client should always use path-style access
+     */
+    public boolean isPathStyleAccess() {
+        return pathStyleAccess;
+    }
+  
+    /**
+     * <p>
+     * Configures the client to use path-style access for all requests.
+     * </p>
+     * <p>
+     * Amazon S3 supports virtual-hosted-style and path-style access in all
+     * Regions. The path-style syntax, however, requires that you use the
+     * region-specific endpoint when attempting to access a bucket.
+     * </p>
+     * <p>
+     * The default behaviour is to detect which access style to use based on
+     * the configured endpoint (an IP will result in path-style access) and
+     * the bucket being accessed (some buckets are not valid DNS names).
+     * Setting this flag will result in path-style access being used for all
+     * requests.
+     * </p>
+     * @param pathStyleAccess
+     *            True to always use path-style access.
+     */  
+    public void setPathStyleAccess(boolean pathStyleAccess) {
+      this.pathStyleAccess = pathStyleAccess;
+    }
+
+    /**
+     * <p>
+     * Configures the client to use path-style access for all requests.
+     * </p>
+     * <p>
+     * Amazon S3 supports virtual-hosted-style and path-style access in all
+     * Regions. The path-style syntax, however, requires that you use the
+     * region-specific endpoint when attempting to access a bucket.
+     * </p>
+     * <p>
+     * The default behaviour is to detect which access style to use based on
+     * the configured endpoint (an IP will result in path-style access) and
+     * the bucket being accessed (some buckets are not valid DNS names).
+     * Setting this flag will result in path-style access being used for all
+     * requests.
+     * </p>
+     * @param pathStyleAccess
+     *            True to always use path-style access.
+     *            
+     * @return The updated S3ClientOptions object with the new path-style
+     *         access setting.
+     */
+    public S3ClientOptions withPathStyleAccess(boolean pathStyleAccess) {
+      setPathStyleAccess(pathStyleAccess);
+      return this;
+    }
+
+}


### PR DESCRIPTION
This change makes the use of path-style access an explicit option for the S3 client. Currently it is possible to force the use of path-style access by using an IP address in the endpoint URL, this change allows users to better control the behaviour.

This pull request is an updated version of https://github.com/aws/aws-sdk-java/pull/33 as per conversation with Jason.
