### PR TITLE
skipping bridge methods when looking for relevant getters

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBReflector.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBReflector.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws.services.dynamodbv2.datamodeling;
 
+import org.apache.http.annotation.GuardedBy;
+
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.HashMap;
@@ -23,8 +25,6 @@ import java.util.Map;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.ReadLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock.WriteLock;
-
-import org.apache.http.annotation.GuardedBy;
 
 /**
  * Reflection assistant for {@link DynamoDBMapper}
@@ -88,6 +88,7 @@ class DynamoDBReflector {
     private static boolean isRelevantGetter(Method m) {
         return (m.getName().startsWith("get") || m.getName().startsWith("is"))
                 && m.getParameterTypes().length == 0
+                && !m.isBridge()
                 && isDocumentType(m.getDeclaringClass())
                 && !ReflectionUtils.getterOrFieldHasAnnotation(m, DynamoDBIgnore.class);
     }


### PR DESCRIPTION
Currently `DynamoDBReflector` isn't ignoring bridge methods which is causing problems when using generic base classes. For example in case of the classes below `User.class.getMethods()` will return 2 versions of the `getId()` method. Correct one returning UUID and bridge one returning Object. Trying to save such user will result in `DynamoDBMappingException` with message _Cannot marshall type class java.lang.Object without a custom marshaler or @DynamoDBDocument annotation_. This change should solve this problem by ignoring bridge methods.

```java
public abstract class Identifiable<ID> {
    protected ID id;
    public ID getId() {  id; }
    public void setId(ID id) {  this.id = id;}
}

@DynamoDBTable(tableName = "user")
public class User extends Identifiable<UUID> {
    @DynamoDBHashKey(attributeName = "id")
    @DynamoDBMarshalling(marshallerClass = UUIDMarshaller.class)
    public UUID getId() {  id;  }

    public void setId(UUID id) {this.id = id; }
}
```

