### PR TITLE
Fix for #36

### DIFF
--- a/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -677,6 +677,7 @@ public class AmazonHttpClient {
         try {
             Thread.sleep(delay);
         } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
             throw new AmazonClientException(e.getMessage(), e);
         }
     }


### PR DESCRIPTION
Avoid clearing interrupt flag when catching InterruptedException.  For this fix to work, HttpClient will also need upgrading to 4.2.4 when it is released (see https://issues.apache.org/jira/browse/HTTPCLIENT-1311)
