### PR TITLE
Reset the request content in retry cases before wrapping and buffering it

### DIFF
--- a/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -355,6 +355,20 @@ public class AmazonHttpClient {
                     requestLog.debug("Sending Request: " + request.toString());
                  }
 
+                InputStream content = request.getContent();
+                if ( content != null ) {
+                    if ( requestCount > 1 ) {   // retry
+                        if ( content.markSupported() ) {
+                            content.reset();
+                            content.mark(-1);
+                        }
+                    } else {
+                        if ( content.markSupported() ) {
+                            content.mark(-1);
+                        }
+                    }
+                }
+
                 httpRequest = httpRequestFactory.createHttpRequest(request, config, executionContext);
 
                 if (httpRequest instanceof HttpEntityEnclosingRequest) {
@@ -374,20 +388,6 @@ public class AmazonHttpClient {
                                              config.getRetryPolicy());
                     } finally {
                         awsRequestMetrics.endEvent(Field.RetryPauseTime);
-                    }
-                }
-
-                if ( entity != null ) {
-                    InputStream content = entity.getContent();
-                    if ( requestCount > 1 ) {   // retry
-                        if ( content.markSupported() ) {
-                            content.reset();
-                            content.mark(-1);
-                        }
-                    } else {
-                        if ( content.markSupported() ) {
-                            content.mark(-1);
-                        }
                     }
                 }
 


### PR DESCRIPTION
Content without known length (something that happens with requests for #setBucketLoggingConfiguration() for example)
will get wrapped and buffered, before it eventually ends up as "entity". Marking/Resetting the content stream
returned by BufferedHttpEntity is pretty pointless, as that is _recreated_ on every call to #getContent(). At the same
time when the BufferedHttpEntity is created the second time (inside #createHttpRequest()), the underlying stream is already at its end,
so the buffering produces an _empty_ buffer/entity.

This should (see below) fix cases where an S3 request with such an entity hits a 307 redirect.

---

Note that this issue leads to errors in perfectly valid requests, caused by something not controllable by the user (it seems the 307 redirects happen once in a while, without any reproducibility).

I can provide a wire dump of the case where I got a redirect from https://BUCKET.s3.amazonaws.com/?logging to https://BUCKET.s3-eu-west-1.amazonaws.com/?logging if you need it. The error I received was a (in hindsight) obvious "MalformedXML", because there was no XML in the second request at all.

Also note that when the redirect is executed the _original_ Host header is used, which smells suspicious to me. Currently I cannot reproduce the redirect, so cannot confirm whether this change is complete.
