### PR TITLE
Make DynamoDBMapper#delete honor the given config

### DIFF
--- a/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -1061,7 +1061,7 @@ public class DynamoDBMapper {
      * Deletes the given object from its DynamoDB table using the specified configuration.
      */
     public void delete(Object object, DynamoDBMapperConfig config) {
-        delete(object, null, this.config);
+        delete(object, null, config);
     }
 
     /**


### PR DESCRIPTION
Instead of using this.config.
No test provided since aws-sdk-java but it worked for me.
