### PR TITLE
Fix InstanceInfo JsonMappingException by changing billingProducts data type

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
@@ -409,7 +409,7 @@ public class EC2MetadataUtils {
         private final String instanceType;
         private final String imageId;
         private final String instanceId;
-        private final String billingProducts;
+        private final List<String> billingProducts;
         private final String architecture;
         private final String accountId;
         private final String kernelId;
@@ -426,7 +426,7 @@ public class EC2MetadataUtils {
                 @JsonProperty(value = "instanceType", required = true) String instanceType,
                 @JsonProperty(value = "imageId", required = true) String imageId,
                 @JsonProperty(value = "instanceId", required = true) String instanceId,
-                @JsonProperty(value = "billingProducts", required = false) String billingProducts,
+                @JsonProperty(value = "billingProducts", required = false) List<String> billingProducts,
                 @JsonProperty(value = "architecture", required = true) String architecture,
                 @JsonProperty(value = "accountId", required = true) String accountId,
                 @JsonProperty(value = "kernelId", required = true) String kernelId,
@@ -468,7 +468,7 @@ public class EC2MetadataUtils {
             return instanceId;
         }
 
-        public String getBillingProducts() {
+        public List<String> getBillingProducts() {
             return billingProducts;
         }
 

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/util/EC2MetadataUtilsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/util/EC2MetadataUtilsTest.java
@@ -104,7 +104,9 @@ public class EC2MetadataUtilsTest {
         Assert.assertEquals("m1.small", info.getInstanceType());
         Assert.assertEquals("ami-a49665cc", info.getImageId());
         Assert.assertEquals("i-6b2de041", info.getInstanceId());
-        Assert.assertEquals("foo", info.getBillingProducts());
+        Assert.assertEquals("foo", info.getBillingProducts().get(0));
+        Assert.assertEquals("bar", info.getBillingProducts().get(1));
+        Assert.assertEquals(2, info.getBillingProducts().size());
         Assert.assertEquals("x86_64", info.getArchitecture());
         Assert.assertEquals("599169622985", info.getAccountId());
         Assert.assertEquals("aki-919dcaf8", info.getKernelId());
@@ -245,7 +247,7 @@ public class EC2MetadataUtilsTest {
                 + "\"instanceType\":\"m1.small\","
                 + "\"imageId\":\"ami-a49665cc\","
                 + "\"instanceId\":\"i-6b2de041\","
-                + "\"billingProducts\":\"foo\","
+                + "\"billingProducts\":[\"foo\",\"bar\"],"
                 + "\"architecture\":\"x86_64\","
                 + "\"accountId\":\"599169622985\","
                 + "\"kernelId\":\"aki-919dcaf8\"," 


### PR DESCRIPTION
I was trying to use Regions.getCurrentRegion() and found out that the latest aws-sdk-java (1.9.28.1) threw JsonMappingException due to billingProducts having an array value in instance-identity/document response payload.

I couldn't find any documentation on response payload data structure. I'm not sure if billingProducts has always had an array value or perhaps it differs between AWS accounts. The only info I could find was http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html with a very brief description.

This pull request changes billingProducts data type from String to List<String> , the relevant test has been updated accordingly.

Here's the error stack trace:

```
Apr 07, 2015 12:49:04 AM com.amazonaws.util.EC2MetadataUtils getInstanceInfo
WARNING: Unable to parse dynamic EC2 instance info ({
  ...
  "billingProducts" : [ "bp-12345678" ],
  ...
}) : Unable to parse Json String.
com.amazonaws.AmazonClientException: Unable to parse Json String.
        at com.amazonaws.util.json.Jackson.fromJsonString(Jackson.java:66)
        at com.amazonaws.util.EC2MetadataUtils.getInstanceInfo(EC2MetadataUtils.java:229)
        at com.amazonaws.regions.Regions.getCurrentRegion(Regions.java:79)
        ...
Caused by: com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.lang.String out of START_ARRAY token
 at [Source: java.io.StringReader@58651fd0; line: 2, column: 30]
        at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:164)
        at com.fasterxml.jackson.databind.DeserializationContext.mappingException(DeserializationContext.java:691)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:46)
        at com.fasterxml.jackson.databind.deser.std.StringDeserializer.deserialize(StringDeserializer.java:11)
        at com.fasterxml.jackson.databind.deser.SettableBeanProperty.deserialize(SettableBeanProperty.java:525)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer._deserializeUsingPropertyBased(BeanDeserializer.java:331)
        at com.fasterxml.jackson.databind.deser.BeanDeserializerBase.deserializeFromObjectUsingNonDefault(BeanDeserializerBase.java:1071)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserializeFromObject(BeanDeserializer.java:268)
        at com.fasterxml.jackson.databind.deser.BeanDeserializer.deserialize(BeanDeserializer.java:124)
        at com.fasterxml.jackson.databind.ObjectMapper._readMapAndClose(ObjectMapper.java:2993)
        at com.fasterxml.jackson.databind.ObjectMapper.readValue(ObjectMapper.java:2098)
        at com.amazonaws.util.json.Jackson.fromJsonString(Jackson.java:64)
        ... 7 more
```