### PR TITLE
Fix RegionUtils.initSDKRegions

### DIFF
--- a/src/main/java/com/amazonaws/regions/RegionUtils.java
+++ b/src/main/java/com/amazonaws/regions/RegionUtils.java
@@ -175,8 +175,7 @@ public class RegionUtils {
      * the SDK, in case it cannot be fetched from the remote source.
      */
     private static void initSDKRegions() {
-        ClassLoader classLoader = RegionUtils.class.getClassLoader();
-        InputStream inputStream = classLoader.getResourceAsStream("/etc/regions.xml");
+        InputStream inputStream = RegionUtils.class.getResourceAsStream("/etc/regions.xml");
         initRegions(inputStream);
     }
 


### PR DESCRIPTION
RegionUtils.initSDKRegions tries to load the /etc/regions.xml file in the classpath using a leading /, which does not work with ClassLoader.getResourceAsStream (returns null)

The proposed fix uses the sorter solution RegionUtils.class.getResourceAsStream("/etc/regions.xml"), but would also work if the leading slash was removed : classLoader.getResourceAsStream("etc/regions.xml").

This is a blocker for applications that must work offline, but rely on code calling the AWS SDK.
