### PR TITLE
Allow the specification of DnsResolver to use

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -22,6 +22,9 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.util.VersionInfoUtils;
+import org.apache.http.conn.DnsResolver;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
+
 /**
  * Client configuration options such as proxy settings, user agent string, max
  * retry attempts, etc.
@@ -210,6 +213,11 @@ public class ClientConfiguration {
     private int responseMetadataCacheSize = DEFAULT_RESPONSE_METADATA_CACHE_SIZE;
 
     /**
+     * The DNS Resolver to resolve ip addresses of amazon web services
+     */
+    private DnsResolver dnsResolver = new SystemDefaultDnsResolver();
+
+    /**
      * Can be used to specify custom specific Apache HTTP client configurations.
      */
     private final ApacheHttpClientConfig apacheHttpClientConfig;
@@ -240,6 +248,7 @@ public class ClientConfiguration {
         this.socketSendBufferSizeHint    = other.socketSendBufferSizeHint;
         this.signerOverride              = other.signerOverride;
         this.responseMetadataCacheSize   = other.responseMetadataCacheSize;
+        this.dnsResolver                 = other.dnsResolver;
         this.apacheHttpClientConfig =
             new ApacheHttpClientConfig(other.apacheHttpClientConfig);
     }
@@ -1151,6 +1160,32 @@ public class ClientConfiguration {
      */
     public ClientConfiguration withTcpKeepAlive(final boolean use) {
         setUseTcpKeepAlive(use);
+        return this;
+    }
+
+    /**
+     * Returns the DnsResolver that is used by the client for resolving AWS ip addresses
+     *
+     */
+    public DnsResolver getDnsResolver() {
+        return dnsResolver;
+    }
+
+    /**
+     * Sets the DNS Resolver that should be used to for resolving AWS ip addresses
+     */
+    public void setDnsResolver(final DnsResolver resolver) {
+        if(resolver!=null) {
+            this.dnsResolver = resolver;
+        }
+    }
+
+    /**
+     * Sets the DNS Resolver that should be used to for resolving AWS ip addresses
+     * @return The updated ClientConfiguration object.
+     */
+    public ClientConfiguration withDnsResolver(final DnsResolver resolver) {
+        setDnsResolver(resolver);
         return this;
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -22,8 +22,6 @@ import com.amazonaws.http.IdleConnectionReaper;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 import com.amazonaws.retry.RetryPolicy;
 import com.amazonaws.util.VersionInfoUtils;
-import org.apache.http.conn.DnsResolver;
-import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 
 /**
  * Client configuration options such as proxy settings, user agent string, max

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/DnsResolver.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/DnsResolver.java
@@ -1,0 +1,12 @@
+package com.amazonaws;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Given a hostname, will resolve the hostname to an ip, or list of ip addresses.
+ */
+public interface DnsResolver {
+    InetAddress[] resolve(String host) throws UnknownHostException;
+
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SystemDefaultDnsResolver.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SystemDefaultDnsResolver.java
@@ -1,0 +1,15 @@
+package com.amazonaws;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Default dns resolver that uses {@link java.net.InetAddress#getAllByName(String)}
+ * to resolve hosts to ip addresses
+ */
+public class SystemDefaultDnsResolver implements DnsResolver {
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        return InetAddress.getAllByName(host);
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/ConnectionManagerFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/ConnectionManagerFactory.java
@@ -28,7 +28,7 @@ class ConnectionManagerFactory {
     public static PoolingClientConnectionManager createPoolingClientConnManager( ClientConfiguration config, HttpParams httpClientParams ) {
         PoolingClientConnectionManager connectionManager = new PoolingClientConnectionManager(
                 SchemeRegistryFactory.createDefault(),
-                config.getConnectionTTL(), TimeUnit.MILLISECONDS,config.getDnsResolver());
+                config.getConnectionTTL(), TimeUnit.MILLISECONDS,new DelegatingDnsResolver(config.getDnsResolver()));
         connectionManager.setDefaultMaxPerRoute(config.getMaxConnections());
         connectionManager.setMaxTotal(config.getMaxConnections());
         if (config.useReaper()) {

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/ConnectionManagerFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/ConnectionManagerFactory.java
@@ -28,7 +28,7 @@ class ConnectionManagerFactory {
     public static PoolingClientConnectionManager createPoolingClientConnManager( ClientConfiguration config, HttpParams httpClientParams ) {
         PoolingClientConnectionManager connectionManager = new PoolingClientConnectionManager(
                 SchemeRegistryFactory.createDefault(),
-                config.getConnectionTTL(), TimeUnit.MILLISECONDS);
+                config.getConnectionTTL(), TimeUnit.MILLISECONDS,config.getDnsResolver());
         connectionManager.setDefaultMaxPerRoute(config.getMaxConnections());
         connectionManager.setMaxTotal(config.getMaxConnections());
         if (config.useReaper()) {

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/DelegatingDnsResolver.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/DelegatingDnsResolver.java
@@ -1,0 +1,26 @@
+package com.amazonaws.http;
+
+import org.apache.http.conn.DnsResolver;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+/**
+ * Implements the {@link org.apache.http.conn.DnsResolver} interface,
+ * taking in a {@link com.amazonaws.DnsResolver} implementation and executing it's
+ * {@link com.amazonaws.DnsResolver#resolve(String)} method to perform the
+ * actual dns resolution
+ */
+public class DelegatingDnsResolver implements DnsResolver {
+
+    private final com.amazonaws.DnsResolver delegate;
+
+    public DelegatingDnsResolver(com.amazonaws.DnsResolver delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public InetAddress[] resolve(String host) throws UnknownHostException {
+        return delegate.resolve(host);
+    }
+}

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -18,9 +18,13 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.security.KeyStore;
 
+import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.junit.Test;
 
 public class ClientConfigurationTest {
@@ -60,6 +64,23 @@ public class ClientConfigurationTest {
         assertNotNull(
             "ssl soscket of the new httpclient config should not be affected",
             config2.getApacheHttpClientConfig().getSslSocketFactory());
+
+        assertNotNull("Client Configuration must have a default DnsResolver",config.getDnsResolver());
+        config.setDnsResolver(null);
+        assertNotNull("Client Configuration DnsResolver cannot be override with null",config.getDnsResolver());
+
+        DnsResolver resolver = new DnsResolver() {
+            @Override
+            public InetAddress[] resolve(String s) throws UnknownHostException {
+                return new InetAddress[0];
+            }
+        };
+
+        config.setDnsResolver(resolver);
+        assertSame("custom dns resolver set via fluent API",
+                resolver,
+                config.getDnsResolver());
+
     }
 
 }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -22,9 +22,7 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.security.KeyStore;
 
-import org.apache.http.conn.DnsResolver;
 import org.apache.http.conn.ssl.SSLSocketFactory;
-import org.apache.http.impl.conn.SystemDefaultDnsResolver;
 import org.junit.Test;
 
 public class ClientConfigurationTest {

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/SystemDefaultDnsResolverTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/SystemDefaultDnsResolverTest.java
@@ -1,0 +1,16 @@
+package com.amazonaws;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class SystemDefaultDnsResolverTest {
+
+    @Test
+    public void testResolveLocalhost() throws Exception {
+        DnsResolver resolver = new SystemDefaultDnsResolver();
+        assertNotNull(resolver.resolve("127.0.0.1"));
+        assertEquals("Should resolve to 1 address", 1, resolver.resolve("127.0.0.1").length);
+        assertTrue("Should resolve localhost",  resolver.resolve("localhost").length>0);
+    }
+}

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/http/DelegatingDnsResolverTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/http/DelegatingDnsResolverTest.java
@@ -1,0 +1,93 @@
+package com.amazonaws.http;
+
+import com.amazonaws.*;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.Assert.*;
+
+public class DelegatingDnsResolverTest {
+
+    private AmazonHttpClient testedClient;
+    private AtomicInteger dnsResolutionCounter;
+    private Set<String> requestedHosts;
+
+    @Before
+    public void resetClientConfiguration() {
+        dnsResolutionCounter = new AtomicInteger(0);
+        requestedHosts = new CopyOnWriteArraySet<String>();
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration();
+        clientConfiguration.withMaxErrorRetry(0);
+        clientConfiguration.withDnsResolver(new DnsResolver() {
+            DnsResolver system = new SystemDefaultDnsResolver();
+            @Override
+            public InetAddress[] resolve(String host) throws UnknownHostException {
+                dnsResolutionCounter.incrementAndGet();
+                requestedHosts.add(host);
+                return system.resolve(host);
+            }
+        });
+
+        testedClient = new AmazonHttpClient(clientConfiguration);
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            testedClient.shutdown();
+        } catch (Exception e) {}
+    }
+
+    @Test
+    public void testDelegateIsCalledWhenRequestIsMade() {
+        // The ExecutionContext should collect the expected RequestCount
+        ExecutionContext context = new ExecutionContext(true);
+        String randomHost = UUID.randomUUID().toString();
+        final Request request = new DefaultRequest<String>("bob") {};
+        request.setEndpoint(URI.create("http://" + randomHost+"/"));
+        request.setHttpMethod(HttpMethodName.GET);
+
+        try {
+            testedClient.execute(request,
+                    null,
+                    null,
+                    context);
+            Assert.fail("AmazonServiceException is expected.");
+        } catch (Exception ase) {
+        }
+
+        assertTrue("dnsResolver should have been called at least once",dnsResolutionCounter.get()>0);
+        assertTrue("An attempt to resolve host " + randomHost + " should have been made",requestedHosts.contains(randomHost));
+    }
+
+    @Test
+    public void testDelegatingDnsResolverCallsResolveOnDelegate() throws Exception {
+        final AtomicInteger timesCalled = new AtomicInteger();
+
+        DnsResolver delegate = new DnsResolver() {
+            @Override
+            public InetAddress[] resolve(String host) throws UnknownHostException {
+                timesCalled.incrementAndGet();
+                return new InetAddress[0];
+            }
+        };
+
+        org.apache.http.conn.DnsResolver resolver = new DelegatingDnsResolver(delegate);
+
+        resolver.resolve("localhost");
+
+        assertEquals("Delegate Resolver should have been executed",1,timesCalled.get());
+
+    }
+}


### PR DESCRIPTION
Hi there,

This is a patch to allow the user to specify the DnsResolver to use to lookup ip addresses for AWS services.  For example, one could pass a DnsResolver that does exactly the same as the SystemDnsResolver:

    InetAddress.getAllByName(host)

But performs the request in the background so that foreground requests do not suffer from any slight "blips" in dns resolution times.  

thanks
/dom