### PR TITLE
empty strings are not valid credentials

### DIFF
--- a/src/main/java/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/auth/EnvironmentVariableCredentialsProvider.java
@@ -41,11 +41,11 @@ public class EnvironmentVariableCredentialsProvider implements AWSCredentialsPro
 
         String sessionToken = System.getenv(AWS_SESSION_TOKEN_ENV_VAR);
 
-        if (accessKey == null || secretKey == null) {
+        if (accessKey == null || secretKey == null || accessKey.length() == 0 || secretKey.length() == 0) {
             throw new AmazonClientException(
                     "Unable to load AWS credentials from environment variables " +
-                    "(" + ACCESS_KEY_ENV_VAR + " (or " + ALTERNATE_ACCESS_KEY_ENV_VAR + ") and " +
-                    SECRET_KEY_ENV_VAR + " (or " + ALTERNATE_SECRET_KEY_ENV_VAR + "))");
+                            "(" + ACCESS_KEY_ENV_VAR + " (or " + ALTERNATE_ACCESS_KEY_ENV_VAR + ") and " +
+                            SECRET_KEY_ENV_VAR + " (or " + ALTERNATE_SECRET_KEY_ENV_VAR + "))");
         }
 
         return sessionToken == null ?

--- a/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
@@ -26,11 +26,13 @@ import com.amazonaws.AmazonClientException;
 public class SystemPropertiesCredentialsProvider implements AWSCredentialsProvider {
 
     public AWSCredentials getCredentials() {
-        if (System.getProperty(ACCESS_KEY_SYSTEM_PROPERTY) != null &&
-            System.getProperty(SECRET_KEY_SYSTEM_PROPERTY) != null) {
+        String accessKey = System.getProperty(ACCESS_KEY_SYSTEM_PROPERTY);
+        String secretKey = System.getProperty(SECRET_KEY_SYSTEM_PROPERTY);
+        if (accessKey != null &&
+                secretKey != null && accessKey.length() > 0 && secretKey.length() > 0) {
             return new BasicAWSCredentials(
-                    System.getProperty(ACCESS_KEY_SYSTEM_PROPERTY),
-                    System.getProperty(SECRET_KEY_SYSTEM_PROPERTY));
+                    accessKey,
+                    secretKey);
         }
 
         throw new AmazonClientException(


### PR DESCRIPTION
Fixes an issue with DefaultAWSCredentialsProviderChain which picks up the EnvironmentVariableCredentialsProvider even if variables are not set ( in Elasticbeanstalk environment).
