### PR TITLE
Expose more underlying query and scan request options in DynamoDBMapper:

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -2145,6 +2145,9 @@ public class DynamoDBMapper {
 
         result.setResults(marshallIntoObjects(parameters));
         result.setLastEvaluatedKey(scanResult.getLastEvaluatedKey());
+        result.setCount(scanResult.getCount());
+        result.setScannedCount(scanResult.getScannedCount());
+        result.setConsumedCapacity(scanResult.getConsumedCapacity());
 
         return result;
     }
@@ -2253,13 +2256,16 @@ public class DynamoDBMapper {
 
         QueryRequest queryRequest = createQueryRequestFromExpression(clazz, queryExpression, config);
 
-        QueryResult scanResult = db.query(applyUserAgent(queryRequest));
+        QueryResult queryResult = db.query(applyUserAgent(queryRequest));
         QueryResultPage<T> result = new QueryResultPage<T>();
         List<AttributeTransformer.Parameters<T>> parameters =
-            toParameters(scanResult.getItems(), clazz, queryRequest.getTableName(), config);
+            toParameters(queryResult.getItems(), clazz, queryRequest.getTableName(), config);
 
         result.setResults(marshallIntoObjects(parameters));
-        result.setLastEvaluatedKey(scanResult.getLastEvaluatedKey());
+        result.setLastEvaluatedKey(queryResult.getLastEvaluatedKey());
+        result.setCount(queryResult.getCount());
+        result.setScannedCount(queryResult.getScannedCount());
+        result.setConsumedCapacity(queryResult.getConsumedCapacity());
 
         return result;
     }
@@ -2381,6 +2387,9 @@ public class DynamoDBMapper {
         scanRequest.setExpressionAttributeValues(scanExpression
                 .getExpressionAttributeValues());
         scanRequest.setRequestMetricCollector(config.getRequestMetricCollector());
+        scanRequest.setSelect(scanExpression.getSelect());
+        scanRequest.setProjectionExpression(scanExpression.getProjectionExpression());
+        scanRequest.setReturnConsumedCapacity(scanExpression.getReturnConsumedCapacity());
 
         return applyUserAgent(scanRequest);
     }
@@ -2437,6 +2446,9 @@ public class DynamoDBMapper {
                 .getExpressionAttributeNames());
         queryRequest.setExpressionAttributeValues(queryExpression
                 .getExpressionAttributeValues());
+        queryRequest.setSelect(queryExpression.getSelect());
+        queryRequest.setProjectionExpression(queryExpression.getProjectionExpression());
+        queryRequest.setReturnConsumedCapacity(queryExpression.getReturnConsumedCapacity());
 
         return applyUserAgent(queryRequest);
     }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBQueryExpression.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBQueryExpression.java
