### PR TITLE
Add methods to EC2MetadataUtils: getSubnetId() and getVpcIPv4CidrBlock()

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
@@ -602,6 +602,23 @@ public class EC2MetadataUtils {
         }
 
         /**
+         * ID of the Amazon EC2-VPC subnet in which the interface resides.<br>
+         * Returned only for Amazon EC2 instances launched into a VPC.
+         */
+        public String getSubnetId() {
+            return getData("subnet-id");
+        }
+
+        /**
+         * The CIDR block of the Amazon EC2-VPC in which the interface
+         * resides.<br>
+         * Returned only for Amazon EC2 instances launched into a VPC.
+         */
+        public String getVpcIPv4CidrBlock() {
+            return getData("vpc-ipv4-cidr-block");
+        }
+
+        /**
          * ID of the Amazon EC2-VPC in which the interface resides.<br>
          * Returned only for Amazon EC2 instances launched into a VPC.
          */

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
@@ -602,8 +602,7 @@ public class EC2MetadataUtils {
         }
 
         /**
-         * The CIDR block of the Amazon EC2-VPC subnet in which the interface
-         * resides.<br>
+         * ID of the Amazon EC2-VPC in which the interface resides.<br>
          * Returned only for Amazon EC2 instances launched into a VPC.
          */
         public String getVpcId() {


### PR DESCRIPTION
modifications to `com.amazonaws.util.EC2MetadataUtils.NetworkInterface`

- fixed JavaDoc for `public String getVpcId()`
- added `public String getSubnetId()`
- added `public String getVpcIPv4CidrBlock()`