### PR TITLE
Change AWS4Signer newSigningKey method to protected

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -569,7 +569,7 @@ public class AWS4Signer extends AbstractAWSSigner implements
     /**
      * Generates a new signing key from the given parameters and returns it.
      */
-    private byte[] newSigningKey(AWSCredentials credentials,
+    protected byte[] newSigningKey(AWSCredentials credentials,
             String dateStamp, String regionName, String serviceName) {
         byte[] kSecret = ("AWS4" + credentials.getAWSSecretKey())
                 .getBytes(Charset.forName("UTF-8"));


### PR DESCRIPTION
We'd like to keep credential secret keys in a separate secure system and
have that system generate the signingKey.

If we can override this method, that would make it easy to create a
subclass of AWS4Signer and use it as the signerOverride in the
ClientConfiguration