### PR TITLE
Ignore case of S3 custom meta-data headers when getting Object

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
@@ -105,8 +105,8 @@ public abstract class AbstractS3ResponseHandler<T>
     protected void populateObjectMetadata(HttpResponse response, ObjectMetadata metadata) {
         for (Entry<String, String> header : response.getHeaders().entrySet()) {
             String key = header.getKey();
-            if (key.startsWith(Headers.S3_USER_METADATA_PREFIX)) {
-                key = key.substring(Headers.S3_USER_METADATA_PREFIX.length());
+            if (key.toLowerCase().startsWith(Headers.S3_USER_METADATA_PREFIX)) {
+                key = key.substring(Headers.S3_USER_METADATA_PREFIX.length()).toLowerCase();
                 metadata.addUserMetadata(key, header.getValue());
             } else if (ignoredHeaders.contains(key)) {
                 // ignore...


### PR DESCRIPTION
As per the HTTP/1.1 RFC, the message headers should be case-insensitive

http://tools.ietf.org/html/rfc2616#section-4.2

In line with the S3 documentation, the user-defined meta data keys should always be lower-cased:

http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html