### PR TITLE
Set the source encoding to UTF-8 to remove a maven warning when building

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <properties>
         <jackson.version>2.1.1</jackson.version>
         <spring.version>3.0.7.RELEASE</spring.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
This fixes the following warning when building, and should otherwise be non-functional (unless there are non-UTF-8 resources somewhere, in which case it is even more important to set the encoding!)

```
[WARNING] Using platform encoding (UTF-8 actually) to copy filtered resources, i.e. build is platform dependent!
```
