### PR TITLE
Copy the list of ETags before sorting

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/transform/RequestXmlFactory.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/transform/RequestXmlFactory.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.s3.model.transform;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -39,7 +40,8 @@ public class RequestXmlFactory {
         XmlWriter xml = new XmlWriter();
         xml.start("CompleteMultipartUpload");
         if (partETags != null) {
-            Collections.sort(partETags, new Comparator<PartETag>() {
+            List<PartETag> sortedPartETags = new ArrayList<PartETag>(partETags);
+            Collections.sort(sortedPartETags, new Comparator<PartETag>() {
                 public int compare(PartETag tag1, PartETag tag2) {
                     if (tag1.getPartNumber() < tag2.getPartNumber()) return -1;
                     if (tag1.getPartNumber() > tag2.getPartNumber()) return 1;
@@ -47,7 +49,7 @@ public class RequestXmlFactory {
                 }
             });
 
-            for (PartETag partEtag : partETags) {
+            for (PartETag partEtag : sortedPartETags) {
                 xml.start("Part");
                 xml.start("PartNumber").value(Integer.toString(partEtag.getPartNumber())).end();
                 xml.start("ETag").value(partEtag.getETag()).end();


### PR DESCRIPTION
Some S3 multipart upload implementations (for example, the new hadoop
S3 code) pass an immutable list of ETags to `complete`. This can
cause problems when we try to sort the ETags for inclusion in the
actual request.

We can sidestep that by just copying the list before we try to sort
it.

Thanks in advance!