### PR TITLE
Option to specify an 'SSLSocketFactory' in AWS clients

### DIFF
--- a/aws-java-sdk-cloudwatch/src/main/java/com/amazonaws/services/cloudwatch/AmazonCloudWatchClient.java
+++ b/aws-java-sdk-cloudwatch/src/main/java/com/amazonaws/services/cloudwatch/AmazonCloudWatchClient.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.cloudwatch;
 
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.w3c.dom.*;
 
 import java.net.*;
@@ -226,10 +227,42 @@ public class AmazonCloudWatchClient extends AmazonWebServiceClient implements Am
      *                       (ex: proxy settings, retry counts, etc.).
      * @param requestMetricCollector optional request metric collector
      */
-    public AmazonCloudWatchClient(AWSCredentialsProvider awsCredentialsProvider,
+    public AmazonCloudWatchClient(
+            AWSCredentialsProvider awsCredentialsProvider,
             ClientConfiguration clientConfiguration,
             RequestMetricCollector requestMetricCollector) {
-        super(clientConfiguration, requestMetricCollector);
+        this(awsCredentialsProvider, clientConfiguration,
+                requestMetricCollector, null);
+    }
+
+    /**
+     * Constructs a new client to invoke service methods on AmazonCloudWatch
+     * using the specified AWS account credentials provider, client
+     * configuration options, request metric collector and SSL socket factory.
+     * 
+     * <p>
+     * All service calls made using this new client object are blocking, and
+     * will not return until the service call completes.
+     * 
+     * @param awsCredentialsProvider
+     *            The AWS credentials provider which will provide credentials to
+     *            authenticate requests with AWS services.
+     * @param clientConfiguration
+     *            The client configuration options controlling how this client
+     *            connects to AmazonCloudWatch (ex: proxy settings, retry
+     *            counts, etc.).
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. Pass
+     *            'null' to use the default factory.
+     * @param requestMetricCollector
+     *            optional request metric collector
+     */
+    public AmazonCloudWatchClient(
+            AWSCredentialsProvider awsCredentialsProvider,
+            ClientConfiguration clientConfiguration,
+            RequestMetricCollector requestMetricCollector,
+            SSLSocketFactory sslSocketFactory) {
+        super(clientConfiguration, requestMetricCollector, sslSocketFactory);
         this.awsCredentialsProvider = awsCredentialsProvider;
         init();
     }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 
 import com.amazonaws.auth.RegionAwareSigner;
 import com.amazonaws.auth.Signer;
@@ -116,8 +117,28 @@ public abstract class AmazonWebServiceClient {
      */
     public AmazonWebServiceClient(ClientConfiguration clientConfiguration,
             RequestMetricCollector requestMetricCollector) {
+        this(clientConfiguration, requestMetricCollector, null);
+    }
+
+    /**
+     * Constructs a new AmazonWebServiceClient object using the specified
+     * configuration and request metric collector.
+     * 
+     * @param clientConfiguration
+     *            The client configuration for this client.
+     * @param requestMetricCollector
+     *            optional request metric collector to be used at the http
+     *            client level; can be null.
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. Pass
+     *            'null' to use the default factory.
+     */
+    public AmazonWebServiceClient(ClientConfiguration clientConfiguration,
+            RequestMetricCollector requestMetricCollector,
+            SSLSocketFactory sslSocketFactory) {
         this.clientConfiguration = clientConfiguration;
-        client = new AmazonHttpClient(clientConfiguration, requestMetricCollector);
+        client = new AmazonHttpClient(clientConfiguration,
+                requestMetricCollector, sslSocketFactory);
         requestHandler2s = new CopyOnWriteArrayList<RequestHandler2>();
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -190,7 +190,30 @@ public class AmazonHttpClient {
      *            is none.
      */
     public AmazonHttpClient(ClientConfiguration config, RequestMetricCollector requestMetricCollector) {
-        this(config, httpClientFactory.createHttpClient(config), requestMetricCollector);
+        this(config, requestMetricCollector, null);
+    }
+
+    /**
+     * Constructs a new AWS client using the specified client configuration
+     * options (ex: max retry attempts, proxy settings, etc), request metric
+     * collector and SSL socket factory.
+     * 
+     * @param config
+     *            Configuration options specifying how this client will
+     *            communicate with AWS (ex: proxy settings, retry count, etc.).
+     * @param requestMetricCollector
+     *            client specific request metric collector, which takes
+     *            precedence over the one at the AWS SDK level; or null if there
+     *            is none.
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. Pass
+     *            'null' to use the default factory.
+     */
+    public AmazonHttpClient(ClientConfiguration config,
+            RequestMetricCollector requestMetricCollector,
+            SSLSocketFactory sslSocketFactory) {
+        this(config, httpClientFactory.createHttpClient(config,
+                sslSocketFactory), requestMetricCollector);
     }
 
     /**

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/HttpClientFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/HttpClientFactory.java
@@ -86,6 +86,23 @@ class HttpClientFactory {
      * @return The new, configured HttpClient.
      */
     public HttpClient createHttpClient(ClientConfiguration config) {
+    	return createHttpClient(config, null);
+    }
+
+    /**
+     * Creates a new HttpClient object using the specified AWS
+     * ClientConfiguration to configure the client. The client is configured to
+     * use the supplied SSL socket factory.
+     * 
+     * @param config
+     *            Client configuration options (ex: proxy settings, connection
+     *            limits, etc).
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. If 'null'
+     *            it is ignored and the default socket factory is used instead.
+     * @return The new, configured HttpClient.
+     */
+    public HttpClient createHttpClient(ClientConfiguration config, SSLSocketFactory sslSocketFactory) {
         /* Set HTTP client parameters */
         HttpParams httpClientParams = new BasicHttpParams();
         HttpConnectionParams.setConnectionTimeout(httpClientParams, config.getConnectionTimeout());
@@ -113,10 +130,12 @@ class HttpClientFactory {
 
         try {
             Scheme http = new Scheme("http", 80, PlainSocketFactory.getSocketFactory());
-            SdkTLSSocketFactory sf = new SdkTLSSocketFactory(
-                    SSLContext.getDefault(),
-                    SSLSocketFactory.STRICT_HOSTNAME_VERIFIER);
-            Scheme https = new Scheme("https", 443, sf);
+            if (sslSocketFactory == null) {
+                sslSocketFactory = new SdkTLSSocketFactory(
+                        SSLContext.getDefault(),
+                        SSLSocketFactory.STRICT_HOSTNAME_VERIFIER);
+            }
+            Scheme https = new Scheme("https", 443, sslSocketFactory);
             SchemeRegistry sr = connectionManager.getSchemeRegistry();
             sr.register(http);
             sr.register(https);

--- a/aws-java-sdk-ec2/src/main/java/com/amazonaws/services/ec2/AmazonEC2Client.java
+++ b/aws-java-sdk-ec2/src/main/java/com/amazonaws/services/ec2/AmazonEC2Client.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.ec2;
 
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.w3c.dom.*;
 
 import java.net.*;
@@ -193,7 +194,37 @@ public class AmazonEC2Client extends AmazonWebServiceClient implements AmazonEC2
     public AmazonEC2Client(AWSCredentialsProvider awsCredentialsProvider,
             ClientConfiguration clientConfiguration,
             RequestMetricCollector requestMetricCollector) {
-        super(clientConfiguration, requestMetricCollector);
+        this(awsCredentialsProvider, clientConfiguration,
+                requestMetricCollector, null);
+    }
+
+    /**
+     * Constructs a new client to invoke service methods on AmazonEC2 using the
+     * specified AWS account credentials provider, client configuration options,
+     * request metric collector and SSL socket factory.
+     * 
+     * <p>
+     * All service calls made using this new client object are blocking, and
+     * will not return until the service call completes.
+     * 
+     * @param awsCredentialsProvider
+     *            The AWS credentials provider which will provide credentials to
+     *            authenticate requests with AWS services.
+     * @param clientConfiguration
+     *            The client configuration options controlling how this client
+     *            connects to AmazonEC2 (ex: proxy settings, retry counts,
+     *            etc.).
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. Pass
+     *            'null' to use the default factory.
+     * @param requestMetricCollector
+     *            optional request metric collector
+     */
+    public AmazonEC2Client(AWSCredentialsProvider awsCredentialsProvider,
+            ClientConfiguration clientConfiguration,
+            RequestMetricCollector requestMetricCollector,
+            SSLSocketFactory sslSocketFactory) {
+        super(clientConfiguration, requestMetricCollector, sslSocketFactory);
         this.awsCredentialsProvider = awsCredentialsProvider;
         init();
     }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -44,6 +44,7 @@ import java.util.regex.Matcher;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
@@ -410,7 +411,33 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
     public AmazonS3Client(AWSCredentialsProvider credentialsProvider,
             ClientConfiguration clientConfiguration,
             RequestMetricCollector requestMetricCollector) {
-        super(clientConfiguration, requestMetricCollector);
+        this(credentialsProvider, clientConfiguration, requestMetricCollector,
+                null);
+    }
+
+    /**
+     * Constructs a new Amazon S3 client using the specified AWS credentials,
+     * client configuration, request metric collector and SSL socket factory to
+     * access Amazon S3.
+     * 
+     * @param credentialsProvider
+     *            The AWS credentials provider which will provide credentials to
+     *            authenticate requests with AWS services.
+     * @param clientConfiguration
+     *            The client configuration options controlling how this client
+     *            connects to Amazon S3 (e.g. proxy settings, retry counts,
+     *            etc).
+     * @param requestMetricCollector
+     *            request metric collector
+     * @param sslSocketFactory
+     *            client is configured to use this SSL socket factory. Pass
+     *            'null' to use the default factory.
+     */
+    public AmazonS3Client(AWSCredentialsProvider credentialsProvider,
+            ClientConfiguration clientConfiguration,
+            RequestMetricCollector requestMetricCollector,
+            SSLSocketFactory sslSocketFactory) {
+        super(clientConfiguration, requestMetricCollector, sslSocketFactory);
         this.awsCredentialsProvider = credentialsProvider;
         init();
     }


### PR DESCRIPTION
- Currently there is no way to configure AWS clients with a custom
  'SSLSocketFactory'.
  'HttpClientFactory' constructs the factory by using the default
  SSLContext of the system.
- Overloaded the constructors of EC2, S3 and Cloud watch clients (to
  beginwith) to accept a custom 'SSLSocketFactory'.
