### PR TITLE
Prevent livelock in HashMap operations during concurrent requests to enable Bouncy Castle

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CryptoRuntime.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CryptoRuntime.java
@@ -26,12 +26,15 @@ import org.apache.commons.logging.LogFactory;
 public class CryptoRuntime {
     static final String BOUNCY_CASTLE_PROVIDER = "BC";
     private static final String BC_PROVIDER_FQCN = "org.bouncycastle.jce.provider.BouncyCastleProvider";
-    
-    public static boolean isBouncyCastleAvailable() {
+
+    public static synchronized boolean isBouncyCastleAvailable() {
         return Security.getProvider(BOUNCY_CASTLE_PROVIDER) != null;
     }
 
-    public static void enableBouncyCastle() {
+    public static synchronized void enableBouncyCastle() {
+        if (isBouncyCastleAvailable()) {
+            return;
+        }
         try {
             @SuppressWarnings("unchecked")
             Class<Provider> c = (Class<Provider>)Class.forName(BC_PROVIDER_FQCN);
@@ -42,7 +45,7 @@ public class CryptoRuntime {
                     "Bouncy Castle not available", e);
         }
     }
-    
+
     /**
      * Used only for unit test when the same class loader is used across
      * multiple unit tests.
@@ -51,7 +54,7 @@ public class CryptoRuntime {
         recheckAesGcmAvailablility();
         recheckRsaKeyWrapAvailablility();
     }
-    
+
     public static boolean isAesGcmAvailable() { return AesGcm.isAvailable; }
     public static void recheckAesGcmAvailablility() { AesGcm.recheck(); }
 


### PR DESCRIPTION
We ended up livelocking in a couple instances when using the aws java sdk in the context of a hadoop filesystem due to the fact that multiple threads calling getFilesystem get the same instance.  Here's a snippet of a thread dump showing the livelock.  I fear there might be a whole bunch of places where the sdk is not threadsafe, so I'd like to request that the team maintaining this take a look over the code and make sure that threadsafety is accounted for.

Thread 56: Executor task launch worker-0 (RUNNABLE)
java.util.HashMap.put(HashMap.java:494)
org.bouncycastle.jce.provider.BouncyCastleProvider.addKeyInfoConverter(Unknown Source)
org.bouncycastle.jcajce.provider.util.AsymmetricAlgorithmProvider.registerOid(Unknown Source)
org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings.configure(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.setup(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(Unknown Source)
java.security.AccessController.doPrivileged(Native Method)
org.bouncycastle.jce.provider.BouncyCastleProvider.<init>(Unknown Source)
sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
java.lang.reflect.Constructor.newInstance(Constructor.java:526)
java.lang.Class.newInstance(Class.java:379)
com.amazonaws.services.s3.internal.crypto.CryptoRuntime.enableBouncyCastle(CryptoRuntime.java:38)
com.amazonaws.services.s3.model.CryptoConfiguration.check(CryptoConfiguration.java:234)
com.amazonaws.services.s3.model.CryptoConfiguration.setCryptoMode(CryptoConfiguration.java:168)
com.amazonaws.services.s3.internal.crypto.CryptoModuleDispatcher.<init>(CryptoModuleDispatcher.java:91)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:446)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:425)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:413)
org.apache.hadoop.fs.s3native.content.AwsMetadataEncryptedContentManager.getS3Service(AwsMetadataEncryptedContentManager.java:36)
org.apache.hadoop.fs.s3native.AmazonS3Store.initialize(AmazonS3Store.java:177)
org.apache.hadoop.fs.s3native.AmazonS3Store.initialize(AmazonS3Store.java:160)
org.apache.hadoop.fs.s3native.NativeS3FileSystem.initialize(NativeS3FileSystem.java:272)
org.apache.hadoop.fs.s3native.UDPNativeS3FileSystem.initialize(UDPNativeS3FileSystem.java:149)
org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2397)
org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:89)
org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2431)
org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2413)
org.apache.hadoop.fs.FileSystem.get(FileSystem.java:368)
org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter.<init>(FileOutputCommitter.java:91)
org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter.<init>(FileOutputCommitter.java:74)
org.apache.parquet.hadoop.ParquetOutputCommitter.<init>(ParquetOutputCommitter.java:41)
org.apache.spark.sql.parquet.DirectParquetOutputCommitter.<init>(DirectParquetOutputCommitter.scala:28)
...

Thread 57: Executor task launch worker-1 (RUNNABLE)
java.util.HashMap.put(HashMap.java:494)
org.bouncycastle.jce.provider.BouncyCastleProvider.addKeyInfoConverter(Unknown Source)
org.bouncycastle.jcajce.provider.util.AsymmetricAlgorithmProvider.registerOid(Unknown Source)
org.bouncycastle.jcajce.provider.asymmetric.ECGOST$Mappings.configure(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.loadAlgorithms(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.setup(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider.access$000(Unknown Source)
org.bouncycastle.jce.provider.BouncyCastleProvider$1.run(Unknown Source)
java.security.AccessController.doPrivileged(Native Method)
org.bouncycastle.jce.provider.BouncyCastleProvider.<init>(Unknown Source)
sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:57)
sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
java.lang.reflect.Constructor.newInstance(Constructor.java:526)
java.lang.Class.newInstance(Class.java:379)
com.amazonaws.services.s3.internal.crypto.CryptoRuntime.enableBouncyCastle(CryptoRuntime.java:38)
com.amazonaws.services.s3.model.CryptoConfiguration.check(CryptoConfiguration.java:234)
com.amazonaws.services.s3.model.CryptoConfiguration.setCryptoMode(CryptoConfiguration.java:168)
com.amazonaws.services.s3.internal.crypto.CryptoModuleDispatcher.<init>(CryptoModuleDispatcher.java:91)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:446)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:425)
com.amazonaws.services.s3.AmazonS3EncryptionClient.<init>(AmazonS3EncryptionClient.java:413)
org.apache.hadoop.fs.s3native.content.AwsMetadataEncryptedContentManager.getS3Service(AwsMetadataEncryptedContentManager.java:36)
org.apache.hadoop.fs.s3native.AmazonS3Store.initialize(AmazonS3Store.java:177)
org.apache.hadoop.fs.s3native.AmazonS3Store.initialize(AmazonS3Store.java:160)
org.apache.hadoop.fs.s3native.NativeS3FileSystem.initialize(NativeS3FileSystem.java:272)
org.apache.hadoop.fs.s3native.UDPNativeS3FileSystem.initialize(UDPNativeS3FileSystem.java:149)
org.apache.hadoop.fs.FileSystem.createFileSystem(FileSystem.java:2397)
org.apache.hadoop.fs.FileSystem.access$200(FileSystem.java:89)
org.apache.hadoop.fs.FileSystem$Cache.getInternal(FileSystem.java:2431)
org.apache.hadoop.fs.FileSystem$Cache.get(FileSystem.java:2413)
org.apache.hadoop.fs.FileSystem.get(FileSystem.java:368)
org.apache.hadoop.fs.Path.getFileSystem(Path.java:296)
org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter.<init>(FileOutputCommitter.java:91)
org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter.<init>(FileOutputCommitter.java:74)
org.apache.parquet.hadoop.ParquetOutputCommitter.<init>(ParquetOutputCommitter.java:41)
org.apache.spark.sql.parquet.DirectParquetOutputCommitter.<init>(DirectParquetOutputCommitter.scala:28)
...