### PR TITLE
Add generateDeleteTableRequest on DynamoDBMapper

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AbstractDynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AbstractDynamoDBMapper.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapper.FailedBatch;
 import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.s3.model.Region;
 
 /**
@@ -300,4 +301,8 @@ public class AbstractDynamoDBMapper implements IDynamoDBMapper {
         throw new UnsupportedOperationException();
     }
 
+    @Override
+    public DeleteTableRequest generateDeleteTableRequest(Class<?> clazz) {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -55,6 +55,7 @@ import com.amazonaws.services.dynamodbv2.model.Condition;
 import com.amazonaws.services.dynamodbv2.model.ConditionalCheckFailedException;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.DeleteRequest;
 import com.amazonaws.services.dynamodbv2.model.ExpectedAttributeValue;
@@ -2674,5 +2675,11 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         ItemConverter converter = getConverter(config);
         return schemaParser.parseTablePojoToCreateTableRequest(
                 clazz, config, reflector, converter);
+    }
+
+    @Override
+    public DeleteTableRequest generateDeleteTableRequest(Class<?> clazz) {
+        return schemaParser.parseTablePojoToDeleteTableRequest(
+                clazz, config);
     }
 }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTableSchemaParser.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTableSchemaParser.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperFieldModel.DynamoDBAttributeType;
 import com.amazonaws.services.dynamodbv2.model.AttributeDefinition;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.GlobalSecondaryIndex;
 import com.amazonaws.services.dynamodbv2.model.KeySchemaElement;
 import com.amazonaws.services.dynamodbv2.model.KeyType;
@@ -103,6 +104,26 @@ class DynamoDBTableSchemaParser {
         createTableRequest.setAttributeDefinitions(attrDefinitions.values());
 
         return createTableRequest;
+    }
+
+    /**
+     * Parse the given POJO class and return the DeleteTableRequest for the
+     * DynamoDB table it represents.
+     *
+     * @param clazz
+     *            The POJO class.
+     * @param config
+     *            The DynamoDBMapperConfig which contains the TableNameOverrides
+     *            parameter used to determine the table name.
+     */
+    DeleteTableRequest parseTablePojoToDeleteTableRequest(
+            Class<?> clazz,
+            DynamoDBMapperConfig config) {
+
+        DeleteTableRequest deleteTableRequest = new DeleteTableRequest();
+        deleteTableRequest.setTableName(DynamoDBMapper.internalGetTableName(clazz, null, config));
+
+        return deleteTableRequest;
     }
 
     TableIndexesInfo parseTableIndexes(final Class<?> clazz, final DynamoDBReflector reflector) {

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/IDynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/IDynamoDBMapper.java
@@ -25,6 +25,7 @@ import com.amazonaws.services.dynamodbv2.model.AttributeValue;
 import com.amazonaws.services.dynamodbv2.model.BatchGetItemRequest;
 import com.amazonaws.services.dynamodbv2.model.BatchWriteItemRequest;
 import com.amazonaws.services.dynamodbv2.model.CreateTableRequest;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 import com.amazonaws.services.dynamodbv2.model.PutItemRequest;
 import com.amazonaws.services.dynamodbv2.model.UpdateItemRequest;
 import com.amazonaws.services.s3.model.Region;
@@ -741,5 +742,12 @@ public interface IDynamoDBMapper {
      * indexes are initialized with the default projection type - KEY_ONLY.
      */
     CreateTableRequest generateCreateTableRequest(Class<?> clazz);
+
+
+    /**
+     * Parse the given POJO class and return the DeleteTableRequest for the DynamoDB table it
+     * represents.
+     */
+    DeleteTableRequest generateDeleteTableRequest(Class<?> clazz);
 
 }

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
@@ -1,0 +1,29 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
+
+public class DynamoDBMapperTest {
+
+    @Test
+    public void testGenerateDeleteTableRequest(){
+        String prefix = "DEV-";
+        final String tableName = "OBJECTORMEXAMPLE";
+
+        DynamoDBMapperConfig.TableNameOverride tableNameOverride =
+                DynamoDBMapperConfig.TableNameOverride.withTableNamePrefix(prefix);
+        DynamoDBMapperConfig config = new DynamoDBMapperConfig(tableNameOverride);
+        DynamoDBMapper dynamoDBMapper = new DynamoDBMapper(null, config);
+
+        // Create the simplest table as possible for our test purposes only
+        @DynamoDBTable(tableName = tableName)
+        class ObjectORMExample{}
+
+        // test
+        DeleteTableRequest deleteTableRequest = dynamoDBMapper.generateDeleteTableRequest(ObjectORMExample.class);
+        assertEquals(deleteTableRequest.getTableName(), prefix.concat(tableName));
+    }
+
+}

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
@@ -8,7 +8,22 @@ import com.amazonaws.services.dynamodbv2.model.DeleteTableRequest;
 public class DynamoDBMapperTest {
 
     @Test
-    public void testGenerateDeleteTableRequest(){
+    public void testGenerateDeleteTableRequest1(){
+        final String tableName = "OBJECTORMEXAMPLE";
+
+        DynamoDBMapper dynamoDBMapper = new DynamoDBMapper(null);
+
+        // Create the simplest table as possible for our test purposes only
+        @DynamoDBTable(tableName = tableName)
+        class ObjectORMExample{}
+
+        // test
+        DeleteTableRequest deleteTableRequest = dynamoDBMapper.generateDeleteTableRequest(ObjectORMExample.class);
+        assertEquals(deleteTableRequest.getTableName(), tableName);
+    }
+
+    @Test
+    public void testGenerateDeleteTableRequest2(){
         String prefix = "DEV-";
         final String tableName = "OBJECTORMEXAMPLE";
 


### PR DESCRIPTION
I just ran into this need when trying to implement an unit test which should create and delete tables on before and after each test. Currently, it isn't possible to generate ```DeleteTableRequest```  instances through DynamoDBMapper class, although it's possible to generate ```CreateTableRequest``` instances. 

This would be particularly useful for those who use a prefix value in front of the table name based on environment (dev, staging, prod) on  ```TableNameOverride.withTableNamePrefix``` . It's very likely that it's a common scenario for most projects.

I've also add a unit test for this feature. 

If you think this is a good addition to aws-sdk-java please accept this PR.