### PR TITLE
Fix issue with CloudSearch structured queries on URL

### DIFF
--- a/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/SearchRequestMarshaller.java
+++ b/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/SearchRequestMarshaller.java
@@ -71,7 +71,7 @@ public class SearchRequestMarshaller implements Marshaller<Request<SearchRequest
             uriResourcePath    = uriResourcePath.substring(0, uriResourcePath.indexOf("?"));
 
             for (String s : queryString.split("[;&]")) {
-                String[] nameValuePair = s.split("=");
+                String[] nameValuePair = s.split("=", 2);
                 if (nameValuePair.length == 2) {
                     if(!(nameValuePair[1].isEmpty()))
                         request.addParameter(nameValuePair[0], nameValuePair[1]);


### PR DESCRIPTION
Fix issue where structured queries containing '=' don't get serialized to the URL properly. This is a (simpler) alternative fix to the one already provided.
