### PR TITLE
DynamoDB UUID marshallers

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/ConversionSchemas.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/ConversionSchemas.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -60,9 +61,11 @@ import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.NumberSetToNum
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.NumberToNumberMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.ObjectSetToStringSetMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.ObjectToMapMarshaller;
+import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.ObjectToStringMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.S3LinkToStringMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.StringSetToStringSetMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.StringToStringMarshaller;
+import com.amazonaws.services.dynamodbv2.datamodeling.marshallers.UUIDSetToStringSetMarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.BigDecimalSetUnmarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.BigDecimalUnmarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.BigIntegerSetUnmarshaller;
@@ -98,6 +101,8 @@ import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.ShortSetUnma
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.ShortUnmarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.StringSetUnmarshaller;
 import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.StringUnmarshaller;
+import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.UUIDSetUnmarshaller;
+import com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers.UUIDUnmarshaller;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 
 /**
@@ -827,6 +832,9 @@ public final class ConversionSchemas {
 
         list.add(Pair.of(String.class,
                 StringToStringMarshaller.instance()));
+        
+        list.add(Pair.of(UUID.class,
+                ObjectToStringMarshaller.instance()));
     }
 
     private static void addStandardBinaryMarshallers(
@@ -878,6 +886,9 @@ public final class ConversionSchemas {
 
         list.add(Pair.of(String.class,
                 StringSetToStringSetMarshaller.instance()));
+
+        list.add(Pair.of(UUID.class,
+                UUIDSetToStringSetMarshaller.instance()));
     }
 
     private static void addStandardBinarySetMarshallers(
@@ -1033,6 +1044,7 @@ public final class ConversionSchemas {
                     ByteArrayUnmarshaller.instance()));
 
             list.add(Pair.of(S3Link.class, S3LinkUnmarshaller.instance()));
+            list.add(Pair.of(UUID.class, UUIDUnmarshaller.instance()));
             list.add(Pair.of(String.class, StringUnmarshaller.instance()));
 
             list.add(Pair.of(List.class, ListUnmarshaller.instance()));
@@ -1083,6 +1095,7 @@ public final class ConversionSchemas {
             list.add(Pair.of(byte[].class,
                     ByteArraySetUnmarshaller.instance()));
 
+            list.add(Pair.of(UUID.class, UUIDSetUnmarshaller.instance()));
             list.add(Pair.of(String.class, StringSetUnmarshaller.instance()));
 
             // Make sure I'm last since I'll catch all other types.

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/ObjectToStringMarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/ObjectToStringMarshaller.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2014-2015 Amazon Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.datamodeling.marshallers;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.ArgumentMarshaller.StringAttributeMarshaller;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+/**
+ * A marshaller that marshals Java {@code Object} objects into DynamoDB
+ * Strings.
+ * 
+ * @author Sergei Egorov
+ */
+public class ObjectToStringMarshaller implements StringAttributeMarshaller {
+
+    private static final ObjectToStringMarshaller INSTANCE =
+            new ObjectToStringMarshaller();
+
+    public static ObjectToStringMarshaller instance() {
+        return INSTANCE;
+    }
+
+    private ObjectToStringMarshaller() {
+    }
+
+    @Override
+    public AttributeValue marshall(Object obj) {
+        return new AttributeValue().withS(obj.toString());
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/UUIDSetToStringSetMarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/marshallers/UUIDSetToStringSetMarshaller.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014-2015 Amazon Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.datamodeling.marshallers;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.ArgumentMarshaller.StringSetAttributeMarshaller;
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * A marshaller that marshals sets of Java {@code Object} objects into
+ * DynamoDB StringSets.
+ * 
+ * @author Sergei Egorov
+ */
+public class UUIDSetToStringSetMarshaller
+        implements StringSetAttributeMarshaller {
+
+    private static final UUIDSetToStringSetMarshaller INSTANCE =
+            new UUIDSetToStringSetMarshaller();
+
+    public static UUIDSetToStringSetMarshaller instance() {
+        return INSTANCE;
+    }
+
+    private UUIDSetToStringSetMarshaller() {
+    }
+
+    @Override
+    public AttributeValue marshall(Object obj) {
+        @SuppressWarnings("unchecked")
+        Set<UUID> uuids = (Set<UUID>) obj;
+
+        List<String> strings = new ArrayList<String>(uuids.size());
+        for (UUID uuid : uuids) {
+            strings.add(uuid.toString());
+        }
+
+        return new AttributeValue().withSS(strings);
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/UUIDSetUnmarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/UUIDSetUnmarshaller.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2014-2015 Amazon Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.*;
+
+/**
+ * An unmarshaller that unmarshals sets of UUIDs as sets of
+ * Java {@code UUID} objects.
+ * 
+ * @author Sergei Egorov
+ */
+public class UUIDSetUnmarshaller extends SSUnmarshaller {
+
+    private static final UUIDSetUnmarshaller INSTANCE =
+            new UUIDSetUnmarshaller();
+
+    public static UUIDSetUnmarshaller instance() {
+        return INSTANCE;
+    }
+
+    private UUIDSetUnmarshaller() {
+    }
+
+    @Override
+    public Object unmarshall(AttributeValue value) {
+        Set<UUID> result = new HashSet<UUID>();
+
+        for (String s : value.getSS()) {
+            result.add(UUID.fromString(s));
+        }
+
+        return result;
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/UUIDUnmarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/unmarshallers/UUIDUnmarshaller.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2014-2015 Amazon Technologies, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at:
+ *
+ *    http://aws.amazon.com/apache2.0
+ *
+ * This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES
+ * OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.amazonaws.services.dynamodbv2.datamodeling.unmarshallers;
+
+import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+
+import java.util.UUID;
+
+/**
+ * An unmarshaller that unmarshals UUIDs as Java
+ * {@code UUID} objects.
+ * 
+ * @author Sergei Egorov
+ */
+public class UUIDUnmarshaller extends SUnmarshaller {
+
+    private static final UUIDUnmarshaller INSTANCE =
+            new UUIDUnmarshaller();
+
+    public static UUIDUnmarshaller instance() {
+        return INSTANCE;
+    }
+
+    private UUIDUnmarshaller() {
+    }
+
+    @Override
+    public Object unmarshall(AttributeValue value) {
+        return UUID.fromString(value.getS());
+    }
+}


### PR DESCRIPTION
Hi!

We're using UUIDs as ID type in our application, and it's little bit annoying to add custom marshaller to every UUID field. It's basic Java type and IMHO it should be supported as well as other types.


Thanks!