### PR TITLE
Adding support for marshaling/unmarshaling sets of arbitrary values.

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/ObjectSetToListMarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/ObjectSetToListMarshaller.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2014-2014 Amazon Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.datamodeling.marshallers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.ArgumentMarshaller;
+import com.amazonaws.services.dynamodbv2.datamodeling.ArgumentMarshaller.ListAttributeMarshaller;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+public class ObjectSetToListMarshaller implements ListAttributeMarshaller {
+
+    private static final ObjectSetToListMarshaller INSTANCE =
+            new ObjectSetToListMarshaller();
+
+    public static ObjectSetToListMarshaller instance() {
+        return INSTANCE;
+    }
+
+
+    private final ArgumentMarshaller memberMarshaller;
+
+    private ObjectSetToListMarshaller() {
+        memberMarshaller = null;
+    }
+
+    public ObjectSetToListMarshaller(ArgumentMarshaller memberMarshaller) {
+        if (memberMarshaller == null) {
+            throw new NullPointerException("memberMarshaller");
+        }
+        this.memberMarshaller = memberMarshaller;
+    }
+
+    @Override
+    public AttributeValue marshall(Object obj) {
+        if (memberMarshaller == null) {
+            throw new IllegalStateException(
+                    "No member marshaller configured!");
+        }
+
+        Set<?> objects = (Set<?>) obj;
+        List<AttributeValue> values =
+                new ArrayList<AttributeValue>(objects.size());
+
+        for (Object o : objects) {
+            AttributeValue value;
+            if (o == null) {
+                value = new AttributeValue().withNULL(true);
+            } else {
+                value = memberMarshaller.marshall(o);
+            }
+
+            values.add(value);
+        }
+
+        AttributeValue result = new AttributeValue();
+        result.setL(values);
+        return result;
+    }
+
+    public ArgumentMarshaller getMemberMarshaller() {
+        return memberMarshaller;
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/ObjectSetUnmarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/ObjectSetUnmarshaller.java
@@ -1,0 +1,46 @@
+package com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers;
+
+import java.text.ParseException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.ArgumentUnmarshaller;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+public class ObjectSetUnmarshaller extends LUnmarshaller {
+
+    private static final ObjectSetUnmarshaller INSTANCE =
+            new ObjectSetUnmarshaller();
+
+    public static ObjectSetUnmarshaller instance() {
+        return INSTANCE;
+    }
+
+    private final ArgumentUnmarshaller memberUnmarshaller;
+
+    private ObjectSetUnmarshaller() {
+        memberUnmarshaller = null;
+    }
+
+    public ObjectSetUnmarshaller(ArgumentUnmarshaller memberUnmarshaller) {
+        if (memberUnmarshaller == null) {
+            throw new NullPointerException("memberUnmarshaller");
+        }
+        this.memberUnmarshaller = memberUnmarshaller;
+    }
+
+    @Override
+    public Object unmarshall(AttributeValue value) throws ParseException {
+        List<AttributeValue> values = value.getL();
+        Set<Object> objects =  new HashSet<Object>(
+                Math.max((int) (values.size()/.75f) + 1, 16));
+
+        for (AttributeValue v : values) {
+            memberUnmarshaller.typeCheck(v, null);
+            objects.add(memberUnmarshaller.unmarshall(v));
+        }
+
+        return objects;
+    }
+}


### PR DESCRIPTION
See https://github.com/aws/aws-sdk-java/issues/331

Sets of types that are not already stored in one of DynamoDB's native set types are recursively marshaled and stored in a list when ConversionSchemas.V2 is selected. V1 and V1_COMPATIBLE continue to store sets of arbitrary types as DynamoDB string sets (with no way to unmarshal the original objects back out). All schemas can unmarshal data from lists to sets.

This (as a side effect) adds back support for Set<Boolean>, which V1 stored as a number set (1/0 for true/false). V2 dropped support since Set<Boolean> is a little silly, but there doesn't seem to be a compelling reason for going out of the way to block it.

This will prevent us from ever adding explicit mappings from Set<T> to one of DynamoDB's native set types without bumping to ConversionSchema.V3. That seems reasonable to me - the only thing that immediately springs to mind that I'd want to do is maybe Java 8's Temporal types similarly to how we do Date and Calendar? Not sure that there's a good way to add support for those until we drop support for Java 6 and 7 at some point in the far distant future though.