### PR TITLE
Use SLF4J instead of JCL (Case 93189881)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 
     <dependencies>
         <dependency>
-            <groupId>commons-logging</groupId>
-            <artifactId>commons-logging</artifactId>
-            <version>1.1.1</version>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.7.5</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/com/amazonaws/auth/AWS3Signer.java
+++ b/src/main/java/com/amazonaws/auth/AWS3Signer.java
@@ -25,8 +25,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.UUID;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -47,7 +47,7 @@ public class AWS3Signer extends AbstractAWSSigner {
     private String overriddenDate;
 
     protected static final DateUtils dateUtils = new DateUtils();
-    private static final Log log = LogFactory.getLog(AWS3Signer.class);
+    private static final Logger log = LoggerFactory.getLogger(AWS3Signer.class);
 
 
     /**

--- a/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -24,8 +24,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.SimpleTimeZone;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -56,7 +56,7 @@ public class AWS4Signer extends AbstractAWSSigner {
     /** Date override for testing only */
     private Date overriddenDate;
 
-    private static final Log log = LogFactory.getLog(AWS4Signer.class);
+    private static final Logger log = LoggerFactory.getLogger(AWS4Signer.class);
 
 
     /* (non-Javadoc)

--- a/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
+++ b/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
@@ -17,8 +17,8 @@ package com.amazonaws.auth;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 
@@ -33,7 +33,7 @@ import com.amazonaws.AmazonClientException;
  */
 public class AWSCredentialsProviderChain implements AWSCredentialsProvider {
 
-    private static final Log log = LogFactory.getLog(AWSCredentialsProviderChain.class);
+    private static final Logger log = LoggerFactory.getLogger(AWSCredentialsProviderChain.class);
 
     private List<AWSCredentialsProvider> credentialsProviders =
         new LinkedList<AWSCredentialsProvider>();

--- a/src/main/java/com/amazonaws/auth/CloudFrontSigner.java
+++ b/src/main/java/com/amazonaws/auth/CloudFrontSigner.java
@@ -16,8 +16,8 @@ package com.amazonaws.auth;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -30,7 +30,7 @@ import com.amazonaws.util.DateUtils;
 public class CloudFrontSigner extends AbstractAWSSigner {
 
     /** Shared log for signing debug output */
-    private static final Log log = LogFactory.getLog(CloudFrontSigner.class);
+    private static final Logger log = LoggerFactory.getLogger(CloudFrontSigner.class);
 
     @Override
     public void sign(Request<?> request, AWSCredentials credentials) throws AmazonClientException {

--- a/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -27,8 +27,8 @@ import java.util.Random;
 
 import javax.net.ssl.SSLContext;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
@@ -64,13 +64,13 @@ public class AmazonHttpClient {
      * enable this logger to get access to AWS request IDs for responses,
      * individual requests and parameters sent to AWS, etc.
      */
-    private static final Log requestLog = LogFactory.getLog("com.amazonaws.request");
+    private static final Logger requestLog = LoggerFactory.getLogger("com.amazonaws.request");
 
     /**
      * Logger for more detailed debugging information, that might not be as
      * useful for end users (ex: HTTP client configuration, etc).
      */
-    static final Log log = LogFactory.getLog(AmazonHttpClient.class);
+    static final Logger log = LoggerFactory.getLogger(AmazonHttpClient.class);
 
     /** Internal client for sending HTTP requests */
     private final HttpClient httpClient;

--- a/src/main/java/com/amazonaws/http/HttpMethodReleaseInputStream.java
+++ b/src/main/java/com/amazonaws/http/HttpMethodReleaseInputStream.java
@@ -21,8 +21,8 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.client.methods.AbortableHttpRequest;
 
@@ -44,7 +44,7 @@ import com.amazonaws.HttpMethod;
  * ensure the necessary cleanup operations can be performed.
  */
 public class HttpMethodReleaseInputStream extends InputStream {
-    private static final Log log = LogFactory.getLog(HttpMethodReleaseInputStream.class);
+    private static final Logger log = LoggerFactory.getLogger(HttpMethodReleaseInputStream.class);
 
     private InputStream inputStream = null;
     private HttpEntityEnclosingRequest httpRequest = null;

--- a/src/main/java/com/amazonaws/http/IdleConnectionReaper.java
+++ b/src/main/java/com/amazonaws/http/IdleConnectionReaper.java
@@ -18,8 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.conn.ClientConnectionManager;
 
 /**
@@ -55,7 +55,7 @@ public class IdleConnectionReaper extends Thread {
     private static IdleConnectionReaper instance;
 
     /** Shared log for any errors during connection reaping. */
-    static final Log log = LogFactory.getLog(IdleConnectionReaper.class);
+    static final Logger log = LoggerFactory.getLogger(IdleConnectionReaper.class);
 
     /** Private constructor - singleton pattern. */
     private IdleConnectionReaper() {

--- a/src/main/java/com/amazonaws/http/JsonResponseHandler.java
+++ b/src/main/java/com/amazonaws/http/JsonResponseHandler.java
@@ -16,8 +16,8 @@ package com.amazonaws.http;
 
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.codehaus.jackson.JsonFactory;
 import org.codehaus.jackson.JsonParser;
 
@@ -42,7 +42,7 @@ public class JsonResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
     private Unmarshaller<T, JsonUnmarshallerContext> responseUnmarshaller;
 
     /** Shared logger for profiling information */
-    private static final Log log = LogFactory.getLog("com.amazonaws.request");
+    private static final Logger log = LoggerFactory.getLogger("com.amazonaws.request");
 
     private static JsonFactory jsonFactory = new JsonFactory();
 

--- a/src/main/java/com/amazonaws/http/RepeatableInputStreamRequestEntity.java
+++ b/src/main/java/com/amazonaws/http/RepeatableInputStreamRequestEntity.java
@@ -18,8 +18,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.InputStreamEntity;
 
@@ -44,7 +44,7 @@ class RepeatableInputStreamRequestEntity extends BasicHttpEntity {
     private InputStream content;
 
     /** Shared logger for more debugging information */
-    private static final Log log = LogFactory.getLog(AmazonHttpClient.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonHttpClient.class);
 
     /**
      * Record the original exception if we do attempt a retry, so that if the

--- a/src/main/java/com/amazonaws/http/StaxResponseHandler.java
+++ b/src/main/java/com/amazonaws/http/StaxResponseHandler.java
@@ -21,8 +21,8 @@ import java.util.Map;
 import javax.xml.stream.XMLEventReader;
 import javax.xml.stream.XMLInputFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.ResponseMetadata;
@@ -44,7 +44,7 @@ public class StaxResponseHandler<T> implements HttpResponseHandler<AmazonWebServ
     private Unmarshaller<T, StaxUnmarshallerContext> responseUnmarshaller;
 
     /** Shared logger for profiling information */
-    private static final Log log = LogFactory.getLog("com.amazonaws.request");
+    private static final Logger log = LoggerFactory.getLogger("com.amazonaws.request");
 
     /** Shared factory for creating XML event readers */
     private static XMLInputFactory xmlInputFactory = XMLInputFactory.newInstance();

--- a/src/main/java/com/amazonaws/internal/EC2MetadataClient.java
+++ b/src/main/java/com/amazonaws/internal/EC2MetadataClient.java
@@ -19,8 +19,8 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Simple client for accessing the Amazon EC2 Instance Metadata Service.
@@ -36,7 +36,7 @@ public class EC2MetadataClient {
     /** Default resource path for credentials in the Amazon EC2 Instance Metadata Service. */
     public static final String SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials/";
 
-    private static final Log log = LogFactory.getLog(EC2MetadataClient.class);
+    private static final Logger log = LoggerFactory.getLogger(EC2MetadataClient.class);
 
     /**
      * Connects to the Amazon EC2 Instance Metadata Service to retrieve the

--- a/src/main/java/com/amazonaws/regions/RegionUtils.java
+++ b/src/main/java/com/amazonaws/regions/RegionUtils.java
@@ -24,8 +24,8 @@ import java.net.URL;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
@@ -48,7 +48,7 @@ public class RegionUtils {
     private static final String REGIONS_FILE_OVERRIDE = RegionUtils.class.getName() + ".fileOverride";
 
     // Use the same logger as the http client
-    private static final Log log = LogFactory.getLog("com.amazonaws.request");
+    private static final Logger log = LoggerFactory.getLogger("com.amazonaws.request");
     
     /**
      * Returns a list of the available AWS regions.

--- a/src/main/java/com/amazonaws/services/datapipeline/DataPipelineClient.java
+++ b/src/main/java/com/amazonaws/services/datapipeline/DataPipelineClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -84,7 +84,7 @@ public class DataPipelineClient extends AmazonWebServiceClient implements DataPi
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(DataPipeline.class);
+    private static final Logger log = LoggerFactory.getLogger(DataPipeline.class);
 
     /**
      * List of exception unmarshallers for all DataPipeline exceptions.

--- a/src/main/java/com/amazonaws/services/directconnect/AmazonDirectConnectClient.java
+++ b/src/main/java/com/amazonaws/services/directconnect/AmazonDirectConnectClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -77,7 +77,7 @@ public class AmazonDirectConnectClient extends AmazonWebServiceClient implements
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AmazonDirectConnect.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonDirectConnect.class);
 
     /**
      * List of exception unmarshallers for all AmazonDirectConnect exceptions.

--- a/src/main/java/com/amazonaws/services/dynamodb/AmazonDynamoDBClient.java
+++ b/src/main/java/com/amazonaws/services/dynamodb/AmazonDynamoDBClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -60,7 +60,7 @@ public class AmazonDynamoDBClient extends AmazonWebServiceClient implements Amaz
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AmazonDynamoDB.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonDynamoDB.class);
 
     /**
      * List of exception unmarshallers for all AmazonDynamoDB exceptions.

--- a/src/main/java/com/amazonaws/services/elastictranscoder/AmazonElasticTranscoderClient.java
+++ b/src/main/java/com/amazonaws/services/elastictranscoder/AmazonElasticTranscoderClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -57,7 +57,7 @@ public class AmazonElasticTranscoderClient extends AmazonWebServiceClient implem
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AmazonElasticTranscoder.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonElasticTranscoder.class);
 
     /**
      * List of exception unmarshallers for all AmazonElasticTranscoder exceptions.

--- a/src/main/java/com/amazonaws/services/glacier/AmazonGlacierClient.java
+++ b/src/main/java/com/amazonaws/services/glacier/AmazonGlacierClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -90,7 +90,7 @@ public class AmazonGlacierClient extends AmazonWebServiceClient implements Amazo
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AmazonGlacier.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonGlacier.class);
 
     /**
      * List of exception unmarshallers for all AmazonGlacier exceptions.

--- a/src/main/java/com/amazonaws/services/glacier/transfer/JobStatusMonitor.java
+++ b/src/main/java/com/amazonaws/services/glacier/transfer/JobStatusMonitor.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.ClientConfiguration;
@@ -58,7 +58,7 @@ public class JobStatusMonitor {
 	private String queueUrl;
 	private String topicArn;
 
-    private static final Log log = LogFactory.getLog(JobStatusMonitor.class);
+    private static final Logger log = LoggerFactory.getLogger(JobStatusMonitor.class);
 
 	public JobStatusMonitor(AWSCredentialsProvider credentialsProvider, ClientConfiguration clientConfiguration) {
 		sqs = new AmazonSQSClient(credentialsProvider, clientConfiguration);

--- a/src/main/java/com/amazonaws/services/opsworks/AWSOpsWorksClient.java
+++ b/src/main/java/com/amazonaws/services/opsworks/AWSOpsWorksClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -55,7 +55,7 @@ public class AWSOpsWorksClient extends AmazonWebServiceClient implements AWSOpsW
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AWSOpsWorks.class);
+    private static final Logger log = LoggerFactory.getLogger(AWSOpsWorks.class);
 
     /**
      * List of exception unmarshallers for all AWSOpsWorks exceptions.

--- a/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -33,8 +33,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -190,7 +190,7 @@ import com.amazonaws.util.Md5Utils;
 public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
 
     /** Shared logger for client events */
-    private static Log log = LogFactory.getLog(AmazonS3Client.class);
+    private static Logger log = LoggerFactory.getLogger(AmazonS3Client.class);
 
     /** Responsible for handling error responses from all S3 service calls. */
     private S3ErrorResponseHandler errorResponseHandler = new S3ErrorResponseHandler();

--- a/src/main/java/com/amazonaws/services/s3/AmazonS3EncryptionClient.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3EncryptionClient.java
@@ -27,8 +27,8 @@ import java.util.Map;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -78,7 +78,7 @@ public class AmazonS3EncryptionClient extends AmazonS3Client {
     private static final String USER_AGENT = AmazonS3EncryptionClient.class.getName() + "/" + VersionInfoUtils.getVersion();
 
     /** Shared logger for encryption client events */
-    private static Log log = LogFactory.getLog(AmazonS3EncryptionClient.class);
+    private static Logger log = LoggerFactory.getLogger(AmazonS3EncryptionClient.class);
 
     /** Map of data about in progress encrypted multipart uploads. */
     private Map<String, EncryptedUploadContext> currentMultipartUploadSecretKeys =

--- a/src/main/java/com/amazonaws/services/s3/internal/AbstractRepeatableInputStream.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/AbstractRepeatableInputStream.java
@@ -21,8 +21,8 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Abstract base class for input stream wrappers that add support for
@@ -32,7 +32,7 @@ import org.apache.commons.logging.LogFactory;
  */
 public abstract class AbstractRepeatableInputStream extends FilterInputStream {
 
-    private static final Log log = LogFactory.getLog(AbstractRepeatableInputStream.class);
+    private static final Logger log = LoggerFactory.getLogger(AbstractRepeatableInputStream.class);
 
     private long bytesReadPastMarkPoint = 0;
     private long markPoint = 0;

--- a/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
@@ -22,8 +22,8 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.ResponseMetadata;
@@ -45,7 +45,7 @@ public abstract class AbstractS3ResponseHandler<T>
         implements HttpResponseHandler<AmazonWebServiceResponse<T>> {
 
     /** Shared logger */
-    private static final Log log = LogFactory.getLog(S3MetadataResponseHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(S3MetadataResponseHandler.class);
 
     /** The set of response headers that aren't part of the object's metadata */
     private static final Set<String> ignoredHeaders;

--- a/src/main/java/com/amazonaws/services/s3/internal/Mimetypes.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/Mimetypes.java
@@ -25,8 +25,8 @@ import java.io.InputStreamReader;
 import java.util.HashMap;
 import java.util.StringTokenizer;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class that maintains a listing of known Mimetypes, and determines the
@@ -45,7 +45,7 @@ import org.apache.commons.logging.LogFactory;
  * no associated extensions are also ignored.
  */
 public class Mimetypes {
-    private static final Log log = LogFactory.getLog(Mimetypes.class);
+    private static final Logger log = LoggerFactory.getLogger(Mimetypes.class);
 
     /** The default XML mimetype: application/xml */
     public static final String MIMETYPE_XML = "application/xml";

--- a/src/main/java/com/amazonaws/services/s3/internal/RepeatableFileInputStream.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/RepeatableFileInputStream.java
@@ -23,15 +23,15 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A repeatable input stream for files. This input stream can be repeated an
  * unlimited number of times, without any limitation on when a repeat can occur.
  */
 public class RepeatableFileInputStream extends InputStream {
-    private static final Log log = LogFactory.getLog(RepeatableFileInputStream.class);
+    private static final Logger log = LoggerFactory.getLogger(RepeatableFileInputStream.class);
 
     private final File file;
     private FileInputStream fis = null;

--- a/src/main/java/com/amazonaws/services/s3/internal/RepeatableInputStream.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/RepeatableInputStream.java
@@ -20,8 +20,8 @@ package com.amazonaws.services.s3.internal;
 import java.io.IOException;
 import java.io.InputStream;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A repeatable input stream wrapper for any input stream. This input stream
@@ -33,7 +33,7 @@ import org.apache.commons.logging.LogFactory;
  * input stream can be repeated without any limitations.
  */
 public class RepeatableInputStream extends InputStream {
-    private static final Log log = LogFactory.getLog(RepeatableInputStream.class);
+    private static final Logger log = LoggerFactory.getLogger(RepeatableInputStream.class);
 
     private InputStream is = null;
     private int bufferSize = 0;

--- a/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/S3Signer.java
@@ -16,8 +16,8 @@ package com.amazonaws.services.s3.internal;
 
 import java.util.Date;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -35,7 +35,7 @@ import com.amazonaws.services.s3.Headers;
 public class S3Signer extends AbstractAWSSigner {
 
     /** Shared log for signing debug output */
-    private static final Log log = LogFactory.getLog(S3Signer.class);
+    private static final Logger log = LoggerFactory.getLogger(S3Signer.class);
 
     /**
      * The HTTP verb (GET, PUT, HEAD, DELETE) the request to sign

--- a/src/main/java/com/amazonaws/services/s3/internal/S3XmlResponseHandler.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/S3XmlResponseHandler.java
@@ -17,8 +17,8 @@ package com.amazonaws.services.s3.internal;
 import java.io.InputStream;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonWebServiceResponse;
 import com.amazonaws.http.HttpResponse;
@@ -34,7 +34,7 @@ public class S3XmlResponseHandler<T> extends AbstractS3ResponseHandler<T> {
     private Unmarshaller<T, InputStream> responseUnmarshaller;
 
     /** Shared logger for profiling information */
-    private static final Log log = LogFactory.getLog("com.amazonaws.request");
+    private static final Logger log = LoggerFactory.getLogger("com.amazonaws.request");
 
     /** Response headers from the processed response */
     private Map<String, String> responseHeaders;

--- a/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
+++ b/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
@@ -32,8 +32,8 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.Request;
@@ -47,7 +47,7 @@ import com.amazonaws.util.Md5Utils;
  * General utility methods used throughout the AWS S3 Java client.
  */
 public class ServiceUtils {
-    private static final Log log = LogFactory.getLog(ServiceUtils.class);
+    private static final Logger log = LoggerFactory.getLogger(ServiceUtils.class);
 
     protected static final DateUtils dateUtils = new DateUtils();
 

--- a/src/main/java/com/amazonaws/services/s3/model/transform/XmlResponsesSaxParser.java
+++ b/src/main/java/com/amazonaws/services/s3/model/transform/XmlResponsesSaxParser.java
@@ -31,8 +31,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -93,7 +93,7 @@ import com.amazonaws.services.s3.model.VersionListing;
  * converting these documents into objects.
  */
 public class XmlResponsesSaxParser {
-    private static final Log log = LogFactory.getLog(XmlResponsesSaxParser.class);
+    private static final Logger log = LoggerFactory.getLogger(XmlResponsesSaxParser.class);
 
     private XMLReader xr = null;
 

--- a/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -27,8 +27,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -126,7 +126,7 @@ public class TransferManager {
     /** Thread used for periodicially checking transfers and updating thier state. */
     private ScheduledExecutorService timedThreadPool = new ScheduledThreadPoolExecutor(1);
 
-    private static final Log log = LogFactory.getLog(TransferManager.class);
+    private static final Logger log = LoggerFactory.getLogger(TransferManager.class);
 
 
     /**

--- a/src/main/java/com/amazonaws/services/s3/transfer/internal/ProgressListenerChain.java
+++ b/src/main/java/com/amazonaws/services/s3/transfer/internal/ProgressListenerChain.java
@@ -17,8 +17,8 @@ package com.amazonaws.services.s3.transfer.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.s3.model.ProgressEvent;
 import com.amazonaws.services.s3.model.ProgressListener;
@@ -26,7 +26,7 @@ import com.amazonaws.services.s3.model.ProgressListener;
 public class ProgressListenerChain implements ProgressListener {
     private final List<ProgressListener> listeners = new ArrayList<ProgressListener>();
 
-    private static final Log log = LogFactory.getLog(ProgressListenerChain.class);
+    private static final Logger log = LoggerFactory.getLogger(ProgressListenerChain.class);
     
     public ProgressListenerChain(ProgressListener... listeners) {
         for (ProgressListener listener : listeners) addProgressListener(listener);

--- a/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadCallable.java
+++ b/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadCallable.java
@@ -22,8 +22,8 @@ import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3EncryptionClient;
@@ -49,7 +49,7 @@ public class UploadCallable implements Callable<UploadResult> {
     private String multipartUploadId;
     private final UploadImpl upload;
 
-    private static final Log log = LogFactory.getLog(UploadCallable.class);
+    private static final Logger log = LoggerFactory.getLogger(UploadCallable.class);
     private final TransferManagerConfiguration configuration;
     private final ProgressListenerChain progressListenerChain;
     private final List<Future<PartETag>> futures = new ArrayList<Future<PartETag>>();

--- a/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadMonitor.java
+++ b/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadMonitor.java
@@ -23,8 +23,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.services.s3.AmazonS3;
@@ -53,7 +53,7 @@ public class UploadMonitor implements Callable<UploadResult>, TransferMonitor {
     private final PutObjectRequest putObjectRequest;
     private ScheduledExecutorService timedThreadPool;
 
-    private static final Log log = LogFactory.getLog(UploadMonitor.class);
+    private static final Logger log = LoggerFactory.getLogger(UploadMonitor.class);
     private final TransferManagerConfiguration configuration;
     private final ProgressListenerChain progressListenerChain;
     private final UploadCallable multipartUploadCallable;

--- a/src/main/java/com/amazonaws/services/simpleworkflow/AmazonSimpleWorkflowClient.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/AmazonSimpleWorkflowClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -346,7 +346,7 @@ public class AmazonSimpleWorkflowClient extends AmazonWebServiceClient implement
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AmazonSimpleWorkflow.class);
+    private static final Logger log = LoggerFactory.getLogger(AmazonSimpleWorkflow.class);
 
     /**
      * List of exception unmarshallers for all AmazonSimpleWorkflow exceptions.

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/ActivityTaskPoller.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/ActivityTaskPoller.java
@@ -20,8 +20,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.generic.ActivityImplementationFactory;
@@ -30,7 +30,7 @@ import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
 
 public class ActivityTaskPoller extends SynchronousActivityTaskPoller {
 
-    private static final Log log = LogFactory.getLog(ActivityTaskPoller.class);
+    private static final Logger log = LoggerFactory.getLogger(ActivityTaskPoller.class);
 
     private ThreadPoolExecutor taskExecutorService;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecider.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecider.java
@@ -18,8 +18,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
@@ -125,7 +125,7 @@ class AsyncDecider {
 
     }
 
-    private static final Log log = LogFactory.getLog(AsyncDecider.class);
+    private static final Logger log = LoggerFactory.getLogger(AsyncDecider.class);
 
     private final WorkflowDefinitionFactory workflowDefinitionFactory;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecisionTaskHandler.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/AsyncDecisionTaskHandler.java
@@ -18,8 +18,8 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.flow.core.AsyncTaskInfo;
 import com.amazonaws.services.simpleworkflow.flow.generic.WorkflowDefinition;
@@ -32,9 +32,9 @@ import com.amazonaws.services.simpleworkflow.model.WorkflowType;
 
 public class AsyncDecisionTaskHandler extends DecisionTaskHandler {
 
-    private static final Log log = LogFactory.getLog(AsyncDecisionTaskHandler.class);
+    private static final Logger log = LoggerFactory.getLogger(AsyncDecisionTaskHandler.class);
 
-    private static final Log asyncThreadDumpLog = LogFactory.getLog(AsyncDecisionTaskHandler.class.getName()
+    private static final Logger asyncThreadDumpLog = LoggerFactory.getLogger(AsyncDecisionTaskHandler.class.getName()
             + ".waitingTasksStacks");
 
     private final WorkflowDefinitionFactoryFactory definitionFactoryFactory;

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionTaskPoller.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionTaskPoller.java
@@ -18,8 +18,8 @@ import java.lang.management.ManagementFactory;
 import java.util.Iterator;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.common.WorkflowExecutionUtils;
@@ -30,9 +30,9 @@ import com.amazonaws.services.simpleworkflow.model.TaskList;
 
 public class DecisionTaskPoller implements TaskPoller {
 
-    private static final Log log = LogFactory.getLog(DecisionTaskPoller.class);
+    private static final Logger log = LoggerFactory.getLogger(DecisionTaskPoller.class);
 
-    private static final Log decisionsLog = LogFactory.getLog(DecisionTaskPoller.class.getName() + ".decisions");
+    private static final Logger decisionsLog = LoggerFactory.getLogger(DecisionTaskPoller.class.getName() + ".decisions");
 
     private class DecisionTaskIterator implements Iterator<DecisionTask> {
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionsHelper.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/DecisionsHelper.java
@@ -64,7 +64,7 @@ import com.amazonaws.services.simpleworkflow.model.TimerStartedEventAttributes;
 
 class DecisionsHelper {
 
-    //    private static final Log log = LogFactory.getLog(DecisionsHelper.class);
+    //    private static final Logger log = LoggerFactory.getLogger(DecisionsHelper.class);
 
     static final int MAXIMUM_DECISIONS_PER_COMPLETION = 100;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericActivityWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericActivityWorker.java
@@ -19,8 +19,8 @@ import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
@@ -35,7 +35,7 @@ import com.amazonaws.services.simpleworkflow.model.TypeAlreadyExistsException;
 
 public class GenericActivityWorker extends GenericWorker {
 
-    private static final Log log = LogFactory.getLog(GenericActivityWorker.class);
+    private static final Logger log = LoggerFactory.getLogger(GenericActivityWorker.class);
 
     private static final String POLL_THREAD_NAME_PREFIX = "SWF Activity Poll ";
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericWorker.java
@@ -24,8 +24,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.WorkerBase;
@@ -109,7 +109,7 @@ public abstract class GenericWorker implements WorkerBase {
         }
     }
 
-    private static final Log log = LogFactory.getLog(GenericWorker.class);
+    private static final Logger log = LoggerFactory.getLogger(GenericWorker.class);
 
     protected static final int MAX_IDENTITY_LENGTH = 256;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericWorkflowWorker.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/GenericWorkflowWorker.java
@@ -16,8 +16,8 @@ package com.amazonaws.services.simpleworkflow.flow.worker;
 
 import java.lang.management.ManagementFactory;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowTypeRegistrationOptions;
@@ -32,7 +32,7 @@ import com.amazonaws.services.simpleworkflow.model.WorkflowType;
 
 public class GenericWorkflowWorker extends GenericWorker {
 
-    private static final Log log = LogFactory.getLog(GenericWorkflowWorker.class);
+    private static final Logger log = LoggerFactory.getLogger(GenericWorkflowWorker.class);
 
     private static final String THREAD_NAME_PREFIX = "SWF Decider ";
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/HistoryHelper.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/HistoryHelper.java
@@ -17,8 +17,8 @@ package com.amazonaws.services.simpleworkflow.flow.worker;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.flow.common.WorkflowExecutionUtils;
 import com.amazonaws.services.simpleworkflow.model.DecisionTask;
@@ -27,7 +27,7 @@ import com.amazonaws.services.simpleworkflow.model.HistoryEvent;
 
 class HistoryHelper {
 
-    private static final Log historyLog = LogFactory.getLog(HistoryHelper.class.getName() + ".history");
+    private static final Logger historyLog = LoggerFactory.getLogger(HistoryHelper.class.getName() + ".history");
 
     class EventsIterator implements Iterator<HistoryEvent> {
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/SynchronousActivityTaskPoller.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/SynchronousActivityTaskPoller.java
@@ -20,8 +20,8 @@ import java.lang.management.ManagementFactory;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.AmazonSimpleWorkflow;
 import com.amazonaws.services.simpleworkflow.flow.ActivityExecutionContext;
@@ -40,7 +40,7 @@ import com.amazonaws.services.simpleworkflow.model.UnknownResourceException;
 
 public class SynchronousActivityTaskPoller implements TaskPoller {
 
-    private static final Log log = LogFactory.getLog(SynchronousActivityTaskPoller.class);
+    private static final Logger log = LoggerFactory.getLogger(SynchronousActivityTaskPoller.class);
 
     private AmazonSimpleWorkflow service;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/SynchronousRetrier.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/SynchronousRetrier.java
@@ -14,12 +14,12 @@
  */
 package com.amazonaws.services.simpleworkflow.flow.worker;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SynchronousRetrier {
     
-    private static final Log log = LogFactory.getLog(SynchronousRetrier.class);
+    private static final Logger log = LoggerFactory.getLogger(SynchronousRetrier.class);
 
     private final ExponentialRetryParameters retryParameters;
 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/Throttler.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/Throttler.java
@@ -14,12 +14,12 @@
  */
 package com.amazonaws.services.simpleworkflow.flow.worker;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class Throttler {
 
-    private static final Log log = LogFactory.getLog(Throttler.class);
+    private static final Logger log = LoggerFactory.getLogger(Throttler.class);
     
     /**
      * Human readable name of the resource being throttled. 

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/WorkflowClockImpl.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/worker/WorkflowClockImpl.java
@@ -18,8 +18,8 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CancellationException;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.services.simpleworkflow.flow.StartTimerFailedException;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowClock;
@@ -36,7 +36,7 @@ import com.amazonaws.services.simpleworkflow.model.TimerFiredEventAttributes;
 
 class WorkflowClockImpl implements WorkflowClock {
 
-    private static final Log log = LogFactory.getLog(WorkflowClockImpl.class);
+    private static final Logger log = LoggerFactory.getLogger(WorkflowClockImpl.class);
 
     private final class TimerCancellationHandler implements ExternalTaskCancellationHandler {
 

--- a/src/main/java/com/amazonaws/services/sqs/buffered/ReceiveQueueBuffer.java
+++ b/src/main/java/com/amazonaws/services/sqs/buffered/ReceiveQueueBuffer.java
@@ -24,8 +24,8 @@ import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonWebServiceRequest;
@@ -54,7 +54,7 @@ import com.amazonaws.services.sqs.model.ReceiveMessageResult;
  * */
 public class ReceiveQueueBuffer {
     
-    private static Log log = LogFactory.getLog(ReceiveQueueBuffer.class);
+    private static Logger log = LoggerFactory.getLogger(ReceiveQueueBuffer.class);
     
     private final QueueBufferConfig config;
     
@@ -475,7 +475,7 @@ public class ReceiveQueueBuffer {
                     batchRequest.setEntries(entries);
                     sqsClient.changeMessageVisibilityBatch(batchRequest);
                 } catch (AmazonClientException e) {
-                    // Log and ignore.
+                    // Logger and ignore.
                     log.warn("ReceiveMessageBatchTask: changeMessageVisibility failed "    + e);
                 }
             }

--- a/src/main/java/com/amazonaws/services/sqs/buffered/SendQueueBuffer.java
+++ b/src/main/java/com/amazonaws/services/sqs/buffered/SendQueueBuffer.java
@@ -24,8 +24,8 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonWebServiceRequest;
@@ -65,7 +65,7 @@ import com.amazonaws.services.sqs.model.SendMessageResult;
 public class SendQueueBuffer {
     
     
-    private static Log log = LogFactory.getLog(SendQueueBuffer.class);
+    private static Logger log = LoggerFactory.getLogger(SendQueueBuffer.class);
 
     // Interface to support event notifications with a parameter.
     private interface Listener<T> {

--- a/src/main/java/com/amazonaws/services/storagegateway/AWSStorageGatewayClient.java
+++ b/src/main/java/com/amazonaws/services/storagegateway/AWSStorageGatewayClient.java
@@ -19,8 +19,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.*;
 import com.amazonaws.regions.*;
@@ -77,7 +77,7 @@ public class AWSStorageGatewayClient extends AmazonWebServiceClient implements A
     /** Provider for AWS credentials. */
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    private static final Log log = LogFactory.getLog(AWSStorageGateway.class);
+    private static final Logger log = LoggerFactory.getLogger(AWSStorageGateway.class);
 
     /**
      * List of exception unmarshallers for all AWSStorageGateway exceptions.

--- a/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
+++ b/src/main/java/com/amazonaws/transform/SimpleTypeJsonUnmarshallers.java
@@ -24,8 +24,8 @@ import java.util.Date;
 import java.util.Locale;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.util.DateUtils;
@@ -36,7 +36,7 @@ public class SimpleTypeJsonUnmarshallers {
     private static DateUtils dateUtils = new DateUtils();
 
     /** Shared logger */
-    private static Log log = LogFactory.getLog(SimpleTypeJsonUnmarshallers.class);
+    private static Logger log = LoggerFactory.getLogger(SimpleTypeJsonUnmarshallers.class);
 
     /**
      * Unmarshaller for String values.

--- a/src/main/java/com/amazonaws/transform/SimpleTypeStaxUnmarshallers.java
+++ b/src/main/java/com/amazonaws/transform/SimpleTypeStaxUnmarshallers.java
@@ -22,8 +22,8 @@ import java.text.ParseException;
 import java.util.Date;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.util.DateUtils;
@@ -37,7 +37,7 @@ public class SimpleTypeStaxUnmarshallers {
     private static DateUtils dateUtils = new DateUtils();
 
     /** Shared logger */
-    private static Log log = LogFactory.getLog(SimpleTypeStaxUnmarshallers.class);
+    private static Logger log = LoggerFactory.getLogger(SimpleTypeStaxUnmarshallers.class);
 
     /**
      * Unmarshaller for String values.

--- a/src/main/java/com/amazonaws/util/AWSRequestMetrics.java
+++ b/src/main/java/com/amazonaws/util/AWSRequestMetrics.java
@@ -21,8 +21,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.amazonaws.http.AmazonHttpClient;
 
@@ -60,7 +60,7 @@ public class AWSRequestMetrics {
     /* A map to store events that are being profiled. */
     private final Map<String, Long> eventsBeingProfiled = new HashMap<String, Long>();
     /* Latency Logger */
-    private static final Log latencyLogger = LogFactory.getLog("com.amazonaws.latency");
+    private static final Logger latencyLogger = LoggerFactory.getLogger("com.amazonaws.latency");
     private static final Object KEY_VALUE_SEPARATOR = "=";
     private static final Object COMMA_SEPARATOR = ", ";
     

--- a/src/main/java/com/amazonaws/util/BinaryUtils.java
+++ b/src/main/java/com/amazonaws/util/BinaryUtils.java
@@ -24,8 +24,8 @@ import java.nio.ByteBuffer;
 import java.util.Locale;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utilities for encoding and decoding binary data to and from different forms.
@@ -35,7 +35,7 @@ public class BinaryUtils {
     /** Default encoding when extracting binary data from a String */
     private static final String DEFAULT_ENCODING = "UTF-8";
 
-    private static final Log log = LogFactory.getLog(BinaryUtils.class);
+    private static final Logger log = LoggerFactory.getLogger(BinaryUtils.class);
 
     /**
      * Converts byte data to a Hex-encoded string.

--- a/src/main/java/com/amazonaws/util/VersionInfoUtils.java
+++ b/src/main/java/com/amazonaws/util/VersionInfoUtils.java
@@ -17,8 +17,8 @@ package com.amazonaws.util;
 import java.io.InputStream;
 import java.util.Properties;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility class for accessing AWS SDK versioning information.
@@ -38,7 +38,7 @@ public class VersionInfoUtils {
     private static String userAgent = null;
 
     /** Shared logger for any issues while loading version information */
-    private static Log log = LogFactory.getLog(VersionInfoUtils.class);
+    private static Logger log = LoggerFactory.getLogger(VersionInfoUtils.class);
 
     /**
      * Returns the current version for the AWS SDK in which this class is

--- a/src/main/java/com/amazonaws/util/XpathUtils.java
+++ b/src/main/java/com/amazonaws/util/XpathUtils.java
@@ -31,8 +31,8 @@ import javax.xml.xpath.XPathExpressionException;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -55,7 +55,7 @@ public class XpathUtils {
     private static DateUtils dateUtils = new DateUtils();
 
     /** Shared logger */
-    private static Log log = LogFactory.getLog(XpathUtils.class);
+    private static Logger log = LoggerFactory.getLogger(XpathUtils.class);
 
     private static DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
 


### PR DESCRIPTION
This is a simple migration to use the simple logging facade instead of using the Jakarta Commons Logging (a deprecated logging framework).

This is in response to AWS Support Case 93189881.