### PR TITLE
Support for gzip compression

### DIFF
--- a/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -64,6 +64,11 @@ public class ClientConfiguration {
     public static final boolean DEFAULT_USE_REAPER = true;
 
     /**
+     * The default on whether to use gzip compression.
+     */
+    public static final boolean DEFAULT_USE_GZIP = false;
+
+    /**
      * The default expiration time (in milliseconds) for a connection in the
      * connection pool.
      */
@@ -157,6 +162,11 @@ public class ClientConfiguration {
     private boolean useReaper = DEFAULT_USE_REAPER;
 
     /**
+     * Optional whether to use gzip compression when making HTTP requests.
+     */
+    private boolean useGzip = DEFAULT_USE_GZIP;
+
+    /**
      * Optional override to control which signature algorithm should be used to
      * sign requests to the service. If not explicitly set, the client will
      * determine the algorithm to use by inspecting a configuration file baked
@@ -190,6 +200,7 @@ public class ClientConfiguration {
         this.socketTimeout               = other.socketTimeout;
         this.userAgent                   = other.userAgent;
         this.useReaper                   = other.useReaper;
+        this.useGzip                     = other.useGzip;
         this.socketReceiveBufferSizeHint = other.socketReceiveBufferSizeHint;
         this.socketSendBufferSizeHint    = other.socketSendBufferSizeHint;
         this.signerOverride              = other.signerOverride;
@@ -767,6 +778,34 @@ public class ClientConfiguration {
      */
     public ClientConfiguration withReaper(boolean use) {
         setUseReaper(use);
+        return this;
+    }
+
+    /**
+     * Checks if gzip compression is used
+     *
+     * @return if gzip compression is used
+     */
+    public boolean useGzip() {
+        return useGzip;
+    }
+
+    /**
+     * Sets whether gzip compression should be used
+     *
+     * @param use whether gzip compression should be used
+     */
+    public void setUseGzip(boolean use) {
+        this.useGzip = use;
+    }
+
+    /**
+     * Sets whether gzip compression should be used
+     *
+     * @param use whether gzip compression should be used
+     */
+    public ClientConfiguration withGzip(boolean use) {
+        setUseGzip(use);
         return this;
     }
 


### PR DESCRIPTION
API calls with verbose results can take a very long time when made over network links with high latency and/or low bandwidth. The API endpoints seem to support gzip compression, but it is unused by the SDK. This pull request adds support for gzip compression. 

Example:
- A `describeInstances` request to an account with about 1,000 instances returns about 6MB of uncompressed data. Over a slow link in New Delhi, this single API call takes about 1 minute 30 seconds. 
- With gzip compression enabled, it takes 11 seconds and transfers only 246 kB).  
