### PR TITLE
Joda version 2.7

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>[2.2,)</version>
+        <version>2.7</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
joda-time is the only dependency to use a version range: `[2.2,)`.

Version ranges are harmful for release versions, as they cause unreproducible builds. The artifact I am using today and the one I am using tomorrow can be different, without a single change to my own code/POM. And those differences could break things.

There is a way to try to use some of their benefits without actually having them present in releases, but it's [complicated](http://docs.codehaus.org/display/MAVEN/Dependency+Mediation+and+Conflict+Resolution); best practice is typically not to use them.

