### PR TITLE
Fix typo in SNS SignatureChecker causing verification of SubscriptionConfirmation messages to fail

### DIFF
--- a/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/util/SignatureChecker.java
+++ b/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/util/SignatureChecker.java
@@ -55,7 +55,7 @@ public class SignatureChecker {
     private final String SUBJECT = "Subject";
     private final String TOPIC = "TopicArn";
     private final String TOKEN = "Token";
-    private final Set<String> INTERESTING_FIELDS = new HashSet<String>(Arrays.asList(TYPE, SUBSCRIBE_TYPE, MESSAGE,
+    private final Set<String> INTERESTING_FIELDS = new HashSet<String>(Arrays.asList(TYPE, SUBSCRIBE_URL, MESSAGE,
             TIMESTAMP, SIGNATURE, SIGNATURE_VERSION, MESSAGE_ID, SUBJECT, TOPIC, TOKEN));
 
     /**


### PR DESCRIPTION
The SNS SignatureChecker class doesn't currently work with `SubscriptionConfirmation` messages because the `SubscribeURL` is not included as part of the signature verification due to a typo in the code.

The `INTERESTING_FIELDS` set currently includes `SUBSCRIBE_TYPE` which is defined as:

    private final String SUBSCRIBE_TYPE = "SubscriptionConfirmation";

This doesn't make any sense because `SubscriptionConfirmation` is not a field name.  It's a value of the `Type` field.

Instead of `SUBSCRIBE_TYPE` it should be `SUBSCRIBE_URL`.
