### PR TITLE
add version setter / getter

### DIFF
--- a/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -41,6 +41,9 @@ public abstract class AmazonWebServiceClient {
     /** The service endpoint to which this client will send requests. */
     protected URI endpoint;
 
+    /** The api version of client use */
+    protected String version;
+
     /** The client configuration */
     protected ClientConfiguration clientConfiguration;
 
@@ -49,10 +52,9 @@ public abstract class AmazonWebServiceClient {
 
     /** Optional request handlers for additional request processing. */
     protected final List<RequestHandler> requestHandlers;
-    
+
     /** Optional offset (in seconds) to use when signing requests */
     protected int timeOffset;
-
 
     /**
      * Constructs a new AmazonWebServiceClient object using the specified
@@ -82,10 +84,10 @@ public abstract class AmazonWebServiceClient {
      * {@link ClientConfiguration} will be used, which by default is HTTPS.
      * <p>
      * For more information on using AWS regions with the AWS SDK for Java, and
-     * a complete list of all available endpoints for all AWS services, see: 
+     * a complete list of all available endpoints for all AWS services, see:
      * <a href="http://developer.amazonwebservices.com/connect/entry.jspa?externalID=3912">
      * http://developer.amazonwebservices.com/connect/entry.jspa?externalID=3912</a>
-     * 
+     *
      * @param endpoint
      *            The endpoint (ex: "ec2.amazonaws.com") or a full URL,
      *            including the protocol (ex: "https://ec2.amazonaws.com") of
@@ -110,7 +112,26 @@ public abstract class AmazonWebServiceClient {
             throw new IllegalArgumentException(e);
         }
     }
-    
+
+    /**
+     * Set api version of this client
+     *
+     * @param version
+     *            api version client uses
+     */
+    public void setVersion(String version) {
+        this.version = version;
+    }
+    /**
+     * Get api version of this client
+     *
+     * @return version
+     *            api version client uses
+     */
+    public String getVersion() {
+        return version;
+    }
+
     /**
      * An alternative to {@link AmazonWebServiceClient#setEndpoint(String)}, sets the
      * regional endpoint for this client's service calls. Callers can use this
@@ -124,7 +145,7 @@ public abstract class AmazonWebServiceClient {
      * By default, all service endpoints in all regions use the https protocol.
      * To use http instead, specify it in the {@link ClientConfiguration}
      * supplied at construction.
-     * 
+     *
      * @param region
      *            The region this client will communicate with. See
      *            {@link Region#getRegion(com.amazonaws.regions.Regions)} for
@@ -150,11 +171,11 @@ public abstract class AmazonWebServiceClient {
         }
         setEndpoint(serviceEndpoint);
     }
-    
+
     /**
      * Returns the service abbreviation for this service, used for identifying
      * service endpoints by region.
-     * 
+     *
      * @see ServiceAbbreviations
      */
     protected String getServiceAbbreviation() {
@@ -237,7 +258,7 @@ public abstract class AmazonWebServiceClient {
         ExecutionContext executionContext = new ExecutionContext(requestHandlers);
         return executionContext;
     }
-    
+
     /**
      * Sets the optional value for time offset for this client.  This
      * value will be applied to all requests processed through this client.
@@ -250,7 +271,7 @@ public abstract class AmazonWebServiceClient {
     public void setTimeOffset(int timeOffset) {
         this.timeOffset = timeOffset;
     }
-    
+
     /**
      * Sets the optional value for time offset for this client.  This
      * value will be applied to all requests processed through this client.
@@ -259,14 +280,14 @@ public abstract class AmazonWebServiceClient {
      *
      * @param timeOffset
      *            The optional value for time offset (in seconds) for this client.
-     * 
+     *
      * @return the updated web service client
      */
     public AmazonWebServiceClient withTimeOffset(int timeOffset) {
         setTimeOffset(timeOffset);
         return this;
     }
-    
+
     /**
      * Returns the optional value for time offset for this client.  This
      * value will be applied to all requests processed through this client.

--- a/src/main/java/com/amazonaws/services/route53/AmazonRoute53Client.java
+++ b/src/main/java/com/amazonaws/services/route53/AmazonRoute53Client.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -42,7 +42,7 @@ import com.amazonaws.services.route53.model.transform.*;
  * using this client are blocking, and will not return until the service call
  * completes.
  * <p>
- * 
+ *
  */
 public class AmazonRoute53Client extends AmazonWebServiceClient implements AmazonRoute53 {
 
@@ -55,7 +55,7 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
     protected final List<Unmarshaller<AmazonServiceException, Node>> exceptionUnmarshallers
             = new ArrayList<Unmarshaller<AmazonServiceException, Node>>();
 
-    
+
     /** AWS signer for authenticating requests. */
     private AWS3Signer signer;
 
@@ -193,19 +193,19 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
         exceptionUnmarshallers.add(new NoSuchHostedZoneExceptionUnmarshaller());
         exceptionUnmarshallers.add(new NoSuchHealthCheckExceptionUnmarshaller());
         exceptionUnmarshallers.add(new PriorRequestNotCompleteExceptionUnmarshaller());
-        
+
         exceptionUnmarshallers.add(new StandardErrorUnmarshaller());
         setEndpoint("route53.amazonaws.com");
 
         signer = new AWS3Signer();
-        
+
 
         HandlerChainFactory chainFactory = new HandlerChainFactory();
 		requestHandlers.addAll(chainFactory.newRequestHandlerChain(
                 "/com/amazonaws/services/route53/request.handlers"));
     }
 
-    
+
     /**
      * <p>
      * Imagine all the resource record sets in a zone listed out in front of
@@ -215,7 +215,7 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * MaxItems resource record sets from this list, in order, starting at a
      * position specified by the Name and Type arguments:
      * </p>
-     * 
+     *
      * <ul>
      * <li>If both Name and Type are omitted, this means start the results
      * at the first RRSET in the HostedZone.</li>
@@ -226,7 +226,7 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * at the first RRSET in the list whose name is greater than or equal to
      * Name and whose type is greater than or equal to Type.</li>
      * <li>It is an error to specify the Type but not the Name.</li>
-     * 
+     *
      * </ul>
      * <p>
      * Use ListResourceRecordSets to retrieve a single known record set by
@@ -264,10 +264,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * @param listResourceRecordSetsRequest Container for the necessary
      *           parameters to execute the ListResourceRecordSets service method on
      *           AmazonRoute53.
-     * 
+     *
      * @return The response from the ListResourceRecordSets service method,
      *         as returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws NoSuchHostedZoneException
      *
@@ -279,12 +279,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public ListResourceRecordSetsResult listResourceRecordSets(ListResourceRecordSetsRequest listResourceRecordSetsRequest) 
+    public ListResourceRecordSetsResult listResourceRecordSets(ListResourceRecordSetsRequest listResourceRecordSetsRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		listResourceRecordSetsRequest.setVersion(super.getVersion());
+    	}
         Request<ListResourceRecordSetsRequest> request = new ListResourceRecordSetsRequestMarshaller().marshall(listResourceRecordSetsRequest);
         return invoke(request, new ListResourceRecordSetsResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * Use this action to create or change your authoritative DNS
@@ -334,10 +337,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * @param changeResourceRecordSetsRequest Container for the necessary
      *           parameters to execute the ChangeResourceRecordSets service method on
      *           AmazonRoute53.
-     * 
+     *
      * @return The response from the ChangeResourceRecordSets service method,
      *         as returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws NoSuchHostedZoneException
      * @throws InvalidChangeBatchException
@@ -352,12 +355,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public ChangeResourceRecordSetsResult changeResourceRecordSets(ChangeResourceRecordSetsRequest changeResourceRecordSetsRequest) 
+    public ChangeResourceRecordSetsResult changeResourceRecordSets(ChangeResourceRecordSetsRequest changeResourceRecordSetsRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		changeResourceRecordSetsRequest.setVersion(super.getVersion());
+    	}
         Request<ChangeResourceRecordSetsRequest> request = new ChangeResourceRecordSetsRequestMarshaller().marshall(changeResourceRecordSetsRequest);
         return invoke(request, new ChangeResourceRecordSetsResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * This action creates a new hosted zone.
@@ -388,10 +394,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param createHostedZoneRequest Container for the necessary parameters
      *           to execute the CreateHostedZone service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the CreateHostedZone service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws HostedZoneAlreadyExistsException
      * @throws InvalidInputException
      * @throws InvalidDomainNameException
@@ -406,12 +412,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public CreateHostedZoneResult createHostedZone(CreateHostedZoneRequest createHostedZoneRequest) 
+    public CreateHostedZoneResult createHostedZone(CreateHostedZoneRequest createHostedZoneRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		createHostedZoneRequest.setVersion(super.getVersion());
+    	}
         Request<CreateHostedZoneRequest> request = new CreateHostedZoneRequestMarshaller().marshall(createHostedZoneRequest);
         return invoke(request, new CreateHostedZoneResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * To retrieve the health check, send a <code>GET</code> request to the
@@ -420,10 +429,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param getHealthCheckRequest Container for the necessary parameters to
      *           execute the GetHealthCheck service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the GetHealthCheck service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws NoSuchHealthCheckException
      *
@@ -435,12 +444,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public GetHealthCheckResult getHealthCheck(GetHealthCheckRequest getHealthCheckRequest) 
+    public GetHealthCheckResult getHealthCheck(GetHealthCheckRequest getHealthCheckRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		getHealthCheckRequest.setVersion(super.getVersion());
+    	}
         Request<GetHealthCheckRequest> request = new GetHealthCheckRequestMarshaller().marshall(getHealthCheckRequest);
         return invoke(request, new GetHealthCheckResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * This action creates a new health check.
@@ -456,10 +468,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param createHealthCheckRequest Container for the necessary parameters
      *           to execute the CreateHealthCheck service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the CreateHealthCheck service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws HealthCheckAlreadyExistsException
      * @throws TooManyHealthChecksException
@@ -472,12 +484,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public CreateHealthCheckResult createHealthCheck(CreateHealthCheckRequest createHealthCheckRequest) 
+    public CreateHealthCheckResult createHealthCheck(CreateHealthCheckRequest createHealthCheckRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		createHealthCheckRequest.setVersion(super.getVersion());
+    	}
         Request<CreateHealthCheckRequest> request = new CreateHealthCheckRequestMarshaller().marshall(createHealthCheckRequest);
         return invoke(request, new CreateHealthCheckResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * This action returns the current status of a change batch request. The
@@ -495,10 +510,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param getChangeRequest Container for the necessary parameters to
      *           execute the GetChange service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the GetChange service method, as returned by
      *         AmazonRoute53.
-     * 
+     *
      * @throws NoSuchChangeException
      * @throws InvalidInputException
      *
@@ -510,12 +525,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public GetChangeResult getChange(GetChangeRequest getChangeRequest) 
+    public GetChangeResult getChange(GetChangeRequest getChangeRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		getChangeRequest.setVersion(super.getVersion());
+    	}
         Request<GetChangeRequest> request = new GetChangeRequestMarshaller().marshall(getChangeRequest);
         return invoke(request, new GetChangeResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * This action deletes a health check. To delete a health check, send a
@@ -535,10 +553,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param deleteHealthCheckRequest Container for the necessary parameters
      *           to execute the DeleteHealthCheck service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the DeleteHealthCheck service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws HealthCheckInUseException
      * @throws NoSuchHealthCheckException
@@ -551,12 +569,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public DeleteHealthCheckResult deleteHealthCheck(DeleteHealthCheckRequest deleteHealthCheckRequest) 
+    public DeleteHealthCheckResult deleteHealthCheck(DeleteHealthCheckRequest deleteHealthCheckRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		deleteHealthCheckRequest.setVersion(super.getVersion());
+    	}
         Request<DeleteHealthCheckRequest> request = new DeleteHealthCheckRequestMarshaller().marshall(deleteHealthCheckRequest);
         return invoke(request, new DeleteHealthCheckResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * To retrieve the delegation set for a hosted zone, send a
@@ -567,10 +588,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param getHostedZoneRequest Container for the necessary parameters to
      *           execute the GetHostedZone service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the GetHostedZone service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      * @throws NoSuchHostedZoneException
      *
@@ -582,12 +603,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public GetHostedZoneResult getHostedZone(GetHostedZoneRequest getHostedZoneRequest) 
+    public GetHostedZoneResult getHostedZone(GetHostedZoneRequest getHostedZoneRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		getHostedZoneRequest.setVersion(super.getVersion());
+    	}
         Request<GetHostedZoneRequest> request = new GetHostedZoneRequestMarshaller().marshall(getHostedZoneRequest);
         return invoke(request, new GetHostedZoneResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * To retrieve a list of your hosted zones, send a <code>GET</code>
@@ -607,10 +631,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param listHostedZonesRequest Container for the necessary parameters
      *           to execute the ListHostedZones service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the ListHostedZones service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      *
      * @throws AmazonClientException
@@ -621,12 +645,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public ListHostedZonesResult listHostedZones(ListHostedZonesRequest listHostedZonesRequest) 
+    public ListHostedZonesResult listHostedZones(ListHostedZonesRequest listHostedZonesRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		listHostedZonesRequest.setVersion(super.getVersion());
+    	}
         Request<ListHostedZonesRequest> request = new ListHostedZonesRequestMarshaller().marshall(listHostedZonesRequest);
         return invoke(request, new ListHostedZonesResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * This action deletes a hosted zone. To delete a hosted zone, send a
@@ -652,10 +679,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param deleteHostedZoneRequest Container for the necessary parameters
      *           to execute the DeleteHostedZone service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the DeleteHostedZone service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws HostedZoneNotEmptyException
      * @throws InvalidInputException
      * @throws NoSuchHostedZoneException
@@ -669,12 +696,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public DeleteHostedZoneResult deleteHostedZone(DeleteHostedZoneRequest deleteHostedZoneRequest) 
+    public DeleteHostedZoneResult deleteHostedZone(DeleteHostedZoneRequest deleteHostedZoneRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		deleteHostedZoneRequest.setVersion(super.getVersion());
+    	}
         Request<DeleteHostedZoneRequest> request = new DeleteHostedZoneRequestMarshaller().marshall(deleteHostedZoneRequest);
         return invoke(request, new DeleteHostedZoneResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * To retrieve a list of your health checks, send a <code>GET</code>
@@ -694,10 +724,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *
      * @param listHealthChecksRequest Container for the necessary parameters
      *           to execute the ListHealthChecks service method on AmazonRoute53.
-     * 
+     *
      * @return The response from the ListHealthChecks service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      *
      * @throws AmazonClientException
@@ -708,12 +738,15 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      *             If an error response is returned by AmazonRoute53 indicating
      *             either a problem with the data in the request, or a server side issue.
      */
-    public ListHealthChecksResult listHealthChecks(ListHealthChecksRequest listHealthChecksRequest) 
+    public ListHealthChecksResult listHealthChecks(ListHealthChecksRequest listHealthChecksRequest)
             throws AmazonServiceException, AmazonClientException {
+    	if(super.getVersion() != null){
+    		listHealthChecksRequest.setVersion(super.getVersion());
+    	}
         Request<ListHealthChecksRequest> request = new ListHealthChecksRequestMarshaller().marshall(listHealthChecksRequest);
         return invoke(request, new ListHealthChecksResultStaxUnmarshaller());
     }
-    
+
     /**
      * <p>
      * To retrieve a list of your hosted zones, send a <code>GET</code>
@@ -730,10 +763,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * set MaxItems to a value greater than 100, Amazon Route 53 returns only
      * the first 100.
      * </p>
-     * 
+     *
      * @return The response from the ListHostedZones service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      *
      * @throws AmazonClientException
@@ -747,7 +780,7 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
     public ListHostedZonesResult listHostedZones() throws AmazonServiceException, AmazonClientException {
         return listHostedZones(new ListHostedZonesRequest());
     }
-    
+
     /**
      * <p>
      * To retrieve a list of your health checks, send a <code>GET</code>
@@ -764,10 +797,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
      * set MaxItems to a value greater than 100, Amazon Route 53 returns only
      * the first 100.
      * </p>
-     * 
+     *
      * @return The response from the ListHealthChecks service method, as
      *         returned by AmazonRoute53.
-     * 
+     *
      * @throws InvalidInputException
      *
      * @throws AmazonClientException
@@ -781,12 +814,12 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
     public ListHealthChecksResult listHealthChecks() throws AmazonServiceException, AmazonClientException {
         return listHealthChecks(new ListHealthChecksRequest());
     }
-    
+
     @Override
     protected String getServiceAbbreviation() {
         return "route53";
     }
-    
+
 
     /**
      * Returns additional metadata for a previously executed successful, request, typically used for
@@ -824,11 +857,10 @@ public class AmazonRoute53Client extends AmazonWebServiceClient implements Amazo
         ExecutionContext executionContext = createExecutionContext();
         executionContext.setSigner(signer);
         executionContext.setCredentials(credentials);
-        
+
         StaxResponseHandler<X> responseHandler = new StaxResponseHandler<X>(unmarshaller);
         DefaultErrorResponseHandler errorResponseHandler = new DefaultErrorResponseHandler(exceptionUnmarshallers);
 
         return (X)client.execute(request, responseHandler, errorResponseHandler, executionContext);
     }
 }
-        

--- a/src/main/java/com/amazonaws/services/route53/model/ChangeResourceRecordSetsRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/ChangeResourceRecordSetsRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -74,18 +74,23 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
     private ChangeBatch changeBatch;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new ChangeResourceRecordSetsRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public ChangeResourceRecordSetsRequest() {}
-    
+
 
 
     /**
      * Constructs a new ChangeResourceRecordSetsRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param hostedZoneId <i>Alias resource record sets only:</i> The value
      * of the hosted zone ID for the AWS resource. <p>For more information,
      * an example, and several ways to get the hosted zone ID for the
@@ -101,8 +106,23 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
         setChangeBatch(changeBatch);
     }
 
-    
-    
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
     /**
      * <i>Alias resource record sets only:</i> The value of the hosted zone
      * ID for the AWS resource. <p>For more information, an example, and
@@ -124,7 +144,7 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
     public String getHostedZoneId() {
         return hostedZoneId;
     }
-    
+
     /**
      * <i>Alias resource record sets only:</i> The value of the hosted zone
      * ID for the AWS resource. <p>For more information, an example, and
@@ -146,7 +166,7 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
     public void setHostedZoneId(String hostedZoneId) {
         this.hostedZoneId = hostedZoneId;
     }
-    
+
     /**
      * <i>Alias resource record sets only:</i> The value of the hosted zone
      * ID for the AWS resource. <p>For more information, an example, and
@@ -167,15 +187,15 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
      *         Alias Resource Record Sets for Elastic Load Balancing</a> in the
      *         <i>Amazon Route 53 Developer Guide</i>.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ChangeResourceRecordSetsRequest withHostedZoneId(String hostedZoneId) {
         this.hostedZoneId = hostedZoneId;
         return this;
     }
-    
-    
+
+
     /**
      * A complex type that contains an optional comment and the
      * <code>Changes</code> element.
@@ -186,7 +206,7 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
     public ChangeBatch getChangeBatch() {
         return changeBatch;
     }
-    
+
     /**
      * A complex type that contains an optional comment and the
      * <code>Changes</code> element.
@@ -197,7 +217,7 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
     public void setChangeBatch(ChangeBatch changeBatch) {
         this.changeBatch = changeBatch;
     }
-    
+
     /**
      * A complex type that contains an optional comment and the
      * <code>Changes</code> element.
@@ -207,15 +227,15 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
      * @param changeBatch A complex type that contains an optional comment and the
      *         <code>Changes</code> element.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ChangeResourceRecordSetsRequest withChangeBatch(ChangeBatch changeBatch) {
         this.changeBatch = changeBatch;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -233,17 +253,17 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getHostedZoneId() == null) ? 0 : getHostedZoneId().hashCode()); 
-        hashCode = prime * hashCode + ((getChangeBatch() == null) ? 0 : getChangeBatch().hashCode()); 
+
+        hashCode = prime * hashCode + ((getHostedZoneId() == null) ? 0 : getHostedZoneId().hashCode());
+        hashCode = prime * hashCode + ((getChangeBatch() == null) ? 0 : getChangeBatch().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -251,13 +271,12 @@ public class ChangeResourceRecordSetsRequest extends AmazonWebServiceRequest imp
 
         if (obj instanceof ChangeResourceRecordSetsRequest == false) return false;
         ChangeResourceRecordSetsRequest other = (ChangeResourceRecordSetsRequest)obj;
-        
+
         if (other.getHostedZoneId() == null ^ this.getHostedZoneId() == null) return false;
-        if (other.getHostedZoneId() != null && other.getHostedZoneId().equals(this.getHostedZoneId()) == false) return false; 
+        if (other.getHostedZoneId() != null && other.getHostedZoneId().equals(this.getHostedZoneId()) == false) return false;
         if (other.getChangeBatch() == null ^ this.getChangeBatch() == null) return false;
-        if (other.getChangeBatch() != null && other.getChangeBatch().equals(this.getChangeBatch()) == false) return false; 
+        if (other.getChangeBatch() != null && other.getChangeBatch().equals(this.getChangeBatch()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/CreateHealthCheckRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/CreateHealthCheckRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -52,6 +52,26 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
     private HealthCheckConfig healthCheckConfig;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+    /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHealthCheck</code> requests to be retried without the risk
      * of executing the operation twice. You must use a unique
@@ -76,7 +96,7 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
     public String getCallerReference() {
         return callerReference;
     }
-    
+
     /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHealthCheck</code> requests to be retried without the risk
@@ -102,7 +122,7 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
     public void setCallerReference(String callerReference) {
         this.callerReference = callerReference;
     }
-    
+
     /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHealthCheck</code> requests to be retried without the risk
@@ -127,15 +147,15 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
      *         characters are any Unicode code points that are legal in an XML 1.0
      *         document. The UTF-8 encoding of the value must be less than 128 bytes.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public CreateHealthCheckRequest withCallerReference(String callerReference) {
         this.callerReference = callerReference;
         return this;
     }
-    
-    
+
+
     /**
      * A complex type that contains health check configuration.
      *
@@ -144,7 +164,7 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
     public HealthCheckConfig getHealthCheckConfig() {
         return healthCheckConfig;
     }
-    
+
     /**
      * A complex type that contains health check configuration.
      *
@@ -153,7 +173,7 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
     public void setHealthCheckConfig(HealthCheckConfig healthCheckConfig) {
         this.healthCheckConfig = healthCheckConfig;
     }
-    
+
     /**
      * A complex type that contains health check configuration.
      * <p>
@@ -161,15 +181,15 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
      *
      * @param healthCheckConfig A complex type that contains health check configuration.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public CreateHealthCheckRequest withHealthCheckConfig(HealthCheckConfig healthCheckConfig) {
         this.healthCheckConfig = healthCheckConfig;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -187,17 +207,17 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getCallerReference() == null) ? 0 : getCallerReference().hashCode()); 
-        hashCode = prime * hashCode + ((getHealthCheckConfig() == null) ? 0 : getHealthCheckConfig().hashCode()); 
+
+        hashCode = prime * hashCode + ((getCallerReference() == null) ? 0 : getCallerReference().hashCode());
+        hashCode = prime * hashCode + ((getHealthCheckConfig() == null) ? 0 : getHealthCheckConfig().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -205,13 +225,12 @@ public class CreateHealthCheckRequest extends AmazonWebServiceRequest implements
 
         if (obj instanceof CreateHealthCheckRequest == false) return false;
         CreateHealthCheckRequest other = (CreateHealthCheckRequest)obj;
-        
+
         if (other.getCallerReference() == null ^ this.getCallerReference() == null) return false;
-        if (other.getCallerReference() != null && other.getCallerReference().equals(this.getCallerReference()) == false) return false; 
+        if (other.getCallerReference() != null && other.getCallerReference().equals(this.getCallerReference()) == false) return false;
         if (other.getHealthCheckConfig() == null ^ this.getHealthCheckConfig() == null) return false;
-        if (other.getHealthCheckConfig() != null && other.getHealthCheckConfig().equals(this.getHealthCheckConfig()) == false) return false; 
+        if (other.getHealthCheckConfig() != null && other.getHealthCheckConfig().equals(this.getHealthCheckConfig()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/CreateHostedZoneRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/CreateHostedZoneRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -80,18 +80,23 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     private HostedZoneConfig hostedZoneConfig;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new CreateHostedZoneRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public CreateHostedZoneRequest() {}
-    
+
 
 
     /**
      * Constructs a new CreateHostedZoneRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param name The name of the domain. This must be a fully-specified
      * domain, for example, www.example.com. The trailing dot is optional;
      * Route 53 assumes that the domain name is fully qualified. This means
@@ -116,8 +121,22 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
         setCallerReference(callerReference);
     }
 
-    
-    
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
     /**
      * The name of the domain. This must be a fully-specified domain, for
      * example, www.example.com. The trailing dot is optional; Route 53
@@ -145,7 +164,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public String getName() {
         return name;
     }
-    
+
     /**
      * The name of the domain. This must be a fully-specified domain, for
      * example, www.example.com. The trailing dot is optional; Route 53
@@ -173,7 +192,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public void setName(String name) {
         this.name = name;
     }
-    
+
     /**
      * The name of the domain. This must be a fully-specified domain, for
      * example, www.example.com. The trailing dot is optional; Route 53
@@ -200,15 +219,15 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
      *         the set of <code>NameServers</code> elements returned in
      *         <code>DelegationSet</code>.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public CreateHostedZoneRequest withName(String name) {
         this.name = name;
         return this;
     }
-    
-    
+
+
     /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHostedZone</code> requests to be retried without the risk
@@ -236,7 +255,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public String getCallerReference() {
         return callerReference;
     }
-    
+
     /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHostedZone</code> requests to be retried without the risk
@@ -264,7 +283,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public void setCallerReference(String callerReference) {
         this.callerReference = callerReference;
     }
-    
+
     /**
      * A unique string that identifies the request and that allows failed
      * <code>CreateHostedZone</code> requests to be retried without the risk
@@ -291,15 +310,15 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
      *         points that are legal in an XML 1.0 document. The UTF-8 encoding of
      *         the value must be less than 128 bytes.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public CreateHostedZoneRequest withCallerReference(String callerReference) {
         this.callerReference = callerReference;
         return this;
     }
-    
-    
+
+
     /**
      * A complex type that contains an optional comment about your hosted
      * zone.
@@ -310,7 +329,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public HostedZoneConfig getHostedZoneConfig() {
         return hostedZoneConfig;
     }
-    
+
     /**
      * A complex type that contains an optional comment about your hosted
      * zone.
@@ -321,7 +340,7 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
     public void setHostedZoneConfig(HostedZoneConfig hostedZoneConfig) {
         this.hostedZoneConfig = hostedZoneConfig;
     }
-    
+
     /**
      * A complex type that contains an optional comment about your hosted
      * zone.
@@ -331,15 +350,15 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
      * @param hostedZoneConfig A complex type that contains an optional comment about your hosted
      *         zone.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public CreateHostedZoneRequest withHostedZoneConfig(HostedZoneConfig hostedZoneConfig) {
         this.hostedZoneConfig = hostedZoneConfig;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -358,18 +377,18 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getName() == null) ? 0 : getName().hashCode()); 
-        hashCode = prime * hashCode + ((getCallerReference() == null) ? 0 : getCallerReference().hashCode()); 
-        hashCode = prime * hashCode + ((getHostedZoneConfig() == null) ? 0 : getHostedZoneConfig().hashCode()); 
+
+        hashCode = prime * hashCode + ((getName() == null) ? 0 : getName().hashCode());
+        hashCode = prime * hashCode + ((getCallerReference() == null) ? 0 : getCallerReference().hashCode());
+        hashCode = prime * hashCode + ((getHostedZoneConfig() == null) ? 0 : getHostedZoneConfig().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -377,15 +396,14 @@ public class CreateHostedZoneRequest extends AmazonWebServiceRequest implements 
 
         if (obj instanceof CreateHostedZoneRequest == false) return false;
         CreateHostedZoneRequest other = (CreateHostedZoneRequest)obj;
-        
+
         if (other.getName() == null ^ this.getName() == null) return false;
-        if (other.getName() != null && other.getName().equals(this.getName()) == false) return false; 
+        if (other.getName() != null && other.getName().equals(this.getName()) == false) return false;
         if (other.getCallerReference() == null ^ this.getCallerReference() == null) return false;
-        if (other.getCallerReference() != null && other.getCallerReference().equals(this.getCallerReference()) == false) return false; 
+        if (other.getCallerReference() != null && other.getCallerReference().equals(this.getCallerReference()) == false) return false;
         if (other.getHostedZoneConfig() == null ^ this.getHostedZoneConfig() == null) return false;
-        if (other.getHostedZoneConfig() != null && other.getHostedZoneConfig().equals(this.getHostedZoneConfig()) == false) return false; 
+        if (other.getHostedZoneConfig() != null && other.getHostedZoneConfig().equals(this.getHostedZoneConfig()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/DeleteHealthCheckRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/DeleteHealthCheckRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -42,6 +42,26 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
     private String healthCheckId;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+    /**
      * The ID of the health check to delete.
      * <p>
      * <b>Constraints:</b><br/>
@@ -52,7 +72,7 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
     public String getHealthCheckId() {
         return healthCheckId;
     }
-    
+
     /**
      * The ID of the health check to delete.
      * <p>
@@ -64,7 +84,7 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
     public void setHealthCheckId(String healthCheckId) {
         this.healthCheckId = healthCheckId;
     }
-    
+
     /**
      * The ID of the health check to delete.
      * <p>
@@ -75,15 +95,15 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
      *
      * @param healthCheckId The ID of the health check to delete.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public DeleteHealthCheckRequest withHealthCheckId(String healthCheckId) {
         this.healthCheckId = healthCheckId;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -100,16 +120,16 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getHealthCheckId() == null) ? 0 : getHealthCheckId().hashCode()); 
+
+        hashCode = prime * hashCode + ((getHealthCheckId() == null) ? 0 : getHealthCheckId().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -117,11 +137,10 @@ public class DeleteHealthCheckRequest extends AmazonWebServiceRequest implements
 
         if (obj instanceof DeleteHealthCheckRequest == false) return false;
         DeleteHealthCheckRequest other = (DeleteHealthCheckRequest)obj;
-        
+
         if (other.getHealthCheckId() == null ^ this.getHealthCheckId() == null) return false;
-        if (other.getHealthCheckId() != null && other.getHealthCheckId().equals(this.getHealthCheckId()) == false) return false; 
+        if (other.getHealthCheckId() != null && other.getHealthCheckId().equals(this.getHealthCheckId()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/DeleteHostedZoneRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/DeleteHostedZoneRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -47,18 +47,23 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
     private String id;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new DeleteHostedZoneRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public DeleteHostedZoneRequest() {}
-    
+
 
 
     /**
      * Constructs a new DeleteHostedZoneRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param id The ID of the request. Include this ID in a call to
      * <a>GetChange</a> to track when the change has propagated to all Route
      * 53 DNS servers.
@@ -67,8 +72,22 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
         setId(id);
     }
 
-    
-    
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
     /**
      * The ID of the request. Include this ID in a call to <a>GetChange</a>
      * to track when the change has propagated to all Route 53 DNS servers.
@@ -82,7 +101,7 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
     public String getId() {
         return id;
     }
-    
+
     /**
      * The ID of the request. Include this ID in a call to <a>GetChange</a>
      * to track when the change has propagated to all Route 53 DNS servers.
@@ -96,7 +115,7 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
     public void setId(String id) {
         this.id = id;
     }
-    
+
     /**
      * The ID of the request. Include this ID in a call to <a>GetChange</a>
      * to track when the change has propagated to all Route 53 DNS servers.
@@ -109,15 +128,15 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
      * @param id The ID of the request. Include this ID in a call to <a>GetChange</a>
      *         to track when the change has propagated to all Route 53 DNS servers.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public DeleteHostedZoneRequest withId(String id) {
         this.id = id;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -134,16 +153,16 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode()); 
+
+        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -151,11 +170,10 @@ public class DeleteHostedZoneRequest extends AmazonWebServiceRequest implements 
 
         if (obj instanceof DeleteHostedZoneRequest == false) return false;
         DeleteHostedZoneRequest other = (DeleteHostedZoneRequest)obj;
-        
+
         if (other.getId() == null ^ this.getId() == null) return false;
-        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false; 
+        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/GetChangeRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/GetChangeRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,18 +44,23 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
     private String id;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new GetChangeRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public GetChangeRequest() {}
-    
+
 
 
     /**
      * Constructs a new GetChangeRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param id The ID of the change batch request. The value that you
      * specify here is the value that <code>ChangeResourceRecordSets</code>
      * returned in the Id element when you submitted the request.
@@ -64,8 +69,23 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
         setId(id);
     }
 
-    
-    
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
+
     /**
      * The ID of the change batch request. The value that you specify here is
      * the value that <code>ChangeResourceRecordSets</code> returned in the
@@ -81,7 +101,7 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
     public String getId() {
         return id;
     }
-    
+
     /**
      * The ID of the change batch request. The value that you specify here is
      * the value that <code>ChangeResourceRecordSets</code> returned in the
@@ -97,7 +117,7 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
     public void setId(String id) {
         this.id = id;
     }
-    
+
     /**
      * The ID of the change batch request. The value that you specify here is
      * the value that <code>ChangeResourceRecordSets</code> returned in the
@@ -112,15 +132,15 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
      *         the value that <code>ChangeResourceRecordSets</code> returned in the
      *         Id element when you submitted the request.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public GetChangeRequest withId(String id) {
         this.id = id;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -137,16 +157,16 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode()); 
+
+        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -154,11 +174,10 @@ public class GetChangeRequest extends AmazonWebServiceRequest implements Seriali
 
         if (obj instanceof GetChangeRequest == false) return false;
         GetChangeRequest other = (GetChangeRequest)obj;
-        
+
         if (other.getId() == null ^ this.getId() == null) return false;
-        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false; 
+        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/GetHealthCheckRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/GetHealthCheckRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -35,6 +35,26 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
     private String healthCheckId;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+    /**
      * The ID of the health check to retrieve.
      * <p>
      * <b>Constraints:</b><br/>
@@ -45,7 +65,7 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
     public String getHealthCheckId() {
         return healthCheckId;
     }
-    
+
     /**
      * The ID of the health check to retrieve.
      * <p>
@@ -57,7 +77,7 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
     public void setHealthCheckId(String healthCheckId) {
         this.healthCheckId = healthCheckId;
     }
-    
+
     /**
      * The ID of the health check to retrieve.
      * <p>
@@ -68,15 +88,15 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
      *
      * @param healthCheckId The ID of the health check to retrieve.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public GetHealthCheckRequest withHealthCheckId(String healthCheckId) {
         this.healthCheckId = healthCheckId;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -93,16 +113,16 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getHealthCheckId() == null) ? 0 : getHealthCheckId().hashCode()); 
+
+        hashCode = prime * hashCode + ((getHealthCheckId() == null) ? 0 : getHealthCheckId().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -110,11 +130,10 @@ public class GetHealthCheckRequest extends AmazonWebServiceRequest implements Se
 
         if (obj instanceof GetHealthCheckRequest == false) return false;
         GetHealthCheckRequest other = (GetHealthCheckRequest)obj;
-        
+
         if (other.getHealthCheckId() == null ^ this.getHealthCheckId() == null) return false;
-        if (other.getHealthCheckId() != null && other.getHealthCheckId().equals(this.getHealthCheckId()) == false) return false; 
+        if (other.getHealthCheckId() != null && other.getHealthCheckId().equals(this.getHealthCheckId()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/GetHostedZoneRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/GetHostedZoneRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -37,18 +37,23 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
     private String id;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new GetHostedZoneRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public GetHostedZoneRequest() {}
-    
+
 
 
     /**
      * Constructs a new GetHostedZoneRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param id The ID of the hosted zone for which you want to get a list
      * of the name servers in the delegation set.
      */
@@ -56,8 +61,22 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
         setId(id);
     }
 
-    
-    
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
     /**
      * The ID of the hosted zone for which you want to get a list of the name
      * servers in the delegation set.
@@ -71,7 +90,7 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
     public String getId() {
         return id;
     }
-    
+
     /**
      * The ID of the hosted zone for which you want to get a list of the name
      * servers in the delegation set.
@@ -85,7 +104,7 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
     public void setId(String id) {
         this.id = id;
     }
-    
+
     /**
      * The ID of the hosted zone for which you want to get a list of the name
      * servers in the delegation set.
@@ -98,15 +117,15 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
      * @param id The ID of the hosted zone for which you want to get a list of the name
      *         servers in the delegation set.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public GetHostedZoneRequest withId(String id) {
         this.id = id;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -123,16 +142,16 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode()); 
+
+        hashCode = prime * hashCode + ((getId() == null) ? 0 : getId().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -140,11 +159,10 @@ public class GetHostedZoneRequest extends AmazonWebServiceRequest implements Ser
 
         if (obj instanceof GetHostedZoneRequest == false) return false;
         GetHostedZoneRequest other = (GetHostedZoneRequest)obj;
-        
+
         if (other.getId() == null ^ this.getId() == null) return false;
-        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false; 
+        if (other.getId() != null && other.getId().equals(this.getId()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/ListHealthChecksRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/ListHealthChecksRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -51,6 +51,26 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
     private String maxItems;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+    /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
      * response in the <code>marker</code> parameter to get the next page of
@@ -67,7 +87,7 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
     public String getMarker() {
         return marker;
     }
-    
+
     /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
@@ -85,7 +105,7 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
     public void setMarker(String marker) {
         this.marker = marker;
     }
-    
+
     /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
@@ -102,15 +122,15 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
      *         response in the <code>marker</code> parameter to get the next page of
      *         results.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListHealthChecksRequest withMarker(String marker) {
         this.marker = marker;
         return this;
     }
-    
-    
+
+
     /**
      * Specify the maximum number of health checks to return per page of
      * results.
@@ -121,7 +141,7 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
     public String getMaxItems() {
         return maxItems;
     }
-    
+
     /**
      * Specify the maximum number of health checks to return per page of
      * results.
@@ -132,7 +152,7 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
     public void setMaxItems(String maxItems) {
         this.maxItems = maxItems;
     }
-    
+
     /**
      * Specify the maximum number of health checks to return per page of
      * results.
@@ -142,15 +162,15 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
      * @param maxItems Specify the maximum number of health checks to return per page of
      *         results.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListHealthChecksRequest withMaxItems(String maxItems) {
         this.maxItems = maxItems;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -168,17 +188,17 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getMarker() == null) ? 0 : getMarker().hashCode()); 
-        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode()); 
+
+        hashCode = prime * hashCode + ((getMarker() == null) ? 0 : getMarker().hashCode());
+        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -186,13 +206,12 @@ public class ListHealthChecksRequest extends AmazonWebServiceRequest implements 
 
         if (obj instanceof ListHealthChecksRequest == false) return false;
         ListHealthChecksRequest other = (ListHealthChecksRequest)obj;
-        
+
         if (other.getMarker() == null ^ this.getMarker() == null) return false;
-        if (other.getMarker() != null && other.getMarker().equals(this.getMarker()) == false) return false; 
+        if (other.getMarker() != null && other.getMarker().equals(this.getMarker()) == false) return false;
         if (other.getMaxItems() == null ^ this.getMaxItems() == null) return false;
-        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false; 
+        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/ListHostedZonesRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/ListHostedZonesRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -51,11 +51,31 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
     private String maxItems;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new ListHostedZonesRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public ListHostedZonesRequest() {}
-    
+
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
     /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
@@ -73,7 +93,7 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
     public String getMarker() {
         return marker;
     }
-    
+
     /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
@@ -91,7 +111,7 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
     public void setMarker(String marker) {
         this.marker = marker;
     }
-    
+
     /**
      * If the request returned more than one page of results, submit another
      * request and specify the value of <code>NextMarker</code> from the last
@@ -108,15 +128,15 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
      *         response in the <code>marker</code> parameter to get the next page of
      *         results.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListHostedZonesRequest withMarker(String marker) {
         this.marker = marker;
         return this;
     }
-    
-    
+
+
     /**
      * Specify the maximum number of hosted zones to return per page of
      * results.
@@ -127,7 +147,7 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
     public String getMaxItems() {
         return maxItems;
     }
-    
+
     /**
      * Specify the maximum number of hosted zones to return per page of
      * results.
@@ -138,7 +158,7 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
     public void setMaxItems(String maxItems) {
         this.maxItems = maxItems;
     }
-    
+
     /**
      * Specify the maximum number of hosted zones to return per page of
      * results.
@@ -148,15 +168,15 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
      * @param maxItems Specify the maximum number of hosted zones to return per page of
      *         results.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListHostedZonesRequest withMaxItems(String maxItems) {
         this.maxItems = maxItems;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -174,17 +194,17 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getMarker() == null) ? 0 : getMarker().hashCode()); 
-        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode()); 
+
+        hashCode = prime * hashCode + ((getMarker() == null) ? 0 : getMarker().hashCode());
+        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -192,13 +212,12 @@ public class ListHostedZonesRequest extends AmazonWebServiceRequest implements S
 
         if (obj instanceof ListHostedZonesRequest == false) return false;
         ListHostedZonesRequest other = (ListHostedZonesRequest)obj;
-        
+
         if (other.getMarker() == null ^ this.getMarker() == null) return false;
-        if (other.getMarker() != null && other.getMarker().equals(this.getMarker()) == false) return false; 
+        if (other.getMarker() != null && other.getMarker().equals(this.getMarker()) == false) return false;
         if (other.getMaxItems() == null ^ this.getMaxItems() == null) return false;
-        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false; 
+        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/ListResourceRecordSetsRequest.java
+++ b/src/main/java/com/amazonaws/services/route53/model/ListResourceRecordSetsRequest.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -23,7 +23,7 @@ import java.io.Serializable;
  * reversed, like "com.amazon.www" for example), and secondarily, lexicographically by record type. This operation retrieves at most MaxItems resource
  * record sets from this list, in order, starting at a position specified by the Name and Type arguments:
  * </p>
- * 
+ *
  * <ul>
  * <li>If both Name and Type are omitted, this means start the results at the first RRSET in the HostedZone.</li>
  * <li>If Name is specified but Type is omitted, this means start the results at the first RRSET in the list whose name is greater than or equal to
@@ -31,7 +31,7 @@ import java.io.Serializable;
  * <li>If both Name and Type are specified, this means start the results at the first RRSET in the list whose name is greater than or equal to Name and
  * whose type is greater than or equal to Type.</li>
  * <li>It is an error to specify the Type but not the Name.</li>
- * 
+ *
  * </ul>
  * <p>
  * Use ListResourceRecordSets to retrieve a single known record set by specifying the record set's name and type, and setting MaxItems = 1
@@ -115,18 +115,23 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     private String maxItems;
 
     /**
+     * Specify the api version that is used to endpoint.
+     */
+    private String version;
+
+    /**
      * Default constructor for a new ListResourceRecordSetsRequest object.  Callers should use the
      * setter or fluent setter (with...) methods to initialize this object after creating it.
      */
     public ListResourceRecordSetsRequest() {}
-    
+
 
 
     /**
      * Constructs a new ListResourceRecordSetsRequest object.
      * Callers should use the setter or fluent setter (with...) methods to
      * initialize any additional object members.
-     * 
+     *
      * @param hostedZoneId The ID of the hosted zone that contains the
      * resource record sets that you want to get.
      */
@@ -134,8 +139,22 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
         setHostedZoneId(hostedZoneId);
     }
 
-    
-    
+    /**
+     * Specify the api version.
+     *
+     * @return api version
+     */
+    public String getVersion(){
+        return version;
+    }
+    /**
+     * Specify the api version.
+     */
+    public void setVersion(String version){
+        this.version = version;
+    }
+
+
     /**
      * The ID of the hosted zone that contains the resource record sets that
      * you want to get.
@@ -149,7 +168,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public String getHostedZoneId() {
         return hostedZoneId;
     }
-    
+
     /**
      * The ID of the hosted zone that contains the resource record sets that
      * you want to get.
@@ -163,7 +182,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setHostedZoneId(String hostedZoneId) {
         this.hostedZoneId = hostedZoneId;
     }
-    
+
     /**
      * The ID of the hosted zone that contains the resource record sets that
      * you want to get.
@@ -176,15 +195,15 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      * @param hostedZoneId The ID of the hosted zone that contains the resource record sets that
      *         you want to get.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListResourceRecordSetsRequest withHostedZoneId(String hostedZoneId) {
         this.hostedZoneId = hostedZoneId;
         return this;
     }
-    
-    
+
+
     /**
      * The first name in the lexicographic ordering of domain names that you
      * want the <code>ListResourceRecordSets</code> request to list.
@@ -198,7 +217,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public String getStartRecordName() {
         return startRecordName;
     }
-    
+
     /**
      * The first name in the lexicographic ordering of domain names that you
      * want the <code>ListResourceRecordSets</code> request to list.
@@ -212,7 +231,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setStartRecordName(String startRecordName) {
         this.startRecordName = startRecordName;
     }
-    
+
     /**
      * The first name in the lexicographic ordering of domain names that you
      * want the <code>ListResourceRecordSets</code> request to list.
@@ -225,15 +244,15 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      * @param startRecordName The first name in the lexicographic ordering of domain names that you
      *         want the <code>ListResourceRecordSets</code> request to list.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListResourceRecordSetsRequest withStartRecordName(String startRecordName) {
         this.startRecordName = startRecordName;
         return this;
     }
-    
-    
+
+
     /**
      * The DNS type at which to begin the listing of resource record sets.
      * <p>Valid values: <code>A</code> | <code>AAAA</code> |
@@ -269,7 +288,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public String getStartRecordType() {
         return startRecordType;
     }
-    
+
     /**
      * The DNS type at which to begin the listing of resource record sets.
      * <p>Valid values: <code>A</code> | <code>AAAA</code> |
@@ -305,7 +324,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setStartRecordType(String startRecordType) {
         this.startRecordType = startRecordType;
     }
-    
+
     /**
      * The DNS type at which to begin the listing of resource record sets.
      * <p>Valid values: <code>A</code> | <code>AAAA</code> |
@@ -338,7 +357,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      *         <code>type</code> without specifying <code>name</code> returns an
      *         <a>InvalidInput</a> error.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      *
      * @see RRType
@@ -347,8 +366,8 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
         this.startRecordType = startRecordType;
         return this;
     }
-    
-    
+
+
     /**
      * The DNS type at which to begin the listing of resource record sets.
      * <p>Valid values: <code>A</code> | <code>AAAA</code> |
@@ -384,7 +403,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setStartRecordType(RRType startRecordType) {
         this.startRecordType = startRecordType.toString();
     }
-    
+
     /**
      * The DNS type at which to begin the listing of resource record sets.
      * <p>Valid values: <code>A</code> | <code>AAAA</code> |
@@ -417,7 +436,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      *         <code>type</code> without specifying <code>name</code> returns an
      *         <a>InvalidInput</a> error.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      *
      * @see RRType
@@ -426,7 +445,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
         this.startRecordType = startRecordType.toString();
         return this;
     }
-    
+
     /**
      * <i>Weighted resource record sets only:</i> If results were truncated
      * for a given DNS name and type, specify the value of
@@ -446,7 +465,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public String getStartRecordIdentifier() {
         return startRecordIdentifier;
     }
-    
+
     /**
      * <i>Weighted resource record sets only:</i> If results were truncated
      * for a given DNS name and type, specify the value of
@@ -466,7 +485,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setStartRecordIdentifier(String startRecordIdentifier) {
         this.startRecordIdentifier = startRecordIdentifier;
     }
-    
+
     /**
      * <i>Weighted resource record sets only:</i> If results were truncated
      * for a given DNS name and type, specify the value of
@@ -485,15 +504,15 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      *         the previous response to get the next resource record set that has the
      *         current DNS name and type.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListResourceRecordSetsRequest withStartRecordIdentifier(String startRecordIdentifier) {
         this.startRecordIdentifier = startRecordIdentifier;
         return this;
     }
-    
-    
+
+
     /**
      * The maximum number of records you want in the response body.
      *
@@ -502,7 +521,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public String getMaxItems() {
         return maxItems;
     }
-    
+
     /**
      * The maximum number of records you want in the response body.
      *
@@ -511,7 +530,7 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
     public void setMaxItems(String maxItems) {
         this.maxItems = maxItems;
     }
-    
+
     /**
      * The maximum number of records you want in the response body.
      * <p>
@@ -519,15 +538,15 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
      *
      * @param maxItems The maximum number of records you want in the response body.
      *
-     * @return A reference to this updated object so that method calls can be chained 
+     * @return A reference to this updated object so that method calls can be chained
      *         together.
      */
     public ListResourceRecordSetsRequest withMaxItems(String maxItems) {
         this.maxItems = maxItems;
         return this;
     }
-    
-    
+
+
     /**
      * Returns a string representation of this object; useful for testing and
      * debugging.
@@ -548,20 +567,20 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
         sb.append("}");
         return sb.toString();
     }
-    
+
     @Override
     public int hashCode() {
         final int prime = 31;
         int hashCode = 1;
-        
-        hashCode = prime * hashCode + ((getHostedZoneId() == null) ? 0 : getHostedZoneId().hashCode()); 
-        hashCode = prime * hashCode + ((getStartRecordName() == null) ? 0 : getStartRecordName().hashCode()); 
-        hashCode = prime * hashCode + ((getStartRecordType() == null) ? 0 : getStartRecordType().hashCode()); 
-        hashCode = prime * hashCode + ((getStartRecordIdentifier() == null) ? 0 : getStartRecordIdentifier().hashCode()); 
-        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode()); 
+
+        hashCode = prime * hashCode + ((getHostedZoneId() == null) ? 0 : getHostedZoneId().hashCode());
+        hashCode = prime * hashCode + ((getStartRecordName() == null) ? 0 : getStartRecordName().hashCode());
+        hashCode = prime * hashCode + ((getStartRecordType() == null) ? 0 : getStartRecordType().hashCode());
+        hashCode = prime * hashCode + ((getStartRecordIdentifier() == null) ? 0 : getStartRecordIdentifier().hashCode());
+        hashCode = prime * hashCode + ((getMaxItems() == null) ? 0 : getMaxItems().hashCode());
         return hashCode;
     }
-    
+
     @Override
     public boolean equals(Object obj) {
         if (this == obj) return true;
@@ -569,19 +588,18 @@ public class ListResourceRecordSetsRequest extends AmazonWebServiceRequest imple
 
         if (obj instanceof ListResourceRecordSetsRequest == false) return false;
         ListResourceRecordSetsRequest other = (ListResourceRecordSetsRequest)obj;
-        
+
         if (other.getHostedZoneId() == null ^ this.getHostedZoneId() == null) return false;
-        if (other.getHostedZoneId() != null && other.getHostedZoneId().equals(this.getHostedZoneId()) == false) return false; 
+        if (other.getHostedZoneId() != null && other.getHostedZoneId().equals(this.getHostedZoneId()) == false) return false;
         if (other.getStartRecordName() == null ^ this.getStartRecordName() == null) return false;
-        if (other.getStartRecordName() != null && other.getStartRecordName().equals(this.getStartRecordName()) == false) return false; 
+        if (other.getStartRecordName() != null && other.getStartRecordName().equals(this.getStartRecordName()) == false) return false;
         if (other.getStartRecordType() == null ^ this.getStartRecordType() == null) return false;
-        if (other.getStartRecordType() != null && other.getStartRecordType().equals(this.getStartRecordType()) == false) return false; 
+        if (other.getStartRecordType() != null && other.getStartRecordType().equals(this.getStartRecordType()) == false) return false;
         if (other.getStartRecordIdentifier() == null ^ this.getStartRecordIdentifier() == null) return false;
-        if (other.getStartRecordIdentifier() != null && other.getStartRecordIdentifier().equals(this.getStartRecordIdentifier()) == false) return false; 
+        if (other.getStartRecordIdentifier() != null && other.getStartRecordIdentifier().equals(this.getStartRecordIdentifier()) == false) return false;
         if (other.getMaxItems() == null ^ this.getMaxItems() == null) return false;
-        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false; 
+        if (other.getMaxItems() != null && other.getMaxItems().equals(this.getMaxItems()) == false) return false;
         return true;
     }
-    
+
 }
-    

--- a/src/main/java/com/amazonaws/services/route53/model/transform/ChangeResourceRecordSetsRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/ChangeResourceRecordSetsRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class ChangeResourceRecordSetsRequestMarshaller implements Marshaller<Req
         Request<ChangeResourceRecordSetsRequest> request = new DefaultRequest<ChangeResourceRecordSetsRequest>(changeResourceRecordSetsRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.POST);
 
-        String uriResourcePath = "/2012-12-12/hostedzone/{Id}/rrset/"; 
-        uriResourcePath = uriResourcePath.replace("{Id}", getString(changeResourceRecordSetsRequest.getHostedZoneId())); 
+        String version = changeResourceRecordSetsRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone/{Id}/rrset/";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Id}", getString(changeResourceRecordSetsRequest.getHostedZoneId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,12 +69,12 @@ public class ChangeResourceRecordSetsRequestMarshaller implements Marshaller<Req
 
         request.setResourcePath(uriResourcePath);
 
-        
+
             StringWriter stringWriter = new StringWriter();
             XMLWriter xmlWriter = new XMLWriter(stringWriter, "https://route53.amazonaws.com/doc/2012-12-12/");
 
-            
-            
+
+
             xmlWriter.startElement("ChangeResourceRecordSetsRequest");
                     if (changeResourceRecordSetsRequest != null) {
             ChangeBatch changeBatchChangeBatch = changeResourceRecordSetsRequest.getChangeBatch();
@@ -169,7 +175,7 @@ public class ChangeResourceRecordSetsRequestMarshaller implements Marshaller<Req
         }
 
             xmlWriter.endElement();
-            
+
 
             try {
                 request.setContent(new StringInputStream(stringWriter.getBuffer().toString()));
@@ -178,7 +184,7 @@ public class ChangeResourceRecordSetsRequestMarshaller implements Marshaller<Req
             } catch (UnsupportedEncodingException e) {
                 throw new AmazonClientException("Unable to marshall request to XML", e);
             }
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/CreateHealthCheckRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/CreateHealthCheckRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,7 +44,13 @@ public class CreateHealthCheckRequestMarshaller implements Marshaller<Request<Cr
         Request<CreateHealthCheckRequest> request = new DefaultRequest<CreateHealthCheckRequest>(createHealthCheckRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.POST);
 
-        String uriResourcePath = "/2012-12-12/healthcheck"; 
+        String version = createHealthCheckRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/healthcheck";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -62,12 +68,12 @@ public class CreateHealthCheckRequestMarshaller implements Marshaller<Request<Cr
 
         request.setResourcePath(uriResourcePath);
 
-        
+
             StringWriter stringWriter = new StringWriter();
             XMLWriter xmlWriter = new XMLWriter(stringWriter, "https://route53.amazonaws.com/doc/2012-12-12/");
 
-            
-            
+
+
             xmlWriter.startElement("CreateHealthCheckRequest");
                     if (createHealthCheckRequest.getCallerReference() != null) {
             xmlWriter.startElement("CallerReference").value(createHealthCheckRequest.getCallerReference()).endElement();
@@ -96,7 +102,7 @@ public class CreateHealthCheckRequestMarshaller implements Marshaller<Request<Cr
         }
 
             xmlWriter.endElement();
-            
+
 
             try {
                 request.setContent(new StringInputStream(stringWriter.getBuffer().toString()));
@@ -105,7 +111,7 @@ public class CreateHealthCheckRequestMarshaller implements Marshaller<Request<Cr
             } catch (UnsupportedEncodingException e) {
                 throw new AmazonClientException("Unable to marshall request to XML", e);
             }
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/CreateHostedZoneRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/CreateHostedZoneRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,7 +44,13 @@ public class CreateHostedZoneRequestMarshaller implements Marshaller<Request<Cre
         Request<CreateHostedZoneRequest> request = new DefaultRequest<CreateHostedZoneRequest>(createHostedZoneRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.POST);
 
-        String uriResourcePath = "/2012-12-12/hostedzone"; 
+        String version = createHostedZoneRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -62,12 +68,12 @@ public class CreateHostedZoneRequestMarshaller implements Marshaller<Request<Cre
 
         request.setResourcePath(uriResourcePath);
 
-        
+
             StringWriter stringWriter = new StringWriter();
             XMLWriter xmlWriter = new XMLWriter(stringWriter, "https://route53.amazonaws.com/doc/2012-12-12/");
 
-            
-            
+
+
             xmlWriter.startElement("CreateHostedZoneRequest");
                     if (createHostedZoneRequest.getName() != null) {
             xmlWriter.startElement("Name").value(createHostedZoneRequest.getName()).endElement();
@@ -87,7 +93,7 @@ public class CreateHostedZoneRequestMarshaller implements Marshaller<Request<Cre
         }
 
             xmlWriter.endElement();
-            
+
 
             try {
                 request.setContent(new StringInputStream(stringWriter.getBuffer().toString()));
@@ -96,7 +102,7 @@ public class CreateHostedZoneRequestMarshaller implements Marshaller<Request<Cre
             } catch (UnsupportedEncodingException e) {
                 throw new AmazonClientException("Unable to marshall request to XML", e);
             }
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/DeleteHealthCheckRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/DeleteHealthCheckRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class DeleteHealthCheckRequestMarshaller implements Marshaller<Request<De
         Request<DeleteHealthCheckRequest> request = new DefaultRequest<DeleteHealthCheckRequest>(deleteHealthCheckRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.DELETE);
 
-        String uriResourcePath = "/2012-12-12/healthcheck/{HealthCheckId}"; 
-        uriResourcePath = uriResourcePath.replace("{HealthCheckId}", getString(deleteHealthCheckRequest.getHealthCheckId())); 
+        String version = deleteHealthCheckRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/healthcheck/{HealthCheckId}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{HealthCheckId}", getString(deleteHealthCheckRequest.getHealthCheckId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,7 +69,7 @@ public class DeleteHealthCheckRequestMarshaller implements Marshaller<Request<De
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/DeleteHostedZoneRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/DeleteHostedZoneRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class DeleteHostedZoneRequestMarshaller implements Marshaller<Request<Del
         Request<DeleteHostedZoneRequest> request = new DefaultRequest<DeleteHostedZoneRequest>(deleteHostedZoneRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.DELETE);
 
-        String uriResourcePath = "/2012-12-12/hostedzone/{Id}"; 
-        uriResourcePath = uriResourcePath.replace("{Id}", getString(deleteHostedZoneRequest.getId())); 
+        String version = deleteHostedZoneRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone/{Id}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Id}", getString(deleteHostedZoneRequest.getId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,7 +69,7 @@ public class DeleteHostedZoneRequestMarshaller implements Marshaller<Request<Del
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/GetChangeRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/GetChangeRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class GetChangeRequestMarshaller implements Marshaller<Request<GetChangeR
         Request<GetChangeRequest> request = new DefaultRequest<GetChangeRequest>(getChangeRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/change/{Id}"; 
-        uriResourcePath = uriResourcePath.replace("{Id}", getString(getChangeRequest.getId())); 
+        String version = getChangeRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/change/{Id}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Id}", getString(getChangeRequest.getId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,7 +69,7 @@ public class GetChangeRequestMarshaller implements Marshaller<Request<GetChangeR
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/GetHealthCheckRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/GetHealthCheckRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class GetHealthCheckRequestMarshaller implements Marshaller<Request<GetHe
         Request<GetHealthCheckRequest> request = new DefaultRequest<GetHealthCheckRequest>(getHealthCheckRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/healthcheck/{HealthCheckId}"; 
-        uriResourcePath = uriResourcePath.replace("{HealthCheckId}", getString(getHealthCheckRequest.getHealthCheckId())); 
+        String version = getHealthCheckRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/healthcheck/{HealthCheckId}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{HealthCheckId}", getString(getHealthCheckRequest.getHealthCheckId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,7 +69,7 @@ public class GetHealthCheckRequestMarshaller implements Marshaller<Request<GetHe
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/GetHostedZoneRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/GetHostedZoneRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,8 +44,14 @@ public class GetHostedZoneRequestMarshaller implements Marshaller<Request<GetHos
         Request<GetHostedZoneRequest> request = new DefaultRequest<GetHostedZoneRequest>(getHostedZoneRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/hostedzone/{Id}"; 
-        uriResourcePath = uriResourcePath.replace("{Id}", getString(getHostedZoneRequest.getId())); 
+        String version = getHostedZoneRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone/{Id}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Id}", getString(getHostedZoneRequest.getId()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -63,7 +69,7 @@ public class GetHostedZoneRequestMarshaller implements Marshaller<Request<GetHos
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/ListHealthChecksRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/ListHealthChecksRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,9 +44,15 @@ public class ListHealthChecksRequestMarshaller implements Marshaller<Request<Lis
         Request<ListHealthChecksRequest> request = new DefaultRequest<ListHealthChecksRequest>(listHealthChecksRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/healthcheck?marker={Marker}&maxitems={MaxItems}"; 
-        uriResourcePath = uriResourcePath.replace("{Marker}", getString(listHealthChecksRequest.getMarker())); 
-        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listHealthChecksRequest.getMaxItems())); 
+        String version = listHealthChecksRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/healthcheck?marker={Marker}&maxitems={MaxItems}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Marker}", getString(listHealthChecksRequest.getMarker()));
+        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listHealthChecksRequest.getMaxItems()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -64,7 +70,7 @@ public class ListHealthChecksRequestMarshaller implements Marshaller<Request<Lis
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/ListHostedZonesRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/ListHostedZonesRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,9 +44,15 @@ public class ListHostedZonesRequestMarshaller implements Marshaller<Request<List
         Request<ListHostedZonesRequest> request = new DefaultRequest<ListHostedZonesRequest>(listHostedZonesRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/hostedzone?marker={Marker}&maxitems={MaxItems}"; 
-        uriResourcePath = uriResourcePath.replace("{Marker}", getString(listHostedZonesRequest.getMarker())); 
-        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listHostedZonesRequest.getMaxItems())); 
+        String version = listHostedZonesRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone?marker={Marker}&maxitems={MaxItems}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Marker}", getString(listHostedZonesRequest.getMarker()));
+        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listHostedZonesRequest.getMaxItems()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -64,7 +70,7 @@ public class ListHostedZonesRequestMarshaller implements Marshaller<Request<List
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }

--- a/src/main/java/com/amazonaws/services/route53/model/transform/ListResourceRecordSetsRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/route53/model/transform/ListResourceRecordSetsRequestMarshaller.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2010-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
  * A copy of the License is located at
- * 
+ *
  *  http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed
  * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -44,12 +44,18 @@ public class ListResourceRecordSetsRequestMarshaller implements Marshaller<Reque
         Request<ListResourceRecordSetsRequest> request = new DefaultRequest<ListResourceRecordSetsRequest>(listResourceRecordSetsRequest, "AmazonRoute53");
         request.setHttpMethod(HttpMethodName.GET);
 
-        String uriResourcePath = "/2012-12-12/hostedzone/{Id}/rrset?type={Type}&name={Name}&identifier={Identifier}&maxitems={MaxItems}"; 
-        uriResourcePath = uriResourcePath.replace("{Id}", getString(listResourceRecordSetsRequest.getHostedZoneId())); 
-        uriResourcePath = uriResourcePath.replace("{Name}", getString(listResourceRecordSetsRequest.getStartRecordName())); 
-        uriResourcePath = uriResourcePath.replace("{Type}", getString(listResourceRecordSetsRequest.getStartRecordType())); 
-        uriResourcePath = uriResourcePath.replace("{Identifier}", getString(listResourceRecordSetsRequest.getStartRecordIdentifier())); 
-        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listResourceRecordSetsRequest.getMaxItems())); 
+        String version = listResourceRecordSetsRequest.getVersion();
+        if(version == null){
+            version = "2012-12-12";
+        }
+
+        String uriResourcePath = "/{Version}/hostedzone/{Id}/rrset?type={Type}&name={Name}&identifier={Identifier}&maxitems={MaxItems}";
+        uriResourcePath = uriResourcePath.replace("{Version}", version);
+        uriResourcePath = uriResourcePath.replace("{Id}", getString(listResourceRecordSetsRequest.getHostedZoneId()));
+        uriResourcePath = uriResourcePath.replace("{Name}", getString(listResourceRecordSetsRequest.getStartRecordName()));
+        uriResourcePath = uriResourcePath.replace("{Type}", getString(listResourceRecordSetsRequest.getStartRecordType()));
+        uriResourcePath = uriResourcePath.replace("{Identifier}", getString(listResourceRecordSetsRequest.getStartRecordIdentifier()));
+        uriResourcePath = uriResourcePath.replace("{MaxItems}", getString(listResourceRecordSetsRequest.getMaxItems()));
 
         if (uriResourcePath.contains("?")) {
             String queryString = uriResourcePath.substring(uriResourcePath.indexOf("?") + 1);
@@ -67,7 +73,7 @@ public class ListResourceRecordSetsRequestMarshaller implements Marshaller<Reque
 
         request.setResourcePath(uriResourcePath);
 
-        
+
 
         return request;
     }


### PR DESCRIPTION
In this commit, user can set / get api version client uses.

``` java
AmazonRoute53Client client = new AmazonRoute53Client();
client.setVersion("2013-12-12");
```

above code changes hardcoded paths:

```
String uriResourcePath = "/2012-12-12/hostedzone"; 
```

to dynamically version dependent paths.

```
String uriResourcePath = "/{Version}/hostedzone";
uriResourcePath = uriResourcePath.replace("{Version}", version);
```
