### PR TITLE
Add option to serialize a Method's input parameters separately

### DIFF
--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/DataConverter.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/DataConverter.java
@@ -45,5 +45,4 @@ public abstract class DataConverter {
      *             reason.
      */
     public abstract <T> T fromData(String content, Class<T> valueType) throws DataConverterException;
-
 }

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonMethodAwareDataConverter.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/JsonMethodAwareDataConverter.java
@@ -1,0 +1,42 @@
+package com.amazonaws.services.simpleworkflow.flow;
+
+import java.util.Iterator;
+import java.lang.reflect.Method;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+
+public class JsonMethodAwareDataConverter extends JsonDataConverter implements MethodAwareDataConverter {
+  public JsonMethodAwareDataConverter() {
+    super();
+  }
+  public JsonMethodAwareDataConverter(ObjectMapper mapper) {
+    super(mapper);
+  }
+
+  @Override
+  public Object[] fromDataForMethod(String content, Method method) throws DataConverterException {
+    ArrayNode arr = fromData(content, ArrayNode.class);
+    Iterator<JsonNode> arrElements = arr.elements();
+    Object[] parameters = new Object[arr.size()];
+    Class<?>[] parameterTypes = method.getParameterTypes();
+    try {
+      for (int i=0; i < arr.size(); i++) {
+        parameters[i] = mapper.treeToValue(arrElements.next(), parameterTypes[i]);
+      }
+    }
+    catch (JsonProcessingException jsonProcessingException) {
+      throwDataConverterException(jsonProcessingException, null);
+    }
+    return parameters;
+  }
+
+  private void throwDataConverterException(Throwable e, Object value) {
+    if (value == null) {
+        throw new DataConverterException("Failure serializing null value", e);
+    }
+    throw new DataConverterException("Failure serializing \"" + value + "\" of type \"" + value.getClass() + "\"", e);
+  }
+}

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/MethodAwareDataConverter.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/MethodAwareDataConverter.java
@@ -1,0 +1,7 @@
+package com.amazonaws.services.simpleworkflow.flow;
+
+import java.lang.reflect.Method;
+
+public interface MethodAwareDataConverter {
+  public Object[] fromDataForMethod(String content, Method method) throws DataConverterException;
+}

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOActivityImplementation.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOActivityImplementation.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CancellationException;
 import com.amazonaws.services.simpleworkflow.flow.ActivityExecutionContext;
 import com.amazonaws.services.simpleworkflow.flow.ActivityFailureException;
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
+import com.amazonaws.services.simpleworkflow.flow.MethodAwareDataConverter;
 import com.amazonaws.services.simpleworkflow.flow.DataConverterException;
 import com.amazonaws.services.simpleworkflow.flow.common.WorkflowExecutionUtils;
 import com.amazonaws.services.simpleworkflow.flow.generic.ActivityImplementationBase;
@@ -57,7 +58,7 @@ class POJOActivityImplementation extends ActivityImplementationBase {
         // after new parameters were added to activity method
         // It requires creation of inputParameters array of the correct size and
         // populating the new parameter values with default values for each type
-        Object[] inputParameters = converter.fromData(input, Object[].class);
+        Object[] inputParameters = deserializeParameters(converter,input,activity);
         CurrentActivityExecutionContext.set(context);
         Object result = null;
         try {
@@ -87,6 +88,16 @@ class POJOActivityImplementation extends ActivityImplementationBase {
     @Override
     public ActivityTypeExecutionOptions getExecutionOptions() {
         return executionOptions;
+    }
+
+    private Object[] deserializeParameters(DataConverter c, String input, Method method)
+            throws DataConverterException {
+        if (c instanceof MethodAwareDataConverter) {
+            MethodAwareDataConverter madc = (MethodAwareDataConverter) c;
+            return madc.fromDataForMethod(input, method);
+        } else {
+            return c.fromData(input, Object[].class);
+        }
     }
     
     void throwActivityFailureException(Throwable exception) 

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinition.java
@@ -71,8 +71,8 @@ public class POJOWorkflowDefinition extends WorkflowDefinition {
                 // after new parameters were added to @Execute method
                 // It requires creation of parameters array of the correct size and
                 // populating the new parameter values with default values for each type
-                Object[] parameters = c.fromData(input, Object[].class);
                 Method method = workflowMethod.getMethod();
+                Object[] parameters = deserializeParameters(c, input, method);
                 Object r = invokeMethod(method, parameters);
                 if (!method.getReturnType().equals(Void.TYPE)) {
                     methodResult.set((Promise) r);
@@ -108,8 +108,8 @@ public class POJOWorkflowDefinition extends WorkflowDefinition {
                 c = converter;
             }
             Method method = signalMethod.getMethod();
-            Object[] parameters = c.fromData(details, Object[].class);
             try {
+                Object[] parameters = deserializeParameters(c, details, method);
                 invokeMethod(method, parameters);
             }
             catch (Throwable e) {
@@ -142,6 +142,16 @@ public class POJOWorkflowDefinition extends WorkflowDefinition {
         catch (Throwable e) {
             throwWorkflowException(c, e);
             throw new IllegalStateException("Unreacheable");
+        }
+    }
+
+    private Object[] deserializeParameters(DataConverter c, String input, Method method)
+            throws DataConverterException {
+        if (c instanceof MethodAwareDataConverter) {
+            MethodAwareDataConverter madc = (MethodAwareDataConverter) c;
+            return madc.fromDataForMethod(input, method);
+        } else {
+            return c.fromData(input, Object[].class);
         }
     }
 


### PR DESCRIPTION
Allows developers to disable the default typing on an ObjectMapper and still be able to use the Flow framework successfully.