### PR TITLE
Flow Framework: Delegating logic for parsing method arguments to DataConverter

### DIFF
--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/DataConverter.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/DataConverter.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws.services.simpleworkflow.flow;
 
+import java.lang.reflect.Method;
+
 /**
  * Used by the framework to serialize/deserialize method parameters that need to
  * be sent over the wire. 
@@ -44,6 +46,16 @@ public abstract class DataConverter {
      *             if conversion of the data passed as parameter failed for any
      *             reason.
      */
-    public abstract <T> T fromData(String content, Class<T> valueType) throws DataConverterException;
+    public abstract <T> T fromData(String data, Class<T> valueType) throws DataConverterException;
+
+    /**
+     * Parses the method arguments for {@code Method} from  Simple Workflow Data value.
+     * @param data  Simple Workflow Data value to convert to a Java object.
+     * @param method {@code Method} whose arguments needs to be parsed..
+     * @return {@code Object[]} Parsed method arguments.
+     * @throws DataConverterException  if conversion of the data passed as parameter failed for any
+     *             reason.
+     */
+    public abstract Object[] parseMethodArguments (String data, Method method) throws DataConverterException;
 
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonDataConverter.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonDataConverter.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.simpleworkflow.flow;
 
 import java.io.IOException;
+import java.lang.reflect.Method;
 
 import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
@@ -104,5 +105,14 @@ public class JsonDataConverter extends DataConverter {
         catch (IOException e) {
             throw new DataConverterException(e);
         }
+    }
+
+    /**
+     * This uses Object[] to de-serialize the arguments.
+     * @see com.amazonaws.services.simpleworkflow.flow.DataConverter#parseMethodArguments(String, java.lang.reflect.Method)
+     */
+    @Override
+    public Object[] parseMethodArguments(String serialized, Method method) throws DataConverterException {
+        return fromData(serialized, Object[].class);
     }
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/annotations/NullDataConverter.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/annotations/NullDataConverter.java
@@ -17,6 +17,8 @@ package com.amazonaws.services.simpleworkflow.flow.annotations;
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
 import com.amazonaws.services.simpleworkflow.flow.DataConverterException;
 
+import java.lang.reflect.Method;
+
 /**
  * To be used only by annotations as they do not support <code>null</code> parameters.
  * 
@@ -38,4 +40,8 @@ public final class NullDataConverter extends DataConverter {
         throw new UnsupportedOperationException("not implemented");
     }
 
+    @Override
+    public Object[] parseMethodArguments(String data, Method method) throws DataConverterException {
+        throw new UnsupportedOperationException("not implemented");
+    }
 }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOActivityImplementation.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOActivityImplementation.java
@@ -57,7 +57,7 @@ class POJOActivityImplementation extends ActivityImplementationBase {
         // after new parameters were added to activity method
         // It requires creation of inputParameters array of the correct size and
         // populating the new parameter values with default values for each type
-        Object[] inputParameters = converter.fromData(input, Object[].class);
+        Object[] inputParameters = converter.parseMethodArguments(input,activity);
         CurrentActivityExecutionContext.set(context);
         Object result = null;
         try {

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
@@ -108,7 +108,7 @@ public class POJOWorkflowDefinition extends WorkflowDefinition {
                 c = converter;
             }
             Method method = signalMethod.getMethod();
-            Object[] parameters = c.fromData(details, Object[].class);
+            Object[] parameters = c.parseMethodArguments(details, method);
             try {
                 invokeMethod(method, parameters);
             }

--- a/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
+++ b/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
@@ -71,8 +71,8 @@ public class POJOWorkflowDefinition extends WorkflowDefinition {
                 // after new parameters were added to @Execute method
                 // It requires creation of parameters array of the correct size and
                 // populating the new parameter values with default values for each type
-                Object[] parameters = c.fromData(input, Object[].class);
                 Method method = workflowMethod.getMethod();
+                Object[] parameters = c.parseMethodArguments(input, method);
                 Object r = invokeMethod(method, parameters);
                 if (!method.getReturnType().equals(Void.TYPE)) {
                     methodResult.set((Promise) r);


### PR DESCRIPTION
Description:
Delegating logic for parsing method arguments to DataConverter so that we can control the behavior of de-serialization.

Use Case:
I am using custom Data Converter which does not serialize the java type information in the serialized message.  In order to de-serialize the message, we can derive the type from the method arguments.  However , there is no way to specify in the current implementation.

In order to achieve the same, I  have delegated the call to DataConverter for parsing arguments from the source message.  The behavior for JsonDataConverter is same. 
