### PR TITLE
Introduce `InstanceFamily` abstraction

### DIFF
--- a/src/main/java/com/amazonaws/services/ec2/model/InstanceFamily.java
+++ b/src/main/java/com/amazonaws/services/ec2/model/InstanceFamily.java
@@ -1,0 +1,26 @@
+package com.amazonaws.services.ec2.model;
+
+import java.util.Collection;
+
+/**
+ * An abstraction of the family of the instances such as processing bound or I/O
+ * bound. Based on the categorization of Amazon AWS instance families, there are
+ * different families of instances that are <b>optimized</b> for certain class
+ * of operations such as computation, storage or I/O.
+ * 
+ * @see InstanceType
+ */
+public interface InstanceFamily {
+
+	/**
+	 * @return The name of the instance family such as {@code GPU}.
+	 */
+	String getName();
+
+	/**
+	 * @return A {@link Collection} of {@link InstanceType}s of this instance
+	 *         family. The result can be empty but not {@code null}.
+	 */
+	Collection<InstanceType> getInstanceTypes();
+
+}

--- a/src/main/java/com/amazonaws/services/ec2/model/InstanceFamilyType.java
+++ b/src/main/java/com/amazonaws/services/ec2/model/InstanceFamilyType.java
@@ -1,0 +1,69 @@
+package com.amazonaws.services.ec2.model;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+
+/**
+ * Enumerations of {@link InstanceFamily} as described in:
+ * 
+ * <a href="http://aws.amazon.com/ec2/instance-types/instance-details/">http://
+ * aws.amazon.com/ec2/instance-types/instance-details/</a>
+ * 
+ * @see InstanceFamily
+ */
+public enum InstanceFamilyType implements InstanceFamily {
+
+	GeneralPurpose("General Purpose", InstanceType.M1Small, InstanceType.M1Medium, InstanceType.M1Large,
+			InstanceType.M1Xlarge, InstanceType.M3Xlarge, InstanceType.M32xlarge),
+
+	ComputeOptimized("Compute Optimized", InstanceType.C1Medium, InstanceType.C1Xlarge, InstanceType.Cc14xlarge,
+			InstanceType.Cc28xlarge),
+
+	MemoryOptimized("Memory Optimized", InstanceType.M22xlarge, InstanceType.M24xlarge, InstanceType.M2Xlarge,
+			InstanceType.Cr18xlarge),
+
+	StorageOptimized("Storage Optimized", InstanceType.Hi14xlarge, InstanceType.Hs18xlarge),
+
+	MicroInstances("Micro Instances", InstanceType.T1Micro),
+
+	GPUInstances("GPU Instances", InstanceType.Cg14xlarge);
+
+	private final String name;
+	private final Collection<InstanceType> instanceTypes = new HashSet<InstanceType>();
+
+	private InstanceFamilyType(String name, InstanceType... instanceTypes) {
+		this.name = name;
+		if (instanceTypes != null && instanceTypes.length > 0) {
+			this.instanceTypes.addAll(Arrays.asList(instanceTypes));
+		}
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public Collection<InstanceType> getInstanceTypes() {
+		return instanceTypes;
+	}
+
+	@Override
+	public String toString() {
+		return name;
+	}
+
+	/**
+	 * @param instanceType
+	 * @return The {@link InstanceFamily} of the instance type; or {@code null}
+	 *         if no associated family can be determined.
+	 */
+	public static InstanceFamily valueOf(InstanceType instanceType) {
+		for (InstanceFamily family : values()) {
+			if (family.getInstanceTypes().contains(instanceType)) {
+				return family;
+			}
+		}
+		return null;
+	}
+
+}

--- a/src/main/java/com/amazonaws/services/ec2/model/InstanceType.java
+++ b/src/main/java/com/amazonaws/services/ec2/model/InstanceType.java
@@ -43,6 +43,17 @@ public enum InstanceType {
     private InstanceType(String value) {
         this.value = value;
     }
+    
+    /**
+	 * Resolve the instance family of this instance type.
+	 * 
+	 * @return The instance family of this instance type. It can be {@code null}
+	 *         .
+	 * @see InstanceFamilyType
+	 */
+    public InstanceFamily getInstanceFamily() {
+    	return InstanceFamilyType.valueOf(this);
+    }
 
     @Override
     public String toString() {
@@ -100,5 +111,6 @@ public enum InstanceType {
             throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
         }
     }
+    
 }
     


### PR DESCRIPTION
Based on the details that are described in this page:
http://aws.amazon.com/ec2/instance-types/instance-details/

InstanceFamilyType introduces a higher level abstraction of the types of the instances that are used. Examples include "general purpose" or "compute optimized". Such abstraction can be better used in application-level awareness of the resources that are required to deliver a type of service. For instance, a service such as data storage needs resources of the family "Storage optimized" which could help hide away lower-level details
of the instance type that is used. It additionally allows to be used in higher-level description of the services that are deployed on the cloud.

A method is added to `InstanceType` to resolve the instance family of the instance type.
There *can* be also a method added to `Instance` that resolves the family directly.