### PR TITLE
Retry on DNS failure.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedRetryPolicies.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedRetryPolicies.java
@@ -187,6 +187,11 @@ public class PredefinedRetryPolicies {
                  * and then retry the request.
                  */
                 if (RetryUtils.isClockSkewError(ase)) return true;
+
+                /*
+                 * DNS fails to resolve, it may be caused by temporary network failure.
+                 */
+                if (RetryUtils.isDnsError(ase)) return true;
             }
 
             return false;

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/retry/RetryUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/retry/RetryUtils.java
@@ -71,4 +71,18 @@ public class RetryUtils {
                 || "InvalidSignatureException".equals(errorCode)
                 || "SignatureDoesNotMatch".equals(errorCode);
     }
+
+    /**
+     * Returns true if the specified exception is dns resolution issue.
+     *
+     * @param ase
+     *            The exception to test.
+     *
+     * @return True if the exception resulted from dns resolution failure,
+     *         otherwise false
+     */
+    public static boolean isDnsError(AmazonServiceException ase) {
+        return ase != null && ase.getCause() != null
+            && ase.getCause() instanceof java.net.UnknownHostException;
+    }
 }


### PR DESCRIPTION
Fixes our issue that we hit in production. Temporary network failures can cause DNS fail to resolve which is not retried. However, since AWS SDK is retrying on IOException. It should also retry on DNS failures.

Tests:
- [x] aws-sdk-java/aws-java-sdk-core master$ mvn test

Fixes:
https://github.com/aws/aws-sdk-java/issues/452