### PR TITLE
Fix NPE in StartChildWorkflowExecutionParameters

### DIFF
--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/generic/StartChildWorkflowExecutionParameters.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/generic/StartChildWorkflowExecutionParameters.java
@@ -1,12 +1,12 @@
 /*
  * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
  * use this file except in compliance with the License. A copy of the License is
  * located at
- * 
+ *
  * http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
  * express or implied. See the License for the specific language governing
@@ -164,7 +164,7 @@ public class StartChildWorkflowExecutionParameters implements Cloneable {
         this.childPolicy = childPolicy;
         return this;
     }
-    
+
     public int getTaskPriority() {
         return taskPriority;
     }
@@ -177,7 +177,7 @@ public class StartChildWorkflowExecutionParameters implements Cloneable {
         this.taskPriority = taskPriority;
         return this;
     }
-	
+
     public String getLambdaRole() {
         return lambdaRole;
     }
@@ -221,7 +221,7 @@ public class StartChildWorkflowExecutionParameters implements Cloneable {
             if (childPolicy != null) {
                 startChildWorkflowExecutionParameters.setChildPolicy(childPolicy);
             }
-            
+
             Integer taskPriority = options.getTaskPriority();
             if (taskPriority != null) {
                 startChildWorkflowExecutionParameters.setTaskPriority(taskPriority);
@@ -264,7 +264,7 @@ public class StartChildWorkflowExecutionParameters implements Cloneable {
                 startChildWorkflowExecutionParameters.setTaskPriority(taskPriority);
             }
 
-            String lambdaRole = options.getLambdaRole();
+            String lambdaRole = optionsOverride.getLambdaRole();
             if (lambdaRole != null) {
                 startChildWorkflowExecutionParameters.setLambdaRole(lambdaRole);
             }


### PR DESCRIPTION
Some of our SWF Flow Framework unit tests started failing after upgrade to 1.10.10. Caused by NPE in StartChildWorkflowExecutionParameters that looks like a cut & paste error.