### PR TITLE
Added support for Lambda java8 runtime

### DIFF
--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/CreateFunctionRequest.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/CreateFunctionRequest.java
@@ -56,10 +56,10 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
 
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      */
     private String runtime;
 
@@ -225,13 +225,13 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
 
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function you are uploading.
-     *         Currently, Lambda supports only "nodejs" as the runtime.
+     *         Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      *
      * @see Runtime
      */
@@ -241,13 +241,13 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function you are uploading.
-     *         Currently, Lambda supports only "nodejs" as the runtime.
+     *         Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      *
      * @see Runtime
      */
@@ -257,15 +257,15 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function you are uploading.
-     *         Currently, Lambda supports only "nodejs" as the runtime.
+     *         Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      *
      * @return A reference to this updated object so that method calls can be chained
      *         together.
@@ -279,13 +279,13 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
 
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function you are uploading.
-     *         Currently, Lambda supports only "nodejs" as the runtime.
+     *         Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      *
      * @see Runtime
      */
@@ -295,15 +295,15 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     
     /**
      * The runtime environment for the Lambda function you are uploading.
-     * Currently, Lambda supports only "nodejs" as the runtime.
+     * Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      * <p>
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function you are uploading.
-     *         Currently, Lambda supports only "nodejs" as the runtime.
+     *         Currently, Lambda supports only "nodejs" or "java8" as the runtime.
      *
      * @return A reference to this updated object so that method calls can be chained
      *         together.
@@ -384,7 +384,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     /**
      * The function within your code that Lambda calls to begin execution.
      * For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     * function.
+     * function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>0 - 128<br/>
@@ -392,7 +392,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
      *
      * @return The function within your code that Lambda calls to begin execution.
      *         For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     *         function.
+     *         function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      */
     public String getHandler() {
         return handler;
@@ -401,7 +401,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     /**
      * The function within your code that Lambda calls to begin execution.
      * For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     * function.
+     * function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>0 - 128<br/>
@@ -409,7 +409,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
      *
      * @param handler The function within your code that Lambda calls to begin execution.
      *         For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     *         function.
+     *         function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      */
     public void setHandler(String handler) {
         this.handler = handler;
@@ -418,7 +418,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
     /**
      * The function within your code that Lambda calls to begin execution.
      * For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     * function.
+     * function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      * <p>
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
@@ -428,7 +428,7 @@ public class CreateFunctionRequest extends AmazonWebServiceRequest implements Se
      *
      * @param handler The function within your code that Lambda calls to begin execution.
      *         For Node.js, it is the <i>module-name</i>.<i>export</i> value in your
-     *         function.
+     *         function. For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      *
      * @return A reference to this updated object so that method calls can be chained
      *         together.

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/CreateFunctionResult.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/CreateFunctionResult.java
@@ -44,7 +44,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      */
     private String runtime;
 
@@ -196,7 +196,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function.
      *
@@ -210,7 +210,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -226,7 +226,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -244,7 +244,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -260,7 +260,7 @@ public class CreateFunctionResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/FunctionConfiguration.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/FunctionConfiguration.java
@@ -44,7 +44,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      */
     private String runtime;
 
@@ -196,7 +196,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function.
      *
@@ -210,7 +210,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -226,7 +226,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -244,7 +244,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -260,7 +260,7 @@ public class FunctionConfiguration implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/GetFunctionConfigurationResult.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/GetFunctionConfigurationResult.java
@@ -196,7 +196,7 @@ public class GetFunctionConfigurationResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function.
      *
@@ -210,7 +210,7 @@ public class GetFunctionConfigurationResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -226,7 +226,7 @@ public class GetFunctionConfigurationResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -244,7 +244,7 @@ public class GetFunctionConfigurationResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -260,7 +260,7 @@ public class GetFunctionConfigurationResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/Runtime.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/Runtime.java
@@ -19,8 +19,9 @@ package com.amazonaws.services.lambda.model;
  */
 public enum Runtime {
     
-    Nodejs("nodejs");
-
+    Nodejs("nodejs"),
+    Java8("java8");
+    
     private String value;
 
     private Runtime(String value) {
@@ -45,6 +46,8 @@ public enum Runtime {
         
         } else if ("nodejs".equals(value)) {
             return Runtime.Nodejs;
+        } else if ("java8".equals(value)) {
+            return Runtime.Java8;
         } else {
             throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
         }

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionCodeResult.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionCodeResult.java
@@ -44,7 +44,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      */
     private String runtime;
 
@@ -196,7 +196,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function.
      *
@@ -210,7 +210,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -226,7 +226,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -244,7 +244,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -260,7 +260,7 @@ public class UpdateFunctionCodeResult implements Serializable, Cloneable {
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionConfigurationRequest.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionConfigurationRequest.java
@@ -64,6 +64,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
     /**
      * The function that Lambda calls to begin executing your function. For
      * Node.js, it is the <i>module-name.export</i> value in your function.
+     * For Java, it is your <i>package-name</i>.<i>class-name</i>::<i>method-name</i>.
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>0 - 128<br/>
@@ -242,6 +243,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
     /**
      * The function that Lambda calls to begin executing your function. For
      * Node.js, it is the <i>module-name.export</i> value in your function.
+     * For Java, it is your<i>package-name</i>.<i>class-name</i>::<i>method-name</i>>.
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>0 - 128<br/>
@@ -249,6 +251,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
      *
      * @return The function that Lambda calls to begin executing your function. For
      *         Node.js, it is the <i>module-name.export</i> value in your function.
+     *         For Java, it is you<i>package-name</i>.<i>class-name</i>::<i>method-name</i>i>.
      */
     public String getHandler() {
         return handler;
@@ -257,6 +260,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
     /**
      * The function that Lambda calls to begin executing your function. For
      * Node.js, it is the <i>module-name.export</i> value in your function.
+     * For Java, it is yo<i>package-name</i>.<i>class-name</i>::<i>method-name</i>/i>.
      * <p>
      * <b>Constraints:</b><br/>
      * <b>Length: </b>0 - 128<br/>
@@ -264,6 +268,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
      *
      * @param handler The function that Lambda calls to begin executing your function. For
      *         Node.js, it is the <i>module-name.export</i> value in your function.
+     *         For Java, it is y<i>package-name</i>.<i>class-name</i>::<i>method-name</i></i>.
      */
     public void setHandler(String handler) {
         this.handler = handler;
@@ -272,6 +277,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
     /**
      * The function that Lambda calls to begin executing your function. For
      * Node.js, it is the <i>module-name.export</i> value in your function.
+     * For Java, it is <i>package-name</i>.<i>class-name</i>::<i>method-name</i>e</i>.
      * <p>
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
@@ -281,6 +287,7 @@ public class UpdateFunctionConfigurationRequest extends AmazonWebServiceRequest 
      *
      * @param handler The function that Lambda calls to begin executing your function. For
      *         Node.js, it is the <i>module-name.export</i> value in your function.
+     *         For Java, it is<i>package-name</i>.<i>class-name</i>::<i>method-name</i>me</i>.
      *
      * @return A reference to this updated object so that method calls can be chained
      *         together.

--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionConfigurationResult.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/model/UpdateFunctionConfigurationResult.java
@@ -44,7 +44,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      */
     private String runtime;
 
@@ -196,7 +196,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @return The runtime environment for the Lambda function.
      *
@@ -210,7 +210,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -226,7 +226,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -244,7 +244,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * The runtime environment for the Lambda function.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *
@@ -260,7 +260,7 @@ public class UpdateFunctionConfigurationResult implements Serializable, Cloneabl
      * Returns a reference to this object so that method calls can be chained together.
      * <p>
      * <b>Constraints:</b><br/>
-     * <b>Allowed Values: </b>nodejs
+     * <b>Allowed Values: </b>nodejs, java8
      *
      * @param runtime The runtime environment for the Lambda function.
      *


### PR DESCRIPTION
Added the 'java8' runtime to the Lambda classes.
This allows libraries like https://github.com/classmethod-aws/gradle-aws-plugin to deploy & invoke Java Lambda functions.