### PR TITLE
Bug fix for updating dynamodb table from Table object

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/Table.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/Table.java
@@ -358,6 +358,7 @@ public class Table implements PutItemApi, GetItemApi, QueryApi, ScanApi,
     public TableDescription updateTable(
             ProvisionedThroughput provisionedThroughput) {
         return updateTable(new UpdateTableSpec()
+            .withTableName(tableName)
             .withProvisionedThroughput(provisionedThroughput));
     }
 

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/UpdateTableSpec.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/UpdateTableSpec.java
@@ -25,6 +25,11 @@ public class UpdateTableSpec extends AbstractSpec<UpdateTableRequest> {
         super(new UpdateTableRequest());
     }
 
+    public UpdateTableSpec withTableName(String tableName) {
+        getRequest().setTableName(tableName);
+        return this;
+    }
+
     public ProvisionedThroughput getProvisionedThroughput() {
         return getRequest().getProvisionedThroughput();
     }


### PR DESCRIPTION
Table.updateTable method creates new UpdateTableSpec object without table name parameter for request. So it throws AmazonServiceException, its message like "The parameter 'TableName' is required but was not present in the request".