### PR TITLE
Adding the option to modify the end point

### DIFF
--- a/src/samples/AmazonKinesisApplication/SampleKinesisApplication.java
+++ b/src/samples/AmazonKinesisApplication/SampleKinesisApplication.java
@@ -128,7 +128,7 @@ public final class SampleKinesisApplication {
         LOG.info("Using credentials with access key id: " + credentialsProvider.getCredentials().getAWSAccessKeyId());
 
         kinesisClientLibConfiguration = new KinesisClientLibConfiguration(applicationName, streamName,
-                credentialsProvider, workerId).withInitialPositionInStream(initialPositionInStream);
+                credentialsProvider, workerId).withKinesisEndpoint(kinesisEndpoint).withInitialPositionInStream(initialPositionInStream);
     }
 
     /**


### PR DESCRIPTION
Now that Kinesis is available in multiple regions, changing the endpoint is needed. The current code was only applicable for Kinesis streams in us-east-1.