### PR TITLE
Improved type resolution in decider registration cargs

### DIFF
--- a/aws-java-sdk-osgi/dependency-reduced-pom.xml
+++ b/aws-java-sdk-osgi/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>aws-java-sdk-pom</artifactId>
     <groupId>com.amazonaws</groupId>
-    <version>1.10.39</version>
+    <version>1.10.40-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/SpringTestPOJOWorkflowImplementationGenericWorkflowClient.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/junit/spring/SpringTestPOJOWorkflowImplementationGenericWorkflowClient.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
-import com.amazonaws.services.simpleworkflow.flow.DecisionContext;
 import com.amazonaws.services.simpleworkflow.flow.DecisionContextProvider;
 import com.amazonaws.services.simpleworkflow.flow.WorkflowException;
 import com.amazonaws.services.simpleworkflow.flow.core.Promise;
@@ -29,7 +28,7 @@ import com.amazonaws.services.simpleworkflow.flow.generic.StartChildWorkflowExec
 import com.amazonaws.services.simpleworkflow.flow.generic.StartChildWorkflowReply;
 import com.amazonaws.services.simpleworkflow.flow.pojo.POJOWorkflowDefinitionFactoryFactory;
 import com.amazonaws.services.simpleworkflow.flow.pojo.POJOWorkflowImplementationFactory;
-import com.amazonaws.services.simpleworkflow.flow.spring.WorkflowScope;
+import com.amazonaws.services.simpleworkflow.flow.spring.POJOWorkflowStubImplementationFactory;
 import com.amazonaws.services.simpleworkflow.flow.test.TestGenericWorkflowClient;
 import com.amazonaws.services.simpleworkflow.model.WorkflowExecution;
 import com.amazonaws.services.simpleworkflow.model.WorkflowType;
@@ -49,25 +48,7 @@ public class SpringTestPOJOWorkflowImplementationGenericWorkflowClient implement
                 if (instanceProxy == null) {
                     throw new IllegalArgumentException("unknown workflowImplementationType: " + workflowImplementationType);
                 }
-                return new POJOWorkflowImplementationFactory() {
-
-                    @Override
-                    public Object newInstance(DecisionContext decisionContext) throws Exception {
-                        WorkflowScope.setDecisionContext(decisionContext);
-                        return instanceProxy;
-                    }
-
-                    @Override
-                    public Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception {
-                        WorkflowScope.setDecisionContext(decisionContext);
-                        return instanceProxy;
-                    }
-
-                    @Override
-                    public void deleteInstance(Object instance) {
-                        WorkflowScope.removeDecisionContext();
-                    }
-                };
+                return new POJOWorkflowStubImplementationFactory(instanceProxy);
             }
         });
     }

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinitionFactoryFactory.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowDefinitionFactoryFactory.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.simpleworkflow.flow.pojo;
 
+import java.beans.Expression;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -233,15 +234,7 @@ public class POJOWorkflowDefinitionFactoryFactory extends WorkflowDefinitionFact
 
             @Override
             public Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception {
-                List<Class<?>> constructorArgsTypes = new ArrayList<Class<?>>();
-
-                for (Object arg : constructorArgs) {
-                    constructorArgsTypes.add(arg.getClass());
-                }
-
-                Class<?>[] constructorArgsTypesArray = constructorArgsTypes.toArray(new Class<?>[constructorArgs.length]);
-
-                return workflowImplementationType.getDeclaredConstructor(constructorArgsTypesArray).newInstance(constructorArgs);
+                return new Expression(workflowImplementationType, "new", constructorArgs).getValue();
             }
 
             @Override

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowImplementationFactory.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/pojo/POJOWorkflowImplementationFactory.java
@@ -18,10 +18,10 @@ import com.amazonaws.services.simpleworkflow.flow.DecisionContext;
 
 public interface POJOWorkflowImplementationFactory {
     
-    public Object newInstance(DecisionContext decisionContext) throws Exception;
+    Object newInstance(DecisionContext decisionContext) throws Exception;
 
-    public Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception;
+    Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception;
 
-    public void deleteInstance(Object instance);
+    void deleteInstance(Object instance);
 
 }

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/POJOWorkflowStubImplementationFactory.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/POJOWorkflowStubImplementationFactory.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2012-2015 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.simpleworkflow.flow.spring;
+
+import com.amazonaws.services.simpleworkflow.flow.DecisionContext;
+import com.amazonaws.services.simpleworkflow.flow.pojo.POJOWorkflowImplementationFactory;
+
+/**
+ * A stub implementation of the @see{POJOWorkflowImplementationFactory}
+ * Used for Spring injection proxying
+ *
+ * @author nicholasterry
+ */
+public class POJOWorkflowStubImplementationFactory implements POJOWorkflowImplementationFactory {
+
+    private Object instanceProxy;
+
+    public POJOWorkflowStubImplementationFactory(Object instanceProxy) {
+    this.instanceProxy = instanceProxy;
+  }
+
+    @Override
+    public Object newInstance(DecisionContext decisionContext) throws Exception {
+      return newInstance(decisionContext, null);
+    }
+
+    @Override
+    public Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception {
+      WorkflowScope.setDecisionContext(decisionContext);
+      return instanceProxy;
+    }
+
+    @Override
+    public void deleteInstance(Object instance) {
+    WorkflowScope.removeDecisionContext();
+  }
+}

--- a/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringWorkflowDefinitionFactoryFactory.java
+++ b/aws-java-sdk-swf-libraries/src/main/java/com/amazonaws/services/simpleworkflow/flow/spring/SpringWorkflowDefinitionFactoryFactory.java
@@ -18,7 +18,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 import com.amazonaws.services.simpleworkflow.flow.DataConverter;
-import com.amazonaws.services.simpleworkflow.flow.DecisionContext;
 import com.amazonaws.services.simpleworkflow.flow.generic.WorkflowDefinitionFactory;
 import com.amazonaws.services.simpleworkflow.flow.generic.WorkflowDefinitionFactoryFactory;
 import com.amazonaws.services.simpleworkflow.flow.pojo.POJOWorkflowDefinitionFactoryFactory;
@@ -36,26 +35,7 @@ class SpringWorkflowDefinitionFactoryFactory extends WorkflowDefinitionFactoryFa
             if (instanceProxy == null) {
                 throw new IllegalArgumentException("unknown workflowImplementationType: " + workflowImplementationType);
             }
-            return new POJOWorkflowImplementationFactory() {
-
-                @Override
-                public Object newInstance(DecisionContext decisionContext) throws Exception {
-                    WorkflowScope.setDecisionContext(decisionContext);
-                    return instanceProxy;
-                }
-
-                @Override
-                public Object newInstance(DecisionContext decisionContext, Object[] constructorArgs) throws Exception {
-                    WorkflowScope.setDecisionContext(decisionContext);
-                    return instanceProxy;
-                }
-
-                @Override
-                public void deleteInstance(Object instance) {
-                    WorkflowScope.removeDecisionContext();
-                }
-
-            };
+            return new POJOWorkflowStubImplementationFactory(instanceProxy);
         }
 
     };


### PR DESCRIPTION
Brought in java.beans.Expression class to perform dynamic
constructor resolution. This is in response to some feedback
from Luc on the SWF team.

Also removed some redundant code and added a stub POJO to replace
an anonymous SWF POJO implementation.