### PR TITLE
fixing TransferManager download of versioned object

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -680,6 +680,9 @@ public class TransferManager {
         if (getObjectRequest.getSSECustomerKey() != null) {
             getObjectMetadataRequest.setSSECustomerKey(getObjectRequest.getSSECustomerKey());
         }
+        if (getObjectRequest.getVersionId() != null) {
+            getObjectMetadataRequest.setVersionId(getObjectRequest.getVersionId());
+        }
         final ObjectMetadata objectMetadata = s3.getObjectMetadata(getObjectMetadataRequest);
 
         // We still pass the unfiltered listener chain into DownloadImpl


### PR DESCRIPTION
When downloading, TransferManager first gets content length by getting object metadata. 
Still for versioned objects - when creating get-metadata request TransferManager fails to copy version-id of the "get-object request" . 

This results in nasty consequences:

If the object has a delete marker as the latest version - 
  download of previous versions of that object will fail (404 NOT FOUND)

For other cases where we download previous object versions:
Since we get the content length of the latest object, downloading previous versions will lead to corrupted/truncated downloads.
