### PR TITLE
Fix for SDK not working on upcoming Java 1.8u60 #444

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -36,7 +36,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.8</version>
+        <version>2.8.1</version>
       </dependency>
       <dependency>
         <groupId>junit</groupId>


### PR DESCRIPTION
Upgraded to Joda Time version that fixes issue (https://github.com/JodaOrg/joda-time/issues/288) with time zone formatting when running on JDK 1.8u60 and newer.