### PR TITLE
Downgrade LOG.errors to LOG.infos on SocketExceptions.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/JsonErrorResponseHandlerV2.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/JsonErrorResponseHandlerV2.java
@@ -96,7 +96,7 @@ public class JsonErrorResponseHandlerV2 implements HttpResponseHandler<AmazonSer
                 try {
                     return unmarshaller.unmarshall(jsonContent.jsonNode);
                 } catch (Exception e) {
-                    LOG.error("Unable to unmarshall exception content", e);
+                    LOG.info("Unable to unmarshall exception content", e);
                     return null;
                 }
             }
@@ -136,7 +136,7 @@ public class JsonErrorResponseHandlerV2 implements HttpResponseHandler<AmazonSer
             try {
                 rawJsonContent = IOUtils.toString(httpResponse.getContent());
             } catch (Exception e) {
-                LOG.error("Unable to read HTTP response content", e);
+                LOG.info("Unable to read HTTP response content", e);
             }
             return new JsonContent(rawJsonContent);
 
@@ -151,7 +151,7 @@ public class JsonErrorResponseHandlerV2 implements HttpResponseHandler<AmazonSer
             try {
                 return MAPPER.readTree(rawJsonContent);
             } catch (Exception e) {
-                LOG.error("Unable to parse HTTP response content", e);
+                LOG.info("Unable to parse HTTP response content", e);
                 return null;
             }
         }


### PR DESCRIPTION
When calling an AWS service, the following can happen:

* SocketException happens in createJsonContent
* LOG.error "Unable to read HTTP response context" is called, and the
SocketException is suppressed
* new JsonContent(null) is called
* new JsonContent constructor calls parseJsonContent
* MAPPER.readTree(null) is called, which causes an NPE
* LOG.error "Unable to parse HTTP response content" is called, and
the NPE is suppressed

The caller of createJsonContent is returned a JsonContent object
with a null node, but this is actually handled correctly (without
any further log.errors), and is turned into an AmazonServiceException:

com.amazonaws.AmazonServiceException: Unable to parse HTTP response content
(Service: AmazonDynamoDBv2; Status Code: 505; Error Code: null; Request ID:
null)

Which is great, as then the request can be retried.

However, the code has issued two LOG.errors for exceptions are suppressed, when
the notification of the failure is going to be passed on to the client as an
AmazonServiceException. E.g. it should be up to the client to call log.error if
this is fatal for them (e.g. after their retries are up).

In our case, the spurious log.errors are causing alerts to happen on
failures that end up being retried and are only transient.