### PR TITLE
Added 'le', 'lt', 'ge', 'gt' and 'between' methods to the S PathOperand (Fix for #592)

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/xspec/S.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/xspec/S.java
@@ -78,6 +78,108 @@ public final class S extends PathOperand {
     }
 
     /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is less than or equal to the specified value) for building
+     * condition expression.
+     */
+    public ComparatorCondition le(String value) {
+        return new ComparatorCondition("<=", this, new LiteralOperand(value));
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is less than or equal to that of the specified attribute) for building
+     * condition expression.
+     */
+    public ComparatorCondition le(S that) {
+        return new ComparatorCondition("<=", this, that);
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is less than the specified value) for building
+     * condition expression.
+     */
+    public ComparatorCondition lt(String value) {
+        return new ComparatorCondition("<", this, new LiteralOperand(value));
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is less than that of the specified attribute) for building
+     * condition expression.
+     */
+    public ComparatorCondition lt(S that) {
+        return new ComparatorCondition("<", this, that);
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is greater than or equal to the specified value) for building
+     * condition expression.
+     */
+    public ComparatorCondition ge(String value) {
+        return new ComparatorCondition(">=", this, new LiteralOperand(value));
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is greater than or equal to that of the specified attribute) for building
+     * condition expression.
+     */
+    public ComparatorCondition ge(S that) {
+        return new ComparatorCondition(">=", this, that);
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is greater than the specified value) for building
+     * condition expression.
+     */
+    public ComparatorCondition gt(String value) {
+        return new ComparatorCondition(">", this, new LiteralOperand(value));
+    }
+
+    /**
+     * Returns a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >comparator condition</a> (that evaluates to true if the value of the current
+     * attribute is greater than that of the specified attribute) for building
+     * condition expression.
+     */
+    public ComparatorCondition gt(S that) {
+        return new ComparatorCondition(">", this, that);
+    }
+
+    /**
+     * Returns a <code>BetweenCondition</code> that represents a <a href=
+     * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.SpecifyingConditions.html#ConditionExpressionReference.Comparators"
+     * >BETWEEN comparison</a> (that evaluates to true if the value of the
+     * current attribute is greater than or equal to the given low value, and
+     * less than or equal to the given high value) for building condition
+     * expression.
+     */
+    public BetweenCondition between(String low, String high) {
+        return new BetweenCondition(this,
+                new LiteralOperand(low),
+                new LiteralOperand(high));
+    }
+
+    /**
      * Returns an <code>IfNotExists</code> object which represents an <a href=
      * "http://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.Modifying.html"
      * >if_not_exists(path, operand)</a> function call where path refers to that


### PR DESCRIPTION
I straight-up copypasted the le/lt/ge/gt and between methods from N.java because as far as I can see they should work as-is. Did a quick test to confirm that they work, though I didn't find any unit-tests to add to. Fixes issue #592