### PR TITLE
Allow ClientConfiguration proxy settings to be used with -Dcom.amazonaws.sdk.disableCertChecking

### DIFF
--- a/src/main/java/com/amazonaws/http/HttpClientFactory.java
+++ b/src/main/java/com/amazonaws/http/HttpClientFactory.java
@@ -209,7 +209,7 @@ class HttpClientFactory {
 
         public Socket createLayeredSocket(Socket arg0, String arg1, int arg2, HttpParams arg3)
                 throws IOException, UnknownHostException {
-            return getSSLContext().getSocketFactory().createSocket();
+            return getSSLContext().getSocketFactory().createSocket(arg0, arg1, arg2, true);
         }
     }
 


### PR DESCRIPTION
If you try to proxy any of the existing client objects using a ClientConfiguration such as

``` Java
        ClientConfiguration config = new ClientConfiguration();
        config.setProxyHost("localhost");
        config.setProxyPort(8080);

        AmazonS3 s3 = new AmazonS3Client(new ClasspathPropertiesFileCredentialsProvider(), config);
```

and also pass `-Dcom.amazonaws.sdk.disableCertChecking=treu` all of the connections will fail with `Socket not connected`` messages.

This patch corrects the `TrustingSocketFactory.createLayeredSocket` method to use the passed in Socket.
