### PR TITLE
Use Content-Type application/octet-stream when not set

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -3584,7 +3584,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
              */
             if (!request.getHeaders().containsKey(Headers.CONTENT_TYPE)) {
                 request.addHeader(Headers.CONTENT_TYPE,
-                    "application/x-www-form-urlencoded; charset=utf-8");
+                    "application/octet-stream");
             }
             AWSCredentials credentials = awsCredentialsProvider.getCredentials();
             if (originalRequest.getRequestCredentials() != null) {


### PR DESCRIPTION
Previously the SDK provided application/x-www-form-urlencoded, which
confused servers like S3Proxy.  The underlying Jetty interpreted a
multi-part put object entity body as form data, exhausting the fixed
buffer size.  Fixes andrewgaul/s3proxy#80.