### PR TITLE
Modularisation of SDK breaks OSGi bundle imports

### DIFF
--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -325,8 +325,8 @@
         <configuration>
           <instructions>
             <Export-Package>com.amazonaws.*</Export-Package>
-            <Import-Package>!org.junit.*,!org.springframework.*,!org.aspectj.*,org.apache.http.conn.routing,*</Import-Package>
-            <Embed-Dependency>*;scope=compile</Embed-Dependency>
+            <Import-Package>!org.junit.*,!org.springframework.*,!org.apache.avalon.*,!org.apache.log.*,!org.aspectj.*,org.apache.http.conn.routing,*</Import-Package>
+            <Embed-Dependency>*;scope=compile;inline=true</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
           </instructions>
         </configuration>

--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -325,7 +325,7 @@
         <configuration>
           <instructions>
             <Export-Package>com.amazonaws.*</Export-Package>
-            <Import-Package>!org.junit.*,!org.springframework.*,!org.aspectj.*,*</Import-Package>
+            <Import-Package>!org.junit.*,!org.springframework.*,!org.aspectj.*,org.apache.http.conn.routing,*</Import-Package>
             <Embed-Dependency>*;scope=compile</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
           </instructions>


### PR DESCRIPTION
The SDK modularisation breaks the OSGi bundle as BNDTools does not have
visibility of all the imports that are required. This results in a
ClassNotFoundException at runtime