### PR TITLE
S3 system property to disable sigv4 upgrade

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -115,6 +115,16 @@ public class SDKGlobalConfiguration {
         "com.amazonaws.services.s3.enforceV4";
 
     /**
+     * Like {@link #ENFORCE_S3_SIGV4_SYSTEM_PROPERTY}, but causes the client to
+     * never upgrade to Signature Version 4. This property is overridden by
+     * {@link #ENFORCE_S3_SIGV4_SYSTEM_PROPERTY} and Signature Version 4 will
+     * still be used when otherwise configured or overridden for a client
+     * instance.
+     */
+    public static final String DISABLE_S3_SIGV4_UPGRADE_SYSTEM_PROPERTY =
+        "com.amazonaws.services.s3.disableV4Upgrade";
+
+    /**
      * @deprecated with {@link AmazonWebServiceRequest#getRequestClientOptions()}
      * and {@link RequestClientOptions#setReadLimit(int)}.
      * <p>

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.s3;
 
+import static com.amazonaws.SDKGlobalConfiguration.DISABLE_S3_SIGV4_UPGRADE_SYSTEM_PROPERTY;
 import static com.amazonaws.SDKGlobalConfiguration.ENABLE_S3_SIGV4_SYSTEM_PROPERTY;
 import static com.amazonaws.SDKGlobalConfiguration.ENFORCE_S3_SIGV4_SYSTEM_PROPERTY;
 import static com.amazonaws.event.SDKProgressPublisher.publishProgress;
@@ -3077,6 +3078,12 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         // explicitly setting the region.
         if (System.getProperty(ENFORCE_S3_SIGV4_SYSTEM_PROPERTY) != null) {
             return true;
+        }
+
+        // User has disabled signature version upgrades - SigV4 will only be
+        // used when otherwise specified.
+        if (System.getProperty(DISABLE_S3_SIGV4_UPGRADE_SYSTEM_PROPERTY) != null) {
+            return false;
         }
 
         // User can ask to enable SigV4 if it's safe - this will fall back


### PR DESCRIPTION
This pull request adds a system property that can be used to disable upgrade to signature version 4 for S3.

The use case for this is against S3 clones that do not support signature v4 where code modifications are not possible (the signer override property of the client configuration can be used otherwise)

The system property does not disable signature version 4, only upgrades to signature v4, so in addition to the system property an override configuration may be required (awssdk_config_override.json)