### PR TITLE
slight fix to wording in ClientConfiguration documentation

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -905,7 +905,7 @@ public class ClientConfiguration {
      * <p>
      * <b>Note:</b> This feature is not compatible with Java 1.6.
      * </p>
-     * 
+     *
      * @return The amount of time (in milliseconds) to allow the client to complete the execution of
      *         an API call.
      * @see {@link ClientConfiguration#setRequestTimeout(int)} to enforce a timeout per HTTP request
@@ -915,7 +915,7 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the amount of time (in milliseconds) to allow the client to complete the execution of
+     * Sets the amount of time (in milliseconds) to allow the client to complete the execution of
      * an API call. This timeout covers the entire client execution except for marshalling. This
      * includes request handler execution, all HTTP request including retries, unmarshalling, etc.
      * <p>
@@ -950,7 +950,7 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the amount of time (in milliseconds) to allow the client to complete the execution of
+     * Sets the amount of time (in milliseconds) to allow the client to complete the execution of
      * an API call. This timeout covers the entire client execution except for marshalling. This
      * includes request handler execution, all HTTP request including retries, unmarshalling, etc.
      * <p>


### PR DESCRIPTION
A couple of methods set timeouts but claimed to return them. This has been fixed.