### PR TITLE
Process headers case-insensitive

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
@@ -110,29 +110,29 @@ public abstract class AbstractS3ResponseHandler<T>
                 metadata.addUserMetadata(key, header.getValue());
             } else if (ignoredHeaders.contains(key)) {
                 // ignore...
-            } else if (key.equals(Headers.LAST_MODIFIED)) {
+            } else if (key.equalsIgnoreCase(Headers.LAST_MODIFIED)) {
                 try {
                     metadata.setHeader(key, ServiceUtils.parseRfc822Date(header.getValue()));
                 } catch (Exception pe) {
                     log.warn("Unable to parse last modified date: " + header.getValue(), pe);
                 }
-            } else if (key.equals(Headers.CONTENT_LENGTH)) {
+            } else if (key.equalsIgnoreCase(Headers.CONTENT_LENGTH)) {
                 try {
                     metadata.setHeader(key, Long.parseLong(header.getValue()));
                 } catch (NumberFormatException nfe) {
                     log.warn("Unable to parse content length: " + header.getValue(), nfe);
                 }
-            } else if (key.equals(Headers.ETAG)) {
+            } else if (key.equalsIgnoreCase(Headers.ETAG)) {
                 metadata.setHeader(key, ServiceUtils.removeQuotes(header.getValue()));
-            } else if (key.equals(Headers.EXPIRES)) {
+            } else if (key.equalsIgnoreCase(Headers.EXPIRES)) {
                 try {
                     metadata.setHttpExpiresDate(DateUtils.parseRFC822Date(header.getValue()));
                 } catch (Exception pe) {
                     log.warn("Unable to parse http expiration date: " + header.getValue(), pe);
                 }
-            } else if (key.equals(Headers.EXPIRATION)) {
+            } else if (key.equalsIgnoreCase(Headers.EXPIRATION)) {
                 new ObjectExpirationHeaderHandler<ObjectMetadata>().handle(metadata, response);
-            } else if (key.equals(Headers.RESTORE)) {
+            } else if (key.equalsIgnoreCase(Headers.RESTORE)) {
                 new ObjectRestoreHeaderHandler<ObjectRestoreResult>().handle(metadata, response);
             } else {
                 metadata.setHeader(key, header.getValue());

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
@@ -19,7 +19,7 @@ import static com.amazonaws.util.DateUtils.cloneDate;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
+import java.util.TreeMap;
 import java.util.Map;
 
 import com.amazonaws.services.s3.Headers;
@@ -46,13 +46,13 @@ public class ObjectMetadata implements ServerSideEncryptionResult,
      * Custom user metadata, represented in responses with the x-amz-meta-
      * header prefix
      */
-    private Map<String, String> userMetadata = new HashMap<String, String>();
+    private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
     /**
      * All other (non user custom) headers such as Content-Length, Content-Type,
      * etc.
      */
-    private Map<String, Object> metadata = new HashMap<String, Object>();
+    private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
 
     public static final String AES_256_SERVER_SIDE_ENCRYPTION =
             SSEAlgorithm.AES256.getAlgorithm();
@@ -94,11 +94,11 @@ public class ObjectMetadata implements ServerSideEncryptionResult,
     private ObjectMetadata(ObjectMetadata from) {
         this.userMetadata = from.userMetadata == null
             ? null
-            : new HashMap<String,String>(from.userMetadata);
+            : new TreeMap<String,String>(from.userMetadata);
         // shallow clone the meata data
         this.metadata = from.metadata == null
             ? null
-            : new HashMap<String, Object>(from.metadata);
+            : new TreeMap<String, Object>(from.metadata);
         this.expirationTime = cloneDate(from.expirationTime);
         this.expirationTimeRuleId = from.expirationTimeRuleId;
         this.httpExpiresDate = cloneDate(from.httpExpiresDate);
@@ -228,7 +228,7 @@ public class ObjectMetadata implements ServerSideEncryptionResult,
      * @return A map of the raw metadata/headers for the associated object.
      */
     public Map<String, Object> getRawMetadata() {
-        return Collections.unmodifiableMap(new HashMap<String,Object>(metadata));
+        return Collections.unmodifiableMap(new TreeMap<String,Object>(metadata));
     }
 
     /**


### PR DESCRIPTION
According to RFC 2616 section 4.2 HTTP header fields should be processed case insensitive (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):
"Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive."

This is currently not being done by the aws-java-sdk-s3 module, causing file uploads to S3 compatible storage providers such as Riak CS to fail. The reason they fail is because the response headers from Riak CS have a "Etag" field, while the aws-java-sdk-s3 module expects "ETag".

The attached changes fix this by handling all headers case insensitive. The used TreeMap will be a bit slower than a HashMap, but this should be in the range of nano-seconds, which I would not expect to be a bottleneck. If there are scenarios I cannot oversee right now, which do make this a bottleneck, all headers could first be put to lowercase and then stored in and retrieved from the HashMap, but this looks less elegant in code in my opinion.