### PR TITLE
Removed regions that Elastic Transcoder is not present in.

### DIFF
--- a/src/main/resources/etc/regions.xml
+++ b/src/main/resources/etc/regions.xml
@@ -1118,12 +1118,6 @@
         <Https>true</Https>
         <Hostname>redshift.ap-southeast-2.amazonaws.com</Hostname>
       </Endpoint>
-      <Endpoint>
-        <ServiceName>elastictranscoder</ServiceName>
-        <Http>false</Http>
-        <Https>true</Https>
-        <Hostname>elastictranscoder.ap-southeast-2.amazonaws.com</Hostname>
-      </Endpoint>
     </Region>
     <Region>
       <Name>sa-east-1</Name>
@@ -1258,12 +1252,6 @@
         <Http>false</Http>
         <Https>true</Https>
         <Hostname>directconnect.sa-east-1.amazonaws.com</Hostname>
-      </Endpoint>
-      <Endpoint>
-        <ServiceName>elastictranscoder</ServiceName>
-        <Http>false</Http>
-        <Https>true</Https>
-        <Hostname>elastictranscoder.sa-east-1.amazonaws.com</Hostname>
       </Endpoint>
     </Region>
     <Region>
@@ -1690,8 +1678,6 @@
       <RegionName>eu-west-1</RegionName>
       <RegionName>ap-northeast-1</RegionName>
       <RegionName>ap-southeast-1</RegionName>
-      <RegionName>ap-southeast-2</RegionName>
-      <RegionName>sa-east-1</RegionName>
     </Service>
   </Services>
 </XML>


### PR DESCRIPTION
While consuming your `regions.xml` (to build a JSON variant for Boto's consumption), I discovered you have regions for Elastic Transcoder that don't resolve (& aren't present in good ol' Rande - http://docs.aws.amazon.com/general/latest/gr/rande.html#elastictranscoder_region). This removes those regions.
