### PR TITLE
Add feature to set default profile name via system property for ProfileCredentialsProvider

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfileCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfileCredentialsProvider.java
@@ -97,12 +97,18 @@ public class ProfileCredentialsProvider implements AWSCredentialsProvider {
     public ProfileCredentialsProvider(ProfilesConfigFile profilesConfigFile, String profileName) {
         this.profilesConfigFile = profilesConfigFile;
         if (profileName == null) {
-            String profileOverride = System.getenv(ProfilesConfigFile.AWS_PROFILE_ENVIRONMENT_VARIABLE);
-            profileOverride = StringUtils.trim(profileOverride);
-            if (!StringUtils.isNullOrEmpty(profileOverride)) {
-                this.profileName = profileOverride;
+            String profileEnvVarOverride = System.getenv(ProfilesConfigFile.AWS_PROFILE_ENVIRONMENT_VARIABLE);
+            profileEnvVarOverride = StringUtils.trim(profileEnvVarOverride);
+            if (!StringUtils.isNullOrEmpty(profileEnvVarOverride)) {
+                this.profileName = profileEnvVarOverride;
             } else {
-                this.profileName = ProfilesConfigFile.DEFAULT_PROFILE_NAME;
+                String profileSysPropOverride = System.getProperty(ProfilesConfigFile.AWS_PROFILE_SYSTEM_PROPERTY);
+                profileSysPropOverride = StringUtils.trim(profileSysPropOverride);
+                if (!StringUtils.isNullOrEmpty(profileSysPropOverride)) {
+                    this.profileName = profileSysPropOverride;
+                } else {
+                    this.profileName = ProfilesConfigFile.DEFAULT_PROFILE_NAME;
+                }
             }
         } else {
             this.profileName = profileName;

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
@@ -64,6 +64,9 @@ public class ProfilesConfigFile {
     /** Environment variable name for overriding the default AWS profile */
     public static final String AWS_PROFILE_ENVIRONMENT_VARIABLE = "AWS_PROFILE";
 
+    /** System property name for overriding the default AWS profile */
+    public static final String AWS_PROFILE_SYSTEM_PROPERTY = "aws.profile";
+
     /** Environment variable specifying an alternate location for the AWS credential profiles file */
     @Deprecated
     private static final String LEGACY_CONFIG_FILE_ENVIRONMENT_VARIABLE = "AWS_CONFIG_FILE";


### PR DESCRIPTION
Each default constructor of API client (ex. AmazonEC2Client) class uses DefaultAWSCredentialsProviderChain.
This chain uses ProfileCredentialsProvider with no argument constructor.

The profile name which this ProfileCredentialsProvider uses is environment variable AWS_PROFILE or "default".
There is no way to control the profile name via system property.

This pull-request enable above.