### PR TITLE
Add beijing (.amazon.com.cn) regions.

### DIFF
--- a/src/main/java/com/amazonaws/regions/RegionMetadataParser.java
+++ b/src/main/java/com/amazonaws/regions/RegionMetadataParser.java
@@ -142,6 +142,6 @@ public class RegionMetadataParser {
      * TODO We might want to do more complicated verification in the future.
      */
     private static boolean verifyEndpoint(String endpoint) {
-        return endpoint.endsWith(".amazonaws.com");
+        return endpoint.endsWith(".amazonaws.com") || endpoint.endsWith(".amazonaws.com.cn");
     }
 }


### PR DESCRIPTION
RegionMasterParser writes WARNING StackTrace cause Beijing regons are added to Cloudfont's endpoints.xml.
