### PR TITLE
Update AWSJavaMailTransport to fall back on no-arg AmazonSESClient ctor

### DIFF
--- a/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
+++ b/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
@@ -310,13 +310,21 @@ public class AWSJavaMailTransport extends Transport {
 
 		if (isNullOrEmpty(awsAccessKey) || isNullOrEmpty(awsSecretKey)) {
 			if (isNullOrEmpty(accessKey) || isNullOrEmpty(secretKey)) {
-				return false;
+				// Use the no-argument constructor to fall back on:
+				// - Environment Variables
+				// - Java System Properties
+				// - Instance profile credentials delivered through the Amazon EC2 metadata service
+				this.emailService = new AmazonSimpleEmailServiceClient();
 			}
 			awsAccessKey = this.accessKey;
 			awsSecretKey = this.secretKey;
 		}
 
-        this.emailService = new AmazonSimpleEmailServiceClient(new BasicAWSCredentials(awsAccessKey, awsSecretKey));
+		if (this.emailService == null) {
+			// Use the supplied credentials.
+			this.emailService = new AmazonSimpleEmailServiceClient(new BasicAWSCredentials(awsAccessKey, awsSecretKey));
+		}
+		
 		if (!isNullOrEmpty(host)) {
 			this.emailService.setEndpoint(host);
 		} else if (this.httpsEndpoint != null) {


### PR DESCRIPTION
The current implementation of the AWSJavaMailTransport class only works if credentials are explicitly supplied, which means that you can't use fallback mechanisms such as environment variables, IAM Roles for EC2, etc. that are supported by the AmazonSimpleEmailServiceClient.

This patch allows you to not specify credentials, which causes the transport to fallback on the no-arg ctor of the service client.
