### PR TITLE
Update POM to build with Java 6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,8 +158,8 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-compiler-plugin</artifactId>
             <configuration>
-              <source>1.5</source>
-              <target>1.5</target>
+              <source>1.6</source>
+              <target>1.6</target>
               <encoding>UTF-8</encoding>
             </configuration>
           </plugin>


### PR DESCRIPTION
If you actually try to build with a Java 5 compiler it will failed due
to the use of @Override on methods implementing an interface.  This feature
was not added until Java 6.
