### PR TITLE
AmazonSQSBufferedAsyncClient.receiveMessageAsync: when bypassing prefetch buffers, pass AsyncHandler to realSqs if present.

### DIFF
--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/QueueBuffer.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/QueueBuffer.java
@@ -174,6 +174,8 @@ class QueueBuffer {
                     rq, callback);
             future.setBuffer(this);
             return future;
+        } else if (handler != null) {
+            return realSqs.receiveMessageAsync(rq, handler);
         } else {
             return realSqs.receiveMessageAsync(rq);
         }


### PR DESCRIPTION
This fixes an issue where AmazonSQSBufferedAsyncClient.receiveMessageAsync(request, handler) would never call handler.onSuccess or handler.onError if any of the following were true:
 - Prefetch is disabled (maxInflightReceiveBatches == 0 or maxDoneReceiveBatches == 0)
 - The request specifies any message attributes
 - The request specifies a visibility timeout

This change is contributed under the Apache 2.0 license.
