### PR TITLE
Add option to size the response metadata cache.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -79,6 +79,11 @@ public class ClientConfiguration {
      */
     public static final boolean DEFAULT_TCP_KEEP_ALIVE = false;
 
+    /**
+     * The default response metadata cache size.
+     */
+    public static final int DEFAULT_RESPONSE_METADATA_CACHE_SIZE = 50;
+
     /** The HTTP user agent header passed with all HTTP requests. */
     private String userAgent = DEFAULT_USER_AGENT;
 
@@ -197,6 +202,14 @@ public class ClientConfiguration {
     private boolean tcpKeepAlive = DEFAULT_TCP_KEEP_ALIVE;
     
     /**
+     * Size of the response metadata cache.
+     * <p>
+     * Response metadata is typically used for troubleshooting issues with AWS
+     * support staff when services aren't acting as expected.
+     */
+    private int responseMetadataCacheSize = DEFAULT_RESPONSE_METADATA_CACHE_SIZE;
+
+    /**
      * Can be used to specify custom specific Apache HTTP client configurations.
      */
     private final ApacheHttpClientConfig apacheHttpClientConfig;
@@ -226,6 +239,7 @@ public class ClientConfiguration {
         this.socketReceiveBufferSizeHint = other.socketReceiveBufferSizeHint;
         this.socketSendBufferSizeHint    = other.socketSendBufferSizeHint;
         this.signerOverride              = other.signerOverride;
+        this.responseMetadataCacheSize   = other.responseMetadataCacheSize;
         this.apacheHttpClientConfig =
             new ApacheHttpClientConfig(other.apacheHttpClientConfig);
     }
@@ -1137,6 +1151,33 @@ public class ClientConfiguration {
      */
     public ClientConfiguration withTcpKeepAlive(final boolean use) {
         setUseTcpKeepAlive(use);
+        return this;
+    }
+
+    /**
+     * Returns the response metadata cache size.
+     */
+    public int getResponseMetadataCacheSize() {
+        return responseMetadataCacheSize;
+    }
+
+    /**
+     * Sets the response metadata cache size. By default, it is set to
+     * {@value #DEFAULT_RESPONSE_METADATA_CACHE_SIZE}.
+     * @param responseMetadataCacheSize maximum cache size.
+     */
+    public void setResponseMetadataCacheSize(int responseMetadataCacheSize) {
+        this.responseMetadataCacheSize = responseMetadataCacheSize;
+    }
+
+    /**
+     * Sets the response metadata cache size. By default, it is set to
+     * {@value #DEFAULT_RESPONSE_METADATA_CACHE_SIZE}.
+     * @param responseMetadataCacheSize maximum cache size.
+     * @return The updated ClientConfiguration object.
+     */
+    public ClientConfiguration withResponseMetadataCacheSize(int responseMetadataCacheSize) {
+        setResponseMetadataCacheSize(responseMetadataCacheSize);
         return this;
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -150,7 +150,7 @@ public class AmazonHttpClient {
     private final ClientConfiguration config;
 
     /** Cache of metadata for recently executed requests for diagnostic purposes */
-    private final ResponseMetadataCache responseMetadataCache = new ResponseMetadataCache(50);
+    private final ResponseMetadataCache responseMetadataCache;
 
     /**
      * A request metric collector used specifically for this http client; or
@@ -204,6 +204,7 @@ public class AmazonHttpClient {
         this.config = config;
         this.httpClient = httpClient;
         this.requestMetricCollector = requestMetricCollector;
+        this.responseMetadataCache = new ResponseMetadataCache(config.getResponseMetadataCacheSize());
     }
 
     /**

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/util/ResponseMetadataCacheTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/util/ResponseMetadataCacheTest.java
@@ -64,6 +64,20 @@ public class ResponseMetadataCacheTest {
         assertEquals(metadata4, cache.get(key4));
     }
 
+    /** Tests that the cache works correctly with size=0  */
+    @Test
+    public void TestEmpty() {
+        ResponseMetadataCache cache = new ResponseMetadataCache(0);
+
+        AmazonWebServiceRequest key = new TestRequest();
+        ResponseMetadata metadata = newResponseMetadata();
+        // Add item to the cache, it should be immediately evicted.
+        cache.add(key, metadata);
+
+        // get should return null
+        assertNull(cache.get(key));
+    }
+
     private class TestRequest extends AmazonWebServiceRequest {}
 
     private ResponseMetadata newResponseMetadata() {


### PR DESCRIPTION
In some long-running applications, this cache holds entries just long enough to create old generation garbage.

As the cache is only used for diagnostic purposes, it would be great to configure the size (e.g. to zero) when it causes problems.

See also https://github.com/elastic/elasticsearch-cloud-aws/issues/193