@@ -21,6 +21,8 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
+import com.amazonaws.services.dynamodbv2.model.Select;
 
 /**
  * A query expression.
@@ -52,6 +54,72 @@ public class DynamoDBQueryExpression <T> {
      * One or more values that can be substituted in an expression.
      */
     private java.util.Map<String, AttributeValue> expressionAttributeValues;
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index. <ul> <li> <p><code>ALL_ATTRIBUTES</code> - Returns all of
+     * the item attributes from the specified table or index. If you query a
+     * local secondary index, then for each matching item in the index
+     * DynamoDB will fetch the entire item from the parent table. If the
+     * index is configured to project all item attributes, then all of the
+     * data can be obtained from the local secondary index, and no fetching
+     * is required. </li> <li> <p><code>ALL_PROJECTED_ATTRIBUTES</code> -
+     * Allowed only when querying an index. Retrieves all attributes that
+     * have been projected into the index. If the index is configured to
+     * project all attributes, this return value is equivalent to specifying
+     * <code>ALL_ATTRIBUTES</code>. </li> <li> <p><code>COUNT</code> -
+     * Returns the number of matching items, rather than the matching items
+     * themselves. </li> <li> <p> <code>SPECIFIC_ATTRIBUTES</code> - Returns
+     * only the attributes listed in <i>AttributesToGet</i>. This return
+     * value is equivalent to specifying <i>AttributesToGet</i> without
+     * specifying any value for <i>Select</i>. <p>If you query a local
+     * secondary index and request only attributes that are projected into
+     * that index, the operation will read only the index and not the table.
+     * If any of the requested attributes are not projected into the local
+     * secondary index, DynamoDB will fetch each of these attributes from the
+     * parent table. This extra fetching incurs additional throughput cost
+     * and latency. <p>If you query a global secondary index, you can only
+     * request attributes that are projected into the index. Global secondary
+     * index queries cannot fetch attributes from the parent table. </li>
+     * </ul> <p>If neither <i>Select</i> nor <i>AttributesToGet</i> are
+     * specified, DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when
+     * accessing a table, and <code>ALL_PROJECTED_ATTRIBUTES</code> when
+     * accessing an index. You cannot use both <i>Select</i> and
+     * <i>AttributesToGet</i> together in a single request, unless the value
+     * for <i>Select</i> is <code>SPECIFIC_ATTRIBUTES</code>. (This usage is
+     * equivalent to specifying <i>AttributesToGet</i> without any value for
+     * <i>Select</i>.)
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     */
+    private String select;
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    private String projectionExpression;
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     */
+    private String returnConsumedCapacity;
 
     /**
      * Returns whether this query uses consistent reads.
@@ -209,7 +277,7 @@ public class DynamoDBQueryExpression <T> {
     /**
      * Sets the range key condition for this query. All range key attributes for
      * the table must be specified by attribute name in the map.
-     * 
+     *
      * @param rangeKeyConditions a map from key name to condition
      * 	        NOTE: The current DynamoDB service only allows up to one
      *          range key condition per query. Providing more than one
@@ -222,7 +290,7 @@ public class DynamoDBQueryExpression <T> {
     /**
      * Sets the range key condition for this query. All range key attributes for
      * the table must be specified by attribute name in the map.
-     * 
+     *
      * @param rangeKeyConditions a map from key name to condition
      *         NOTE: The current DynamoDB service only allows up to one range
      *         key condition per query. Providing more than one range key
@@ -594,6 +662,315 @@ public class DynamoDBQueryExpression <T> {
      */
     public DynamoDBQueryExpression<T> clearExpressionAttributeValuesEntries() {
         this.expressionAttributeValues = null;
+        return this;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @return The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public String getSelect() {
+        return select;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public void setSelect(String select) {
+        this.select = select;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public DynamoDBQueryExpression<T> withSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public void setSelect(Select select) {
+        this.select = select.toString();
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public DynamoDBQueryExpression<T> withSelect(Select select) {
+        this.select = select.toString();
+        return this;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public String getProjectionExpression() {
+        return projectionExpression;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @param projectionExpression A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public void setProjectionExpression(String projectionExpression) {
+        this.projectionExpression = projectionExpression;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     *
+     * @param projectionExpression A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     */
+    public DynamoDBQueryExpression<T> withProjectionExpression(String projectionExpression) {
+        this.projectionExpression = projectionExpression;
+        return this;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @return A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public String getReturnConsumedCapacity() {
+        return returnConsumedCapacity;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public void setReturnConsumedCapacity(String returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public DynamoDBQueryExpression<T> withReturnConsumedCapacity(String returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity;
+        return this;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public void setReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity.toString();
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public DynamoDBQueryExpression<T> withReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity.toString();
         return this;
     }
 }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBScanExpression.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBScanExpression.java
@@ -21,7 +21,9 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.ComparisonOperator;
 import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
 import com.amazonaws.services.dynamodbv2.model.ScanRequest;
+import com.amazonaws.services.dynamodbv2.model.Select;
 
 /**
  * Options for filtering results from a scan operation. For example, callers can
@@ -99,6 +101,72 @@ public class DynamoDBScanExpression {
      * (:a,:b,:c)</code></li></ul>
      */
     private java.util.Map<String,AttributeValue> expressionAttributeValues;
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index. <ul> <li> <p><code>ALL_ATTRIBUTES</code> - Returns all of
+     * the item attributes from the specified table or index. If you query a
+     * local secondary index, then for each matching item in the index
+     * DynamoDB will fetch the entire item from the parent table. If the
+     * index is configured to project all item attributes, then all of the
+     * data can be obtained from the local secondary index, and no fetching
+     * is required. </li> <li> <p><code>ALL_PROJECTED_ATTRIBUTES</code> -
+     * Allowed only when querying an index. Retrieves all attributes that
+     * have been projected into the index. If the index is configured to
+     * project all attributes, this return value is equivalent to specifying
+     * <code>ALL_ATTRIBUTES</code>. </li> <li> <p><code>COUNT</code> -
+     * Returns the number of matching items, rather than the matching items
+     * themselves. </li> <li> <p> <code>SPECIFIC_ATTRIBUTES</code> - Returns
+     * only the attributes listed in <i>AttributesToGet</i>. This return
+     * value is equivalent to specifying <i>AttributesToGet</i> without
+     * specifying any value for <i>Select</i>. <p>If you query a local
+     * secondary index and request only attributes that are projected into
+     * that index, the operation will read only the index and not the table.
+     * If any of the requested attributes are not projected into the local
+     * secondary index, DynamoDB will fetch each of these attributes from the
+     * parent table. This extra fetching incurs additional throughput cost
+     * and latency. <p>If you query a global secondary index, you can only
+     * request attributes that are projected into the index. Global secondary
+     * index queries cannot fetch attributes from the parent table. </li>
+     * </ul> <p>If neither <i>Select</i> nor <i>AttributesToGet</i> are
+     * specified, DynamoDB defaults to <code>ALL_ATTRIBUTES</code> when
+     * accessing a table, and <code>ALL_PROJECTED_ATTRIBUTES</code> when
+     * accessing an index. You cannot use both <i>Select</i> and
+     * <i>AttributesToGet</i> together in a single request, unless the value
+     * for <i>Select</i> is <code>SPECIFIC_ATTRIBUTES</code>. (This usage is
+     * equivalent to specifying <i>AttributesToGet</i> without any value for
+     * <i>Select</i>.)
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     */
+    private String select;
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    private String projectionExpression;
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     */
+    private String returnConsumedCapacity;
 
     /**
      * Optional index name that can be specified for the scan operation.
@@ -570,6 +638,315 @@ public class DynamoDBScanExpression {
      */
     public DynamoDBScanExpression clearExpressionAttributeValuesEntries() {
         this.expressionAttributeValues = null;
+        return this;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @return The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public String getSelect() {
+        return select;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public void setSelect(String select) {
+        this.select = select;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public DynamoDBScanExpression withSelect(String select) {
+        this.select = select;
+        return this;
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public void setSelect(Select select) {
+        this.select = select.toString();
+    }
+
+    /**
+     * The attributes to be returned in the result. You can retrieve all item
+     * attributes, specific item attributes, the count of matching items, or
+     * in the case of an index, some or all of the attributes projected into
+     * the index.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>ALL_ATTRIBUTES, ALL_PROJECTED_ATTRIBUTES, SPECIFIC_ATTRIBUTES, COUNT
+     *
+     * @param select The attributes to be returned in the result. You can retrieve all item
+     *         attributes, specific item attributes, the count of matching items, or
+     *         in the case of an index, some or all of the attributes projected into
+     *         the index.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.Select
+     */
+    public DynamoDBScanExpression withSelect(Select select) {
+        this.select = select.toString();
+        return this;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public String getProjectionExpression() {
+        return projectionExpression;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @param projectionExpression A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public void setProjectionExpression(String projectionExpression) {
+        this.projectionExpression = projectionExpression;
+    }
+
+    /**
+     * A string that identifies one or more attributes to retrieve from the
+     * table. These attributes can include scalars, sets, or elements of a
+     * JSON document. The attributes in the expression must be separated by
+     * commas. <p>If no attribute names are specified, then all attributes
+     * will be returned. If any of the requested attributes are not found,
+     * they will not appear in the result. <p>For more information, go to <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     * Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     *
+     * @param projectionExpression A string that identifies one or more attributes to retrieve from the
+     *         table. These attributes can include scalars, sets, or elements of a
+     *         JSON document. The attributes in the expression must be separated by
+     *         commas. <p>If no attribute names are specified, then all attributes
+     *         will be returned. If any of the requested attributes are not found,
+     *         they will not appear in the result. <p>For more information, go to <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.AccessingItemAttributes.html">Accessing
+     *         Item Attributes</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     */
+    public DynamoDBScanExpression withProjectionExpression(String projectionExpression) {
+        this.projectionExpression = projectionExpression;
+        return this;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @return A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public String getReturnConsumedCapacity() {
+        return returnConsumedCapacity;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public void setReturnConsumedCapacity(String returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public DynamoDBScanExpression withReturnConsumedCapacity(String returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity;
+        return this;
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public void setReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity.toString();
+    }
+
+    /**
+     * A value that if set to <code>TOTAL</code>, the response includes
+     * <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     * <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     * for indexes. If set to <code>NONE</code> (the default),
+     * <i>ConsumedCapacity</i> is not included in the response.
+     * <p>
+     * Returns a reference to this object so that method calls can be chained together.
+     * <p>
+     * <b>Constraints:</b><br/>
+     * <b>Allowed Values: </b>INDEXES, TOTAL, NONE
+     *
+     * @param returnConsumedCapacity A value that if set to <code>TOTAL</code>, the response includes
+     *         <i>ConsumedCapacity</i> data for tables and indexes. If set to
+     *         <code>INDEXES</code>, the response includes <i>ConsumedCapacity</i>
+     *         for indexes. If set to <code>NONE</code> (the default),
+     *         <i>ConsumedCapacity</i> is not included in the response.
+     *
+     * @return A reference to this updated object so that method calls can be chained
+     *         together.
+     *
+     * @see com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity
+     */
+    public DynamoDBScanExpression withReturnConsumedCapacity(ReturnConsumedCapacity returnConsumedCapacity) {
+        this.returnConsumedCapacity = returnConsumedCapacity.toString();
         return this;
     }
 }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/QueryResultPage.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/QueryResultPage.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
-
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 /**
  * Container for a page of query results
@@ -27,6 +27,10 @@ public class QueryResultPage<T> {
 
     private List<T> results;
     private Map<String,AttributeValue> lastEvaluatedKey;
+
+    private Integer count;
+    private Integer scannedCount;
+    private ConsumedCapacity consumedCapacity;
 
     /**
      * Returns all matching items for this page of query results.
@@ -43,8 +47,8 @@ public class QueryResultPage<T> {
      * Returns the last evaluated key, which can be used as the
      * exclusiveStartKey to fetch the next page of results. Returns null if this
      * is the last page of results.
-     * 
-     * @return	The key-value pairs which map from the attribute name of each component 
+     *
+     * @return	The key-value pairs which map from the attribute name of each component
      * 			of the primary key to its value.
      */
     public Map<String,AttributeValue> getLastEvaluatedKey() {
@@ -53,5 +57,79 @@ public class QueryResultPage<T> {
 
     public void setLastEvaluatedKey(Map<String,AttributeValue> lastEvaluatedKey) {
         this.lastEvaluatedKey = lastEvaluatedKey;
+    }
+
+    /**
+     * The number of items in the response. <p>If you used a
+     * <i>QueryFilter</i> in the request, then <i>Count</i> is the number of
+     * items returned after the filter was applied, and <i>ScannedCount</i>
+     * is the number of matching items before> the filter was applied. <p>If
+     * you did not use a filter in the request, then <i>Count</i> and
+     * <i>ScannedCount</i> are the same.
+     *
+     * @return The number of items in the response. <p>If you used a
+     *         <i>QueryFilter</i> in the request, then <i>Count</i> is the number of
+     *         items returned after the filter was applied, and <i>ScannedCount</i>
+     *         is the number of matching items before> the filter was applied. <p>If
+     *         you did not use a filter in the request, then <i>Count</i> and
+     *         <i>ScannedCount</i> are the same.
+     */
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+     * The number of items evaluated, before any <i>QueryFilter</i> is
+     * applied. A high <i>ScannedCount</i> value with few, or no,
+     * <i>Count</i> results indicates an inefficient <i>Query</i> operation.
+     * For more information, see <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count">Count
+     * and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     * <p>If you did not use a filter in the request, then
+     * <i>ScannedCount</i> is the same as <i>Count</i>.
+     *
+     * @return The number of items evaluated, before any <i>QueryFilter</i> is
+     *         applied. A high <i>ScannedCount</i> value with few, or no,
+     *         <i>Count</i> results indicates an inefficient <i>Query</i> operation.
+     *         For more information, see <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count">Count
+     *         and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *         <p>If you did not use a filter in the request, then
+     *         <i>ScannedCount</i> is the same as <i>Count</i>.
+     */
+    public Integer getScannedCount() {
+        return scannedCount;
+    }
+    public void setScannedCount(Integer scannedCount) {
+        this.scannedCount = scannedCount;
+    }
+
+    /**
+     * The capacity units consumed by an operation. The data returned
+     * includes the total provisioned throughput consumed, along with
+     * statistics for the table and any indexes involved in the operation.
+     * <i>ConsumedCapacity</i> is only returned if the request asked for it.
+     * For more information, see <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned
+     * Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return The capacity units consumed by an operation. The data returned
+     *         includes the total provisioned throughput consumed, along with
+     *         statistics for the table and any indexes involved in the operation.
+     *         <i>ConsumedCapacity</i> is only returned if the request asked for it.
+     *         For more information, see <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned
+     *         Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public ConsumedCapacity getConsumedCapacity() {
+        return consumedCapacity;
+    }
+
+    public void setConsumedCapacity(ConsumedCapacity consumedCapacity) {
+        this.consumedCapacity = consumedCapacity;
     }
 }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/ScanResultPage.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/ScanResultPage.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
+import com.amazonaws.services.dynamodbv2.model.ConsumedCapacity;
 
 /**
  * Container for a page of scan results.
@@ -26,6 +27,10 @@ public class ScanResultPage<T> {
 
     private List<T> results;
     private Map<String,AttributeValue> lastEvaluatedKey;
+
+    private Integer count;
+    private Integer scannedCount;
+    private ConsumedCapacity consumedCapacity;
 
     /**
      * Returns all matching items for this page of scan results, which may be
@@ -43,8 +48,8 @@ public class ScanResultPage<T> {
      * Returns the last evaluated key, which can be used as the
      * exclusiveStartKey to fetch the next page of results. Returns null if this
      * is the last page of results.
-     * 
-     * @return	The key-value pairs which map from the attribute name of each component 
+     *
+     * @return	The key-value pairs which map from the attribute name of each component
      * 			of the primary key to its value.
      */
     public Map<String,AttributeValue> getLastEvaluatedKey() {
@@ -55,4 +60,78 @@ public class ScanResultPage<T> {
         this.lastEvaluatedKey = lastEvaluatedKey;
     }
 
+    /**
+     * The number of items in the response. <p>If you set <i>ScanFilter</i>
+     * in the request, then <i>Count</i> is the number of items returned
+     * after the filter was applied, and <i>ScannedCount</i> is the number of
+     * matching items before the filter was applied. <p>If you did not use a
+     * filter in the request, then <i>Count</i> is the same as
+     * <i>ScannedCount</i>.
+     *
+     * @return The number of items in the response. <p>If you set <i>ScanFilter</i>
+     *         in the request, then <i>Count</i> is the number of items returned
+     *         after the filter was applied, and <i>ScannedCount</i> is the number of
+     *         matching items before the filter was applied. <p>If you did not use a
+     *         filter in the request, then <i>Count</i> is the same as
+     *         <i>ScannedCount</i>.
+     */
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    /**
+     * The number of items evaluated, before any <i>ScanFilter</i> is
+     * applied. A high <i>ScannedCount</i> value with few, or no,
+     * <i>Count</i> results indicates an inefficient <i>Scan</i> operation.
+     * For more information, see <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count">Count
+     * and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     * <p>If you did not use a filter in the request, then
+     * <i>ScannedCount</i> is the same as <i>Count</i>.
+     *
+     * @return The number of items evaluated, before any <i>ScanFilter</i> is
+     *         applied. A high <i>ScannedCount</i> value with few, or no,
+     *         <i>Count</i> results indicates an inefficient <i>Scan</i> operation.
+     *         For more information, see <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count">Count
+     *         and ScannedCount</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *         <p>If you did not use a filter in the request, then
+     *         <i>ScannedCount</i> is the same as <i>Count</i>.
+     */
+    public Integer getScannedCount() {
+        return scannedCount;
+    }
+
+    public void setScannedCount(Integer scannedCount) {
+        this.scannedCount = scannedCount;
+    }
+
+    /**
+     * The capacity units consumed by an operation. The data returned
+     * includes the total provisioned throughput consumed, along with
+     * statistics for the table and any indexes involved in the operation.
+     * <i>ConsumedCapacity</i> is only returned if the request asked for it.
+     * For more information, see <a
+     * href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned
+     * Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     *
+     * @return The capacity units consumed by an operation. The data returned
+     *         includes the total provisioned throughput consumed, along with
+     *         statistics for the table and any indexes involved in the operation.
+     *         <i>ConsumedCapacity</i> is only returned if the request asked for it.
+     *         For more information, see <a
+     *         href="http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html">Provisioned
+     *         Throughput</a> in the <i>Amazon DynamoDB Developer Guide</i>.
+     */
+    public ConsumedCapacity getConsumedCapacity() {
+        return consumedCapacity;
+    }
+
+    public void setConsumedCapacity(ConsumedCapacity consumedCapacity) {
+        this.consumedCapacity = consumedCapacity;
+    }
 }


### PR DESCRIPTION
* select, projectionExpression and returnConsumedCapacity
  from QueryRequest and ScanRequest into DynamoDBQueryExpression and  DynamoDBScanExpression;
* count, scannedCount and consumedCapacity
  from QueryResult and ScanResult into QueryResultPage and ScanResultPage.