### PR TITLE
Do not hide detail message.

### DIFF
--- a/src/main/java/com/amazonaws/AmazonServiceException.java
+++ b/src/main/java/com/amazonaws/AmazonServiceException.java
@@ -219,7 +219,7 @@ public class AmazonServiceException extends AmazonClientException {
 
     /** {@inheritDoc} */
     @Override
-    public String getMessage() {
+    public String toString() {
         return "Status Code: " + getStatusCode() + ", "
             + "AWS Service: " + getServiceName() + ", "
             + "AWS Request ID: " + getRequestId() + ", "


### PR DESCRIPTION
Overriding #getMessage makes it impossible to obtain the detail message of an exception which contains the detailed human readable error description. Fix this by overriding #toString that prints the exception class fields instead of #getMessage.
