### PR TITLE
Add local address configuration in the HTTP client

### DIFF
--- a/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws;
 
+import java.net.InetAddress;
+
 import org.apache.http.annotation.NotThreadSafe;
 
 import com.amazonaws.retry.PredefinedRetryPolicies;
@@ -74,6 +76,9 @@ public class ClientConfiguration {
     
     /** The retry policy upon failed requests. **/
     private RetryPolicy retryPolicy = DEFAULT_RETRY_POLICY;
+
+    /** Optionally specifies the local address to bind to */
+    private InetAddress localAddress;
 
     /**
      * The protocol to use when connecting to Amazon Web Services.
@@ -147,6 +152,7 @@ public class ClientConfiguration {
         this.maxConnections    = other.maxConnections;
         this.maxErrorRetry     = other.maxErrorRetry;
         this.retryPolicy       = other.retryPolicy;
+        this.localAddress      = other.localAddress;
         this.protocol          = other.protocol;
         this.proxyDomain       = other.proxyDomain;
         this.proxyHost         = other.proxyHost;
@@ -284,6 +290,39 @@ public class ClientConfiguration {
     public ClientConfiguration withUserAgent(String userAgent) {
         setUserAgent(userAgent);
         return this;
+    }
+
+    /**
+     * Returns the optional local address the client will bind to.
+     *
+     * @return The local address the client will bind to.
+     */
+    public InetAddress getLocalAddress() {
+        return localAddress;
+    }
+
+    /**
+     * Sets the optional local address the client will bind to.
+     *
+     * @param proxyHost
+     *            The local address the client will bind to.
+     */
+    public void setLocalAddress(InetAddress localAddress) {
+        this.localAddress = localAddress;
+    }
+
+    /**
+     * Sets the optional local address the client will bind to and returns
+     * the updated ClientConfiguration object.
+     *
+     * @param localAddress
+     *            The local address the client will bind to.
+     *
+     * @return The updated ClientConfiguration object.
+     */
+    public ClientConfiguration withLocalAddress(InetAddress localAddress) {
+      setLocalAddress(localAddress);
+      return this;
     }
 
     /**

--- a/src/main/java/com/amazonaws/http/HttpClientFactory.java
+++ b/src/main/java/com/amazonaws/http/HttpClientFactory.java
@@ -17,6 +17,7 @@ package com.amazonaws.http;
 import static com.amazonaws.SDKGlobalConfiguration.DISABLE_CERT_CHECKING_SYSTEM_PROPERTY;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.UnknownHostException;
@@ -40,6 +41,7 @@ import org.apache.http.auth.NTCredentials;
 import org.apache.http.client.HttpClient;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.conn.params.ConnRouteParams;
 import org.apache.http.conn.scheme.PlainSocketFactory;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeLayeredSocketFactory;
@@ -92,6 +94,10 @@ class HttpClientFactory {
         SdkHttpClient httpClient = new SdkHttpClient(connectionManager, httpClientParams);
         httpClient.setHttpRequestRetryHandler(SdkHttpRequestRetryHandler.Singleton);
         httpClient.setRedirectStrategy(new LocationHeaderNotRequiredRedirectStrategy());
+
+        if (config.getLocalAddress() != null) {
+          ConnRouteParams.setLocalAddress(httpClientParams, config.getLocalAddress());
+        }
 
         try {
             Scheme http = new Scheme("http", 80, PlainSocketFactory.getSocketFactory());


### PR DESCRIPTION
Add a configuration option for specifying the local address to bind
sockets to in HTTP clients. The configuration is optional and will, as
before, default to not use a specific address when binding.

Binding to a configured address enables users of the library to, for
example, ensure that a specific network interface is used.
