### PR TITLE
SearchRequestMarshaller used by AmazonCloudSearchDomainClient breaks when using structured queries with equal signs in them

### DIFF
--- a/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/SearchRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/SearchRequestMarshaller.java
@@ -63,11 +63,9 @@ public class SearchRequestMarshaller implements Marshaller<Request<SearchRequest
 			for (String s : queryString.split("[;&]")) {
 
 				String[] nameValuePair = s.split("=");
+				String key = nameValuePair[0];
 				if (nameValuePair.length >= 2) {
-					String key = nameValuePair[0], value = "";
-					for (int i = 1; i < nameValuePair.length; i++) {
-						value += nameValuePair[i];
-					}
+					String value = s.substring(s.indexOf("=") + 1);
 					if (!(value.isEmpty())) {
 						request.addParameter(key, value);
 					}


### PR DESCRIPTION
This issue is reproducible in 1.8.4.

If you have a structured query string with any '=' in it the URL builder breaks, since it does String.split on equals signs and checks that there are only 2 values in the returned array (line 74 of SearchRequestMarshaller).

According to the documentation at http://docs.aws.amazon.com/cloudsearch/latest/developerguide/searching-compound-queries.html the following query is valid:

q=(and (range field=year [2013,}) (or (term field=title boost=2 'star') (term field=plot 'star'))

But due to this bug the 'q' parameter does not get added to the final string. This pull request fixes this issue.
