### PR TITLE
Modified DateUtils to remove synchronized blocks

### DIFF
--- a/src/main/java/com/amazonaws/util/DateUtils.java
+++ b/src/main/java/com/amazonaws/util/DateUtils.java
@@ -33,31 +33,51 @@ import java.util.SimpleTimeZone;
 public class DateUtils {
 
     /** ISO 8601 format */
-    protected final SimpleDateFormat iso8601DateFormat =
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+    protected final ThreadLocal<SimpleDateFormat> iso8601DateFormat = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df =  new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'");
+            df.setTimeZone(new SimpleTimeZone(0, "GMT"));
+            return df;
+        }
+    };
 
     /** Alternate ISO 8601 format without fractional seconds */
-    protected final SimpleDateFormat alternateIso8601DateFormat =
-        new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+    protected final ThreadLocal<SimpleDateFormat> alternateIso8601DateFormat = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'");
+            df.setTimeZone(new SimpleTimeZone(0, "GMT"));
+            return df;
+        }
+    };
 
     /** RFC 822 format */
-    protected final SimpleDateFormat rfc822DateFormat =
-        new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+    protected final ThreadLocal<SimpleDateFormat> rfc822DateFormat = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss z", Locale.US);
+            df.setTimeZone(new SimpleTimeZone(0, "GMT"));
+            return df;
+        }
+    };
 
     /**
      * This is another ISO 8601 format that's used in clock skew error response
      */
-    protected final SimpleDateFormat compressedIso8601DateFormat =
-        new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+    protected final ThreadLocal<SimpleDateFormat> compressedIso8601DateFormat = new ThreadLocal<SimpleDateFormat>() {
+        @Override
+        protected SimpleDateFormat initialValue() {
+            SimpleDateFormat df = new SimpleDateFormat("yyyyMMdd'T'HHmmss'Z'");
+            df.setTimeZone(new SimpleTimeZone(0, "GMT"));
+            return df;
+        }
+    };
 
     /**
      * Constructs a new DateUtils object, ready to parse/format dates.
      */
     public DateUtils() {
-        iso8601DateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
-        rfc822DateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
-        alternateIso8601DateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
-        compressedIso8601DateFormat.setTimeZone(new SimpleTimeZone(0, "GMT"));
     }
 
     /**
@@ -74,15 +94,11 @@ public class DateUtils {
      */
     public Date parseIso8601Date(String dateString) throws ParseException {
         try {
-            synchronized (iso8601DateFormat) {
-                return iso8601DateFormat.parse(dateString);
-            }
+            return iso8601DateFormat.get().parse(dateString);
         } catch (ParseException e) {
             // If the first ISO 8601 parser didn't work, try the alternate
             // version which doesn't include fractional seconds
-            synchronized (alternateIso8601DateFormat) {
-                return alternateIso8601DateFormat.parse(dateString);
-            }
+            return alternateIso8601DateFormat.get().parse(dateString);
         }
     }
 
@@ -95,9 +111,7 @@ public class DateUtils {
      * @return The ISO 8601 string representing the specified date.
      */
     public String formatIso8601Date(Date date) {
-        synchronized (iso8601DateFormat) {
-            return iso8601DateFormat.format(date);
-        }
+        return iso8601DateFormat.get().format(date);
     }
 
     /**
@@ -113,9 +127,7 @@ public class DateUtils {
      *             If the date string could not be parsed.
      */
     public Date parseRfc822Date(String dateString) throws ParseException {
-        synchronized (rfc822DateFormat) {
-            return rfc822DateFormat.parse(dateString);
-        }
+        return rfc822DateFormat.get().parse(dateString);
     }
 
     /**
@@ -127,9 +139,7 @@ public class DateUtils {
      * @return The RFC 822 string representing the specified date.
      */
     public String formatRfc822Date(Date date) {
-        synchronized (rfc822DateFormat) {
-            return rfc822DateFormat.format(date);
-        }
+        return rfc822DateFormat.get().format(date);
     }
 
     /**
@@ -145,8 +155,6 @@ public class DateUtils {
      *             If the date string could not be parsed.
      */
     public Date parseCompressedIso8601Date(String dateString) throws ParseException {
-        synchronized (compressedIso8601DateFormat) {
-            return compressedIso8601DateFormat.parse(dateString);
-        }
+        return compressedIso8601DateFormat.get().parse(dateString);
     }
 }


### PR DESCRIPTION
At my current workplace we have been heavily downloading data from s3 to our servers in realtime. from time to time at peak loads I noticed synchronized blocks caused all http threads in my servlet container to block. This patch fixes it by using threadlocal's for date format objects.

see http://www.javacodegeeks.com/2010/07/java-best-practices-dateformat-in.html
