### PR TITLE
Disabling --quiet to see if that'll prevent travis from timing out.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ jdk:
   - openjdk6
   - oraclejdk8
 install: /bin/true
-script: mvn install --quiet -Dgpg.skip=true -DskipTests=true -pl \!aws-java-sdk-osgi
+script: mvn install -DskipTests=true -pl \!aws-java-sdk-osgi
 


### PR DESCRIPTION
Travis times out builds after 10 minutes with no output - our oraclejdk7 builds have been [nosing over 10 minutes recently](https://travis-ci.org/aws/aws-sdk-java/builds/65132800), and the others aren't far behind. Disabling --quiet keeps a steady flow of output so [travis doesn't give up on us](https://travis-ci.org/aws/aws-sdk-java/builds/65132800).

I also removed the redundant `-Dgpg.skip=true` since we're only binding the maven-gpg-plugin in the publishing profile these days.