### PR TITLE
Increase the maximum value of multipartUploadThreshold

### DIFF
--- a/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java
+++ b/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java
@@ -55,7 +55,7 @@ public class TransferManagerConfiguration {
      * communication, small uploads are still recommended to use a single
      * connection for the upload.
      */
-    private int multipartUploadThreshold = DEFAULT_MULTIPART_UPLOAD_THRESHOLD;
+    private long multipartUploadThreshold = DEFAULT_MULTIPART_UPLOAD_THRESHOLD;
 
     
     /**
@@ -121,7 +121,7 @@ public class TransferManagerConfiguration {
      *            The size threshold in bytes for when to use multipart
      *            uploads.
      */
-    public void setMultipartUploadThreshold(int multipartUploadThreshold) {
+    public void setMultipartUploadThreshold(long multipartUploadThreshold) {
         this.multipartUploadThreshold = multipartUploadThreshold;
     }
 }


### PR DESCRIPTION
S3 spec. says, "You can upload objects of up to 5 GB in size in a single
operation. For objects greater than 5 GB you must use the multipart
upload API." According to spec., the maximum vaild value of
TransferManagerConfiguration.multipartUploadThreshold should be
5368709120. Use long instead of int here to archive this.
