### PR TITLE
Added OSGi manifest header generation to the pom.xml.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
     <artifactId>aws-java-sdk</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>AWS SDK for Java</name>
     <version>1.3.33</version>
     <description>The Amazon Web Services SDK for Java provides Java APIs for building software on AWS’ cost-effective, scalable, and reliable infrastructure products. The AWS Java SDK allows developers to code against APIs for all of Amazon's infrastructure web services (Amazon S3, Amazon EC2, Amazon SQS, Amazon Relational Database Service, Amazon AutoScaling, etc).</description>
@@ -173,6 +173,18 @@
             </execution>
           </executions>
         </plugin>
+
+        <plugin>
+            <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+            <extensions>true</extensions>
+            <configuration>
+              <instructions>
+                <Export-Package>com.amazonaws.*</Export-Package>                
+              </instructions>
+            </configuration>
+          </plugin>
+
       </plugins>
     </build>
 


### PR DESCRIPTION
Used the Felix Bundle Maven plugin to generate OSGi manifest headers. This makes the jar file usable as an OSGi bundle. It doesn't impact non-OSGi users at all.

Note that I exported all classes from the JAR. Ideally you would hide implementation classes (by not exporting them) so that nobody accidentally uses them. Because I'm not very familiar with the library yet I can't really decide on this.