### PR TITLE
Fixed typo in the comment for putObject

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3.java
@@ -2122,7 +2122,6 @@ public interface AmazonS3 extends S3DirectSpi {
      * </p>
      * <p>
      * If versioning is enabled for the specified bucket,
-     * this operation will
      * this operation will never overwrite an existing object
      * with the same key, but will keep the existing object as an
      * older version


### PR DESCRIPTION
There was a typo in the comment for the put putObject function.  "this operation will" was written twice in a row.