### PR TITLE
Use getRegion to determine where a bucket should be created when using createBucket(bucketName)

### DIFF
--- a/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -606,7 +606,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
      */
     public Bucket createBucket(String bucketName)
             throws AmazonClientException, AmazonServiceException {
-        return createBucket(new CreateBucketRequest(bucketName));
+        return createBucket(new CreateBucketRequest(bucketName, this.getRegion()));
     }
 
     /* (non-Javadoc)


### PR DESCRIPTION
This addresses issue #89. There is a getRegion method already provided in AmazonS3Client that tries to pull the region from the superclass and defaults back to US_Standard when one is not set. Passing the result from getRegion as the region parameter in CreateBucketRequest is a simple way to implement the desired behavior.