### PR TITLE
Fix Content-Type of CompleteMultipartUpload

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -2520,7 +2520,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         request.addParameter("uploadId", uploadId);
 
         byte[] xml = RequestXmlFactory.convertToXmlByteArray(completeMultipartUploadRequest.getPartETags());
-        request.addHeader("Content-Type", "text/plain");
+        request.addHeader("Content-Type", "application/xml");
         request.addHeader("Content-Length", String.valueOf(xml.length));
 
         request.setContent(new ByteArrayInputStream(xml));


### PR DESCRIPTION
Although the content body is XML, the Content-Type is
set to text/plain. This patch sets it to application/xml.

Signed-off-by: Akira Hayakawa <ruby.wktk@gmail.com>