### PR TITLE
Support for AWS_PROFILE override, similar to the php sdk. Override applies only for the default profile, not for specifically named profiles.

### DIFF
--- a/src/main/java/com/amazonaws/auth/profile/ProfileCredentialsProvider.java
+++ b/src/main/java/com/amazonaws/auth/profile/ProfileCredentialsProvider.java
@@ -16,6 +16,7 @@ package com.amazonaws.auth.profile;
 
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.util.StringUtils;
 
 /**
  * Credentials provider based on AWS configuration profiles. This provider vends
@@ -50,7 +51,7 @@ public class ProfileCredentialsProvider implements AWSCredentialsProvider {
      * is called.
      */
     public ProfileCredentialsProvider() {
-        this(ProfilesConfigFile.DEFAULT_PROFILE_NAME);
+        this(null);
     }
 
     /**
@@ -95,7 +96,17 @@ public class ProfileCredentialsProvider implements AWSCredentialsProvider {
      */
     public ProfileCredentialsProvider(ProfilesConfigFile profilesConfigFile, String profileName) {
         this.profilesConfigFile = profilesConfigFile;
-        this.profileName = profileName;
+        if (profileName == null) {
+            String profileOverride = System.getenv(ProfilesConfigFile.AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            profileOverride = StringUtils.trim(profileOverride);
+            if (!StringUtils.isNullOrEmpty(profileOverride)) {
+                this.profileName = profileOverride;
+            } else {
+                this.profileName = ProfilesConfigFile.DEFAULT_PROFILE_NAME;
+            }
+        } else {
+            this.profileName = profileName;
+        }
     }
 
     @Override

--- a/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
+++ b/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
@@ -61,6 +61,9 @@ public class ProfilesConfigFile {
 
     private static final Log LOG = LogFactory.getLog(ProfilesConfigFile.class);
 
+    /** Environment variable name for overriding the default AWS profile */
+    public static final String AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
+
     /** Environment variable specifying an alternate location for the AWS credential profiles file */
     @Deprecated
     private static final String LEGACY_CONFIG_FILE_ENVIRONMENT_VARIABLE = "AWS_CONFIG_FILE";


### PR DESCRIPTION
Fixes issue #249 by adding environment variable profile override support for the Java SDK.

This [amazon security blog post](http://blogs.aws.amazon.com/security/post/Tx3D6U6WSFGOK2H/A-New-and-Standardized-Way-to-Manage-Credentials-in-the-AWS-SDKs) mentions the ability the override the default profiles using the AWS_PROFILE environment variable, but it doesn't look like the java sdk ever implemented it.
