### PR TITLE
Rewind ByteBuffer from MessageAttributeValue

### DIFF
--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/MessageMD5ChecksumHandler.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/MessageMD5ChecksumHandler.java
@@ -278,12 +278,10 @@ public class MessageMD5ChecksumHandler extends AbstractRequestHandler {
      * input ByteBuffer and all the bytes it contains.
      */
     private static void updateLengthAndBytes(MessageDigest digest, ByteBuffer binaryValue) {
-        // Rewind the ByteBuffer, in case that get/put operations were applied to
-        // the unmarshalled BB before it's passed to this handler.
-        binaryValue.rewind();
-        int size = binaryValue.remaining();
+        ByteBuffer readOnlyBuffer = binaryValue.asReadOnlyBuffer();
+        int size = readOnlyBuffer.remaining();
         ByteBuffer lengthBytes = ByteBuffer.allocate(INTEGER_SIZE_IN_BYTES).putInt(size);
         digest.update(lengthBytes.array());
-        digest.update(binaryValue);
+        digest.update(readOnlyBuffer);
     }
 }


### PR DESCRIPTION
This automatically rewinds the ByteBuffer before returning.
SQS and SNS's MessageAttributeValue's behavior has been updated to remain consistent.

This seems to be a necessary behavior.  If the modification behavior is not desired then I recommend that the javadocs be updated to indicate to the developer that a rewind of the buffer may be needed after requesting it.