### PR TITLE
Support newer junit versions for SWF flow tests

### DIFF
--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/FlowBlockJUnit4ClassRunner.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/FlowBlockJUnit4ClassRunner.java
@@ -30,6 +30,16 @@ public class FlowBlockJUnit4ClassRunner extends BlockJUnit4ClassRunner {
     }
 
     @Override
+    protected Object createTest() throws Exception {
+        Object testInstance = super.createTest();
+        // Reset 
+        workflowTestRule = null;
+        timeout = 0;
+        expectedException = null;
+        return testInstance;
+    }
+
+    @Override
     protected Statement withPotentialTimeout(FrameworkMethod method, final Object test, Statement next) {
         Test annotation = method.getAnnotation(Test.class);
         timeout = annotation.timeout();

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/FlowSpringJUnit4ClassRunner.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/FlowSpringJUnit4ClassRunner.java
@@ -32,6 +32,15 @@ public class FlowSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
     }
 
     @Override
+    protected Object createTest() throws Exception {
+        Object testInstance = super.createTest();
+        workflowTestRule = null;
+        timeout = 0;
+        expectedException = null;
+        return testInstance;
+    }
+
+    @Override
     protected Statement withPotentialTimeout(final FrameworkMethod method, final Object test, Statement next) {
         Test annotation = method.getAnnotation(Test.class);
         long timeout = annotation.timeout();

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/FlowSpringJUnit4ClassRunner.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/FlowSpringJUnit4ClassRunner.java
@@ -1,5 +1,6 @@
 package com.amazonaws.services.simpleworkflow.flow.junit.spring;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.Test;
@@ -45,8 +46,25 @@ public class FlowSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
 
     @Override
     protected List<MethodRule> rules(Object test) {
-        List<MethodRule> result = super.rules(test);
-        for (MethodRule methodRule : result) {
+        List<MethodRule> allRules = super.rules(test);
+        List<MethodRule> result = new ArrayList<MethodRule>();
+        for (MethodRule methodRule : allRules) {
+            // Filter out the SWF rules so that they can be applied separately
+            if (!WorkflowTestBase.class.isAssignableFrom(methodRule.getClass())) {
+                result.add(methodRule);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    protected Statement methodInvoker(FrameworkMethod method, Object test) {
+        Statement invoker = super.methodInvoker(method, test);
+
+        // Apply the workflow test rule here so that it only wraps the method
+        // under test, not @Before/@After
+        List<MethodRule> rules = super.rules(test);
+        for (MethodRule methodRule : rules) {
             if (WorkflowTestBase.class.isAssignableFrom(methodRule.getClass())) {
                 workflowTestRule = (WorkflowTestBase) methodRule;
                 workflowTestRule.setFlowTestRunner(true);
@@ -56,9 +74,10 @@ public class FlowSpringJUnit4ClassRunner extends SpringJUnit4ClassRunner {
                 if (expectedException != null) {
                     workflowTestRule.setExpectedException(expectedException);
                 }
+                return workflowTestRule.apply(invoker, method, test);
             }
         }
-        return result;
+        return invoker;
     }
 
     @Override


### PR DESCRIPTION
This enables support for newer junit versions.

I've run this against all of the aws examples in the SDK and the recipes from https://aws.amazon.com/code/2535278400103493 using junit 4.7 and 4.11 with no failures.

The issue is that junit 4.7 (which introduced Rules) only wrapped the actual test method. Junit4.8 and above also wrap the Before/After methods. This results in the teardown code being run as part of the async task block, and since there are no dependencies/Promises, that means that it runs before the activity does, leading to incorrect results.

A test for this is the booking test - without this change, the tearDown method is run before the workflow activity runs, resulting in the 'trace' List being null when the activity runs, causing a NullPointerException in the stub activity.

Junit4.11 also changed behaviour so that tests are not run in the same order as in the test file. This exposed issues with tests that use @Test(expected=XXX.class), such as the handleError recipe. The runner is reused, and so the expectedException is kept around from the previous test and passed into the new workFlowTestRule. This is never reset, because possiblyExpectingExceptions only calls setExpectedException when there is an expected exception.

The second scenario happens even with Junit4.7 if you change the order so that testHandleErrorWorkflowWithNonHandleableException is first instead of last in the file.

PS - it'd be nice to have the build-time flow annotation processors available in github/maven too...