### PR TITLE
SQS permissions apparently require that the 'sqs:' be capitalized

### DIFF
--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/auth/policy/actions/SQSActions.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/auth/policy/actions/SQSActions.java
@@ -21,43 +21,43 @@ import com.amazonaws.auth.policy.Action;
  */
 public enum SQSActions implements Action {
     /** Represents any action executed on Amazon SQS. */
-    AllSQSActions("sqs:*"),
+    AllSQSActions("SQS:*"),
 
     /** Action for the AddPermission operation. */
-    AddPermission("sqs:AddPermission"),
+    AddPermission("SQS:AddPermission"),
 
     /** Action for the ChangeMessageVisibility operation. */
-    ChangeMessageVisibility("sqs:ChangeMessageVisibility"),
+    ChangeMessageVisibility("SQS:ChangeMessageVisibility"),
 
     /** Action for the CreateQueue operation. */
-    CreateQueue("sqs:CreateQueue"),
+    CreateQueue("SQS:CreateQueue"),
 
     /** Action for the DeleteMessage operation. */
-    DeleteMessage("sqs:DeleteMessage"),
+    DeleteMessage("SQS:DeleteMessage"),
 
     /** Action for the DeleteQueue operation. */
-    DeleteQueue("sqs:DeleteQueue"),
+    DeleteQueue("SQS:DeleteQueue"),
 
     /** Action for the GetQueueAttributes operation. */
-    GetQueueAttributes("sqs:GetQueueAttributes"),
+    GetQueueAttributes("SQS:GetQueueAttributes"),
 
     /** Action for the GetQueueUrl operation. */
-    GetQueueUrl("sqs:GetQueueUrl"),
+    GetQueueUrl("SQS:GetQueueUrl"),
 
     /** Action for the ListQueues operation. */
-    ListQueues("sqs:ListQueues"),
+    ListQueues("SQS:ListQueues"),
 
     /** Action for the ReceiveMessage operation. */
-    ReceiveMessage("sqs:ReceiveMessage"),
+    ReceiveMessage("SQS:ReceiveMessage"),
 
     /** Action for the RemovePermission operation. */
-    RemovePermission("sqs:RemovePermission"),
+    RemovePermission("SQS:RemovePermission"),
 
     /** Action for the SendMessage operation. */
-    SendMessage("sqs:SendMessage"),
+    SendMessage("SQS:SendMessage"),
 
     /** Action for the SetQueueAttributes operation. */
-    SetQueueAttributes("sqs:SetQueueAttributes");
+    SetQueueAttributes("SQS:SetQueueAttributes");
 
     private final String action;
 

--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/auth/policy/actions/SQSActions.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/auth/policy/actions/SQSActions.java
@@ -69,3 +69,4 @@ public enum SQSActions implements Action {
         return this.action;
     }
 }
+


### PR DESCRIPTION
When attempting to use this class to construct and set SQS permissions on an existing queue, while the permissions save successfully, they don't seem to be functional. Using this to add the `SendMessage` permission to an SQS queue (for an SNS Topic ARN), for instance, results in the permission appearing to be set, but once the queue is subscribed to the SNS topic, messages sent to a queue with its permissions set via this method fail to show up therein, whereas messages sent to another queue which has had its permissions set via the AWS console appear as expected. The only difference between the two is capitalization, and resaving the first queue's permissions successfully changes the permission to a capitalized "SQS", whereafter the queue receives the messages as expected.