### PR TITLE
Add content-length when initiating multipart upload

### DIFF
--- a/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -2565,7 +2565,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
 
         // Be careful that we don't send the object's total size as the content
         // length for the InitiateMultipartUpload request.
-        request.getHeaders().remove(Headers.CONTENT_LENGTH);
+        request.addHeader(Headers.CONTENT_LENGTH, "0");
         // Set the request content to be empty (but not null) to force the runtime to pass
         // any query params in the query string and not the request body, to keep S3 happy.
         request.setContent(new ByteArrayInputStream(new byte[0]));


### PR DESCRIPTION
When using multipart upload, there is a strange behavior when initiating the upload.

The request has a body setted but no content-length so it is send has "transport-encoding=chunked"

I don't know if it's correct but changing the line removing the content_length header with a line that replace it by 0 make http use a 'normal' request.
