### PR TITLE
ClientConfiguration checks Java proxy properties

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -466,11 +466,7 @@ public class ClientConfiguration {
      * @return The proxy host the client will connect through.
      */
     public String getProxyHost() {
-        if (proxyHost != null) {
-            return proxyHost;
-        } else {
-            return getProxyHostProperty();
-        }
+        return (proxyHost != null) ? proxyHost : getProxyHostProperty();
     }
 
     /**
@@ -500,15 +496,11 @@ public class ClientConfiguration {
      * Returns the Java system property for proxy port depending on
      * {@link this.getProtocol()}: i.e. if protocol is https, returns
      * the value of the system property https.proxyPort, otherwise
-     * returns value of http.proxyPort.
+     * returns value of http.proxyPort.  Defaults to {@link this.proxyPort}
+     * if the system property is not set with a valid port number.
      */
     private int getProxyPortProperty() {
-        String proxyPortString;
-        if (getProtocol() == Protocol.HTTPS) {
-            proxyPortString = System.getProperty("https.proxyPort");
-        } else {
-            proxyPortString = System.getProperty("http.proxyPort");
-        }
+        String proxyPortString = (getProtocol() == Protocol.HTTPS) ? System.getProperty("https.proxyPort") : System.getProperty("http.proxyPort");
         try {
             return Integer.parseInt(proxyPortString);
         } catch (NumberFormatException e) {
@@ -527,11 +519,7 @@ public class ClientConfiguration {
      * @return The proxy port the client will connect through.
      */
     public int getProxyPort() {
-        if (proxyPort > 0) {
-            return proxyPort;
-        } else {
-            return getProxyPortProperty();
-        }
+        return (proxyPort >= 0) ? proxyPort : getProxyPortProperty();
     }
 
     /**
@@ -564,11 +552,7 @@ public class ClientConfiguration {
      * returns value of http.proxyUser.
      */
     private String getProxyUsernameProperty() {
-        if (getProtocol() == Protocol.HTTPS) {
-            return System.getProperty("https.proxyUser");
-        } else {
-            return System.getProperty("http.proxyUser");
-        }
+        return (getProtocol() == Protocol.HTTPS) ? System.getProperty("https.proxyUser") : System.getProperty("http.proxyUser");
     }
 
     /**
@@ -584,11 +568,7 @@ public class ClientConfiguration {
      *         proxy.
      */
     public String getProxyUsername() {
-        if (proxyUsername != null) {
-            return proxyUsername;
-        } else {
-            return getProxyUsernameProperty();
-        }
+        return (proxyUsername != null) ? proxyUsername : getProxyUsernameProperty();
     }
 
     /**
@@ -620,11 +600,7 @@ public class ClientConfiguration {
      * returns value of http.proxyPassword.
      */
     private String getProxyPasswordProperty() {
-        if (getProtocol() == Protocol.HTTPS) {
-            return System.getProperty("https.proxyPassword");
-        } else {
-            return System.getProperty("http.proxyPassword");
-        }
+        return (getProtocol() == Protocol.HTTPS) ? System.getProperty("https.proxyPassword") : System.getProperty("http.proxyPassword");
     }
 
     /**
@@ -639,11 +615,7 @@ public class ClientConfiguration {
      * @return The password to use when connecting through a proxy.
      */
     public String getProxyPassword() {
-        if (proxyPassword != null) {
-            return proxyPassword;
-        } else {
-            return getProxyPasswordProperty();
-        }
+        return (proxyPassword != null) ? proxyPassword : getProxyPasswordProperty();
     }
 
     /**

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -442,12 +442,35 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the optional proxy host the client will connect through.
+     * Returns the Java system property for proxy host depending on
+     * {@link this.getProtocol()}: i.e. if protocol is https, returns
+     * the value of the system property https.proxyHost, otherwise
+     * returns value of http.proxyHost.
+     */
+    private String getProxyHostProperty() {
+        if (getProtocol() == Protocol.HTTPS) {
+            return System.getProperty("https.proxyHost");
+        } else {
+            return System.getProperty("http.proxyHost");
+        }
+    }
+
+    /**
+     * Returns the optional proxy host the client will connect
+     * through.  Returns either the proxyHost set on this object, or
+     * if not provided, checks the value of the Java system property
+     * for proxy host according to {@link this.getProtocol()}: i.e. if
+     * protocol is https, returns the value of the system property
+     * https.proxyHost, otherwise returns value of http.proxyHost.
      *
      * @return The proxy host the client will connect through.
      */
     public String getProxyHost() {
-        return proxyHost;
+        if (proxyHost != null) {
+            return proxyHost;
+        } else {
+            return getProxyHostProperty();
+        }
     }
 
     /**
@@ -474,12 +497,41 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the optional proxy port the client will connect through.
+     * Returns the Java system property for proxy port depending on
+     * {@link this.getProtocol()}: i.e. if protocol is https, returns
+     * the value of the system property https.proxyPort, otherwise
+     * returns value of http.proxyPort.
+     */
+    private int getProxyPortProperty() {
+        String proxyPortString;
+        if (getProtocol() == Protocol.HTTPS) {
+            proxyPortString = System.getProperty("https.proxyPort");
+        } else {
+            proxyPortString = System.getProperty("http.proxyPort");
+        }
+        try {
+            return Integer.parseInt(proxyPortString);
+        } catch (NumberFormatException e) {
+            return proxyPort;
+        }
+    }
+
+    /**
+     * Returns the optional proxy port the client will connect
+     * through.  Returns either the proxyPort set on this object, or
+     * if not provided, checks the value of the Java system property
+     * for proxy port according to {@link this.getProtocol()}: i.e. if
+     * protocol is https, returns the value of the system property
+     * https.proxyPort, otherwise returns value of http.proxyPort.
      *
      * @return The proxy port the client will connect through.
      */
     public int getProxyPort() {
-        return proxyPort;
+        if (proxyPort > 0) {
+            return proxyPort;
+        } else {
+            return getProxyPortProperty();
+        }
     }
 
     /**
@@ -506,13 +558,37 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the optional proxy user name to use if connecting through a proxy.
+     * Returns the Java system property for proxy user name depending on
+     * {@link this.getProtocol()}: i.e. if protocol is https, returns
+     * the value of the system property https.proxyUser, otherwise
+     * returns value of http.proxyUser.
+     */
+    private String getProxyUsernameProperty() {
+        if (getProtocol() == Protocol.HTTPS) {
+            return System.getProperty("https.proxyUser");
+        } else {
+            return System.getProperty("http.proxyUser");
+        }
+    }
+
+    /**
+     * Returns the optional proxy user name to use if connecting
+     * through a proxy.  Returns either the proxyUsername set on this
+     * object, or if not provided, checks the value of the Java system
+     * property for proxy user name according to {@link this.getProtocol()}:
+     * i.e. if protocol is https, returns the value of the system
+     * property https.proxyUsername, otherwise returns value of
+     * http.proxyUsername.
      *
      * @return The optional proxy user name the configured client will use if connecting through a
      *         proxy.
      */
     public String getProxyUsername() {
-        return proxyUsername;
+        if (proxyUsername != null) {
+            return proxyUsername;
+        } else {
+            return getProxyUsernameProperty();
+        }
     }
 
     /**
@@ -538,12 +614,36 @@ public class ClientConfiguration {
     }
 
     /**
-     * Returns the optional proxy password to use when connecting through a proxy.
+     * Returns the Java system property for proxy password depending on
+     * {@link this.getProtocol()}: i.e. if protocol is https, returns
+     * the value of the system property https.proxyPassword, otherwise
+     * returns value of http.proxyPassword.
+     */
+    private String getProxyPasswordProperty() {
+        if (getProtocol() == Protocol.HTTPS) {
+            return System.getProperty("https.proxyPassword");
+        } else {
+            return System.getProperty("http.proxyPassword");
+        }
+    }
+
+    /**
+     * Returns the optional proxy password to use if connecting
+     * through a proxy.  Returns either the proxyPassword set on this
+     * object, or if not provided, checks the value of the Java system
+     * property for proxy password according to {@link this.getProtocol()}:
+     * i.e. if protocol is https, returns the value of the system
+     * property https.proxyPassword, otherwise returns value of
+     * http.proxyPassword.
      *
      * @return The password to use when connecting through a proxy.
      */
     public String getProxyPassword() {
-        return proxyPassword;
+        if (proxyPassword != null) {
+            return proxyPassword;
+        } else {
+            return getProxyPasswordProperty();
+        }
     }
 
     /**

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -17,6 +17,7 @@ package com.amazonaws;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import java.net.InetAddress;
@@ -84,6 +85,77 @@ public class ClientConfigurationTest {
         assertSame("custom dns resolver set via fluent API",
                 resolver,
                 config.getDnsResolver());
+    }
+
+    @Test
+    public void testProxySystemProperties() throws Exception {
+        ClientConfiguration config;
+        config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
+        assertEquals(config.getProxyPort(), -1);
+        assertNull(config.getProxyUsername());
+        assertNull(config.getProxyPassword());
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyHost());
+        assertEquals(config.getProxyPort(), -1);
+        assertNull(config.getProxyUsername());
+        assertNull(config.getProxyPassword());
+
+        System.setProperty("https.proxyHost", "foo");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyHost(), "foo");
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyHost());
+        System.clearProperty("https.proxyHost");
+
+        System.setProperty("http.proxyHost", "foo");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyHost(), "foo");
+        System.clearProperty("http.proxyHost");
+
+        System.setProperty("https.proxyPort", "8443");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyPort(), 8443);
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyPort(), -1);
+        System.clearProperty("https.proxyPort");
+
+        System.setProperty("http.proxyPort", "8080");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyPort(), -1);
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyPort(), 8080);
+        System.clearProperty("http.proxyPort");
+
+        System.setProperty("https.proxyUser", "foo");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyUsername(), "foo");
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyUsername());
+        System.clearProperty("https.proxyUser");
+
+        System.setProperty("http.proxyUser", "foo");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyUsername());
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyUsername(), "foo");
+        System.clearProperty("http.proxyUser");
+
+        System.setProperty("https.proxyPassword", "foo");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyPassword(), "foo");
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyPassword());
+        System.clearProperty("https.proxyPassword");
+
+        System.setProperty("http.proxyPassword", "foo");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyPassword());
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyPassword(), "foo");
+        System.clearProperty("http.proxyPassword");
     }
 
 }


### PR DESCRIPTION
Addresses #524:

* Always prefers set configuration variables over java system properties, but if unset:
  * Uses values of `https.proxy(Host|Port|User|Password)` if protocol is `Protocol.HTTPS`
  * Uses values of `http.proxy(Host|Port|User|Password)` if protocol is `Protocol.HTTP`

`http(s).proxyHost` and `http(s).proxyPort` are official parts of the [Java API](https://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html), whereas `http(s).proxyUser` and `http(s).proxyPassword` are traditions in the Java community.

Two useful follow-ons to this pull request that would really put a bow on #524 would be:

1. Passing `http.nonProxyHosts` (no `https` variant, as per spec) through to the clients somehow (useful e.g. to bypass proxy when hitting 169.254.169.254 in an AWS context, but widely used in general).  This addition could possibly be higher impact, as it introduces a new configuration that must be passed into the underlying HTTP client.
2. Checking, parsing, and using the widely used environment variables `HTTPS_PROXY`, `https_proxy`, `HTTP_PROXY`, `http_proxy`, `NO_PROXY`, and `no_proxy` (where the last two serve the same purpose as `http.nonProxyHosts`).  Precedence order would be: configured values, then Java system properties, then environment variables.  This change (modulo `NO_PROXY`) would be rather straightforward.

Are the above recommendations of interest?  I'd be happy to provide further pull requests.