### PR TITLE
Implement role assumption in profile configuration

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/ProfilesConfigFile.java
@@ -25,6 +25,8 @@ import com.amazonaws.AmazonClientException;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.profile.internal.Profile;
 import com.amazonaws.auth.profile.internal.ProfilesConfigFileLoader;
+import com.amazonaws.auth.profile.internal.securitytoken.ProfileCredentialsService;
+import com.amazonaws.auth.profile.internal.securitytoken.STSProfileCredentialsServiceLoader;
 
 /**
  * Loads the local AWS credential profiles from the standard location
@@ -81,6 +83,7 @@ public class ProfilesConfigFile {
     public static final String DEFAULT_PROFILE_NAME = "default";
 
     private final File profileFile;
+    private final ProfileCredentialsService profileCredentialsService;
     private volatile Map<String, Profile> profilesByName;
     private volatile long profileFileLastModified;
 
@@ -101,6 +104,14 @@ public class ProfilesConfigFile {
         this(new File(validateFilePath(filePath)));
     }
 
+    /**
+     * Loads the AWS credential profiles from the file. The path of the file is
+     * specified as a parameter to the constructor.
+     */
+    public ProfilesConfigFile(String filePath, ProfileCredentialsService credentialsService) throws AmazonClientException {
+        this(new File(validateFilePath(filePath)), credentialsService);
+    }
+
     private static String validateFilePath(String filePath) {
         if (filePath == null) {
             throw new IllegalArgumentException(
@@ -114,9 +125,18 @@ public class ProfilesConfigFile {
      * file is specified as a parameter to the constructor.
      */
     public ProfilesConfigFile(File file) throws AmazonClientException {
+        this(file, STSProfileCredentialsServiceLoader.getInstance());
+    }
+
+    /**
+     * Loads the AWS credential profiles from the file. The reference to the
+     * file is specified as a parameter to the constructor.
+     */
+    public ProfilesConfigFile(File file, ProfileCredentialsService credentialsService) throws AmazonClientException {
         profileFile = file;
+        profileCredentialsService = credentialsService;
         profileFileLastModified = file.lastModified();
-        profilesByName = loadProfiles(profileFile);
+        profilesByName = loadProfiles(profileFile, profileCredentialsService);
     }
 
     /**
@@ -137,7 +157,7 @@ public class ProfilesConfigFile {
     public void refresh() {
         if (profileFile.lastModified() > profileFileLastModified) {
             profileFileLastModified = profileFile.lastModified();
-            profilesByName = loadProfiles(profileFile);
+            profilesByName = loadProfiles(profileFile, profileCredentialsService);
         }
     }
 
@@ -190,8 +210,8 @@ public class ProfilesConfigFile {
         return credentialProfiles;
     }
 
-    private Map<String, Profile> loadProfiles(File file) {
-        return new LinkedHashMap<String, Profile>(ProfilesConfigFileLoader.loadProfiles(file));
+    private static Map<String, Profile> loadProfiles(File file, ProfileCredentialsService profileCredentialsService) {
+        return new LinkedHashMap<String, Profile>(ProfilesConfigFileLoader.loadProfiles(file, profileCredentialsService));
     }
 
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/AbstractProfilesConfigFileScanner.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/AbstractProfilesConfigFileScanner.java
@@ -164,6 +164,10 @@ public abstract class AbstractProfilesConfigFileScanner {
     private static boolean isSupportedProperty(String propertyName) {
         return Profile.AWS_ACCESS_KEY_ID.equals(propertyName)
                 || Profile.AWS_SECRET_ACCESS_KEY.equals(propertyName)
-                || Profile.AWS_SESSION_TOKEN.equals(propertyName);
+                || Profile.AWS_SESSION_TOKEN.equals(propertyName)
+                || Profile.EXTERNAL_ID.equals(propertyName)
+                || Profile.ROLE_ARN.equals(propertyName)
+                || Profile.ROLE_SESSION_NAME.equals(propertyName)
+                || Profile.SOURCE_PROFILE.equals(propertyName);
     }
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/ProfileCredentialsService.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/ProfileCredentialsService.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.auth.profile.internal.securitytoken;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+public interface ProfileCredentialsService {
+    AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo);
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/RoleInfo.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/RoleInfo.java
@@ -1,0 +1,444 @@
+/*
+ * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.auth.profile.internal.securitytoken;
+
+import java.io.Serializable;
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.internal.StaticCredentialsProvider;
+
+/**
+ *
+ */
+public class RoleInfo implements Serializable, Cloneable {
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of the role to assume.
+     * </p>
+     */
+    private String roleArn;
+
+    /**
+     * <p>
+     * An identifier for the assumed role session.
+     * </p>
+     * <p>
+     * Use the role session name to uniquely identify a session when the same
+     * role is assumed by different principals or for different reasons. In
+     * cross-account scenarios, the role session name is visible to, and can be
+     * logged by the account that owns the role. The role session name is also
+     * used in the ARN of the assumed role principal. This means that subsequent
+     * cross-account API requests using the temporary security credentials will
+     * expose the role session name to the external account in their CloudTrail
+     * logs.
+     * </p>
+     */
+    private String roleSessionName;
+
+    /**
+     * <p>
+     * A unique identifier that is used by third parties when assuming roles in
+     * their customers' accounts. For each role that the third party can assume,
+     * they should instruct their customers to ensure the role's trust policy
+     * checks for the external ID that the third party generated. Each time the
+     * third party assumes the role, they should pass the customer's external
+     * ID. The external ID is useful in order to help third parties bind a role
+     * to the customer who created it. For more information about the external
+     * ID, see <a href=
+     * "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     * >How to Use an External ID When Granting Access to Your AWS Resources to
+     * a Third Party</a> in the <i>Using IAM</i>.
+     * </p>
+     */
+    private String externalId;
+
+    /**
+     * <p>
+     * Provides the credentials that are used to assume the role.
+     * </p>
+     */
+    private AWSCredentialsProvider longLivedCredentialsProvider;
+
+    /**
+     * Default constructor for RoleInfo object. Callers should use the setter
+     * or fluent setter (with...) methods to initialize the object after
+     * creating it.
+     */
+    public RoleInfo() {
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of the role to assume.
+     * </p>
+     *
+     * @param roleArn
+     *        The Amazon Resource Name (ARN) of the role to assume.
+     */
+    public void setRoleArn(String roleArn) {
+        this.roleArn = roleArn;
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of the role to assume.
+     * </p>
+     *
+     * @return The Amazon Resource Name (ARN) of the role to assume.
+     */
+    public String getRoleArn() {
+        return this.roleArn;
+    }
+
+    /**
+     * <p>
+     * The Amazon Resource Name (ARN) of the role to assume.
+     * </p>
+     *
+     * @param roleArn
+     *        The Amazon Resource Name (ARN) of the role to assume.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public RoleInfo withRoleArn(String roleArn) {
+        setRoleArn(roleArn);
+        return this;
+    }
+
+    /**
+     * <p>
+     * An identifier for the assumed role session.
+     * </p>
+     * <p>
+     * Use the role session name to uniquely identify a session when the same
+     * role is assumed by different principals or for different reasons. In
+     * cross-account scenarios, the role session name is visible to, and can be
+     * logged by the account that owns the role. The role session name is also
+     * used in the ARN of the assumed role principal. This means that subsequent
+     * cross-account API requests using the temporary security credentials will
+     * expose the role session name to the external account in their CloudTrail
+     * logs.
+     * </p>
+     *
+     * @param roleSessionName
+     *        An identifier for the assumed role session. </p>
+     *        <p>
+     *        Use the role session name to uniquely identify a session when the
+     *        same role is assumed by different principals or for different
+     *        reasons. In cross-account scenarios, the role session name is
+     *        visible to, and can be logged by the account that owns the role.
+     *        The role session name is also used in the ARN of the assumed role
+     *        principal. This means that subsequent cross-account API requests
+     *        using the temporary security credentials will expose the role
+     *        session name to the external account in their CloudTrail logs.
+     */
+    public void setRoleSessionName(String roleSessionName) {
+        this.roleSessionName = roleSessionName;
+    }
+
+    /**
+     * <p>
+     * An identifier for the assumed role session.
+     * </p>
+     * <p>
+     * Use the role session name to uniquely identify a session when the same
+     * role is assumed by different principals or for different reasons. In
+     * cross-account scenarios, the role session name is visible to, and can be
+     * logged by the account that owns the role. The role session name is also
+     * used in the ARN of the assumed role principal. This means that subsequent
+     * cross-account API requests using the temporary security credentials will
+     * expose the role session name to the external account in their CloudTrail
+     * logs.
+     * </p>
+     *
+     * @return An identifier for the assumed role session. </p>
+     *         <p>
+     *         Use the role session name to uniquely identify a session when the
+     *         same role is assumed by different principals or for different
+     *         reasons. In cross-account scenarios, the role session name is
+     *         visible to, and can be logged by the account that owns the role.
+     *         The role session name is also used in the ARN of the assumed role
+     *         principal. This means that subsequent cross-account API requests
+     *         using the temporary security credentials will expose the role
+     *         session name to the external account in their CloudTrail logs.
+     */
+    public String getRoleSessionName() {
+        return this.roleSessionName;
+    }
+
+    /**
+     * <p>
+     * An identifier for the assumed role session.
+     * </p>
+     * <p>
+     * Use the role session name to uniquely identify a session when the same
+     * role is assumed by different principals or for different reasons. In
+     * cross-account scenarios, the role session name is visible to, and can be
+     * logged by the account that owns the role. The role session name is also
+     * used in the ARN of the assumed role principal. This means that subsequent
+     * cross-account API requests using the temporary security credentials will
+     * expose the role session name to the external account in their CloudTrail
+     * logs.
+     * </p>
+     *
+     * @param roleSessionName
+     *        An identifier for the assumed role session. </p>
+     *        <p>
+     *        Use the role session name to uniquely identify a session when the
+     *        same role is assumed by different principals or for different
+     *        reasons. In cross-account scenarios, the role session name is
+     *        visible to, and can be logged by the account that owns the role.
+     *        The role session name is also used in the ARN of the assumed role
+     *        principal. This means that subsequent cross-account API requests
+     *        using the temporary security credentials will expose the role
+     *        session name to the external account in their CloudTrail logs.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public RoleInfo withRoleSessionName(String roleSessionName) {
+        setRoleSessionName(roleSessionName);
+        return this;
+    }
+
+    /**
+     * <p>
+     * A unique identifier that is used by third parties when assuming roles in
+     * their customers' accounts. For each role that the third party can assume,
+     * they should instruct their customers to ensure the role's trust policy
+     * checks for the external ID that the third party generated. Each time the
+     * third party assumes the role, they should pass the customer's external
+     * ID. The external ID is useful in order to help third parties bind a role
+     * to the customer who created it. For more information about the external
+     * ID, see <a href=
+     * "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     * >How to Use an External ID When Granting Access to Your AWS Resources to
+     * a Third Party</a> in the <i>Using IAM</i>.
+     * </p>
+     *
+     * @param externalId
+     *        A unique identifier that is used by third parties when assuming
+     *        roles in their customers' accounts. For each role that the third
+     *        party can assume, they should instruct their customers to ensure
+     *        the role's trust policy checks for the external ID that the third
+     *        party generated. Each time the third party assumes the role, they
+     *        should pass the customer's external ID. The external ID is useful
+     *        in order to help third parties bind a role to the customer who
+     *        created it. For more information about the external ID, see <a
+     *        href=
+     *        "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     *        >How to Use an External ID When Granting Access to Your AWS
+     *        Resources to a Third Party</a> in the <i>Using IAM</i>.
+     */
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
+    }
+
+    /**
+     * <p>
+     * A unique identifier that is used by third parties when assuming roles in
+     * their customers' accounts. For each role that the third party can assume,
+     * they should instruct their customers to ensure the role's trust policy
+     * checks for the external ID that the third party generated. Each time the
+     * third party assumes the role, they should pass the customer's external
+     * ID. The external ID is useful in order to help third parties bind a role
+     * to the customer who created it. For more information about the external
+     * ID, see <a href=
+     * "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     * >How to Use an External ID When Granting Access to Your AWS Resources to
+     * a Third Party</a> in the <i>Using IAM</i>.
+     * </p>
+     *
+     * @return A unique identifier that is used by third parties when assuming
+     *         roles in their customers' accounts. For each role that the third
+     *         party can assume, they should instruct their customers to ensure
+     *         the role's trust policy checks for the external ID that the third
+     *         party generated. Each time the third party assumes the role, they
+     *         should pass the customer's external ID. The external ID is useful
+     *         in order to help third parties bind a role to the customer who
+     *         created it. For more information about the external ID, see <a
+     *         href=
+     *         "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     *         >How to Use an External ID When Granting Access to Your AWS
+     *         Resources to a Third Party</a> in the <i>Using IAM</i>.
+     */
+    public String getExternalId() {
+        return this.externalId;
+    }
+
+    /**
+     * <p>
+     * A unique identifier that is used by third parties when assuming roles in
+     * their customers' accounts. For each role that the third party can assume,
+     * they should instruct their customers to ensure the role's trust policy
+     * checks for the external ID that the third party generated. Each time the
+     * third party assumes the role, they should pass the customer's external
+     * ID. The external ID is useful in order to help third parties bind a role
+     * to the customer who created it. For more information about the external
+     * ID, see <a href=
+     * "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     * >How to Use an External ID When Granting Access to Your AWS Resources to
+     * a Third Party</a> in the <i>Using IAM</i>.
+     * </p>
+     *
+     * @param externalId
+     *        A unique identifier that is used by third parties when assuming
+     *        roles in their customers' accounts. For each role that the third
+     *        party can assume, they should instruct their customers to ensure
+     *        the role's trust policy checks for the external ID that the third
+     *        party generated. Each time the third party assumes the role, they
+     *        should pass the customer's external ID. The external ID is useful
+     *        in order to help third parties bind a role to the customer who
+     *        created it. For more information about the external ID, see <a
+     *        href=
+     *        "http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html"
+     *        >How to Use an External ID When Granting Access to Your AWS
+     *        Resources to a Third Party</a> in the <i>Using IAM</i>.
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public RoleInfo withExternalId(String externalId) {
+        setExternalId(externalId);
+        return this;
+    }
+
+    /**
+     * <p>
+     * Provides the credentials that are used to assume the role.
+     * </p>
+     * @param longLivedCredentialsProvider long lived credentials provider
+     */
+    public void setLongLivedCredentialsProvider(AWSCredentialsProvider longLivedCredentialsProvider) {
+        this.longLivedCredentialsProvider = longLivedCredentialsProvider;
+    }
+
+    /**
+     * <p>
+     * Provides the credentials that are used to assume the role.
+     * </p>
+     * @return long lived credentials provider
+     */
+    public AWSCredentialsProvider getLongLivedCredentialsProvider() {
+        return this.longLivedCredentialsProvider;
+    }
+
+    /**
+     * <p>
+     * Provides the credentials that are used to assume the role.
+     * </p>
+     * @param longLivedCredentialsProvider long lived credentials provider
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public RoleInfo withLongLivedCredentialsProvider(AWSCredentialsProvider longLivedCredentialsProvider) {
+        setLongLivedCredentialsProvider(longLivedCredentialsProvider);
+        return this;
+    }
+
+    /**
+     * <p>
+     * Provides the credentials that are used to assume the role.
+     * </p>
+     * @param longLivedCredentials long lived credentials
+     * @return Returns a reference to this object so that method calls can be
+     *         chained together.
+     */
+    public RoleInfo withLongLivedCredentials(AWSCredentials longLivedCredentials) {
+        setLongLivedCredentialsProvider(new StaticCredentialsProvider(longLivedCredentials));
+        return this;
+    }
+
+    /**
+     * Returns a string representation of this object; useful for testing and
+     * debugging.
+     *
+     * @return A string representation of this object.
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append("{");
+        if (getRoleArn() != null)
+            sb.append("RoleArn: " + getRoleArn() + ",");
+        if (getRoleSessionName() != null)
+            sb.append("RoleSessionName: " + getRoleSessionName() + ",");
+        if (getExternalId() != null)
+            sb.append("ExternalId: " + getExternalId() + ",");
+        sb.append("}");
+        return sb.toString();
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof RoleInfo == false)
+            return false;
+
+        RoleInfo other = (RoleInfo) obj;
+        if (other.getRoleArn() == null ^ this.getRoleArn() == null)
+            return false;
+        if (other.getRoleArn() != null
+                && other.getRoleArn().equals(this.getRoleArn()) == false)
+            return false;
+        if (other.getRoleSessionName() == null
+                ^ this.getRoleSessionName() == null)
+            return false;
+        if (other.getRoleSessionName() != null
+                && other.getRoleSessionName().equals(this.getRoleSessionName()) == false)
+            return false;
+        if (other.getExternalId() == null ^ this.getExternalId() == null)
+            return false;
+        if (other.getExternalId() != null
+                && other.getExternalId().equals(this.getExternalId()) == false)
+            return false;
+        if (other.getLongLivedCredentialsProvider() != this.getLongLivedCredentialsProvider())
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int hashCode = 1;
+
+        hashCode = prime * hashCode
+                + ((getRoleArn() == null) ? 0 : getRoleArn().hashCode());
+        hashCode = prime
+                * hashCode
+                + ((getRoleSessionName() == null) ? 0 : getRoleSessionName()
+                .hashCode());
+        hashCode = prime * hashCode
+                + ((getExternalId() == null) ? 0 : getExternalId().hashCode());
+        hashCode = prime * hashCode
+                + ((getLongLivedCredentialsProvider() == null) ? 0 : getLongLivedCredentialsProvider().hashCode());
+        return hashCode;
+    }
+
+    @Override
+    public RoleInfo clone() {
+        try {
+            return (RoleInfo) super.clone();
+        } catch (CloneNotSupportedException e) {
+            throw new IllegalStateException(
+                    "Got a CloneNotSupportedException from Object.clone() "
+                            + "even though we're Cloneable!", e);
+        }
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceLoader.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceLoader.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.auth.profile.internal.securitytoken;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+/**
+ * Loads <code>com.amazonaws.services.securitytoken.internal.STSProfileCredentialsService</code>
+ * from the STS SDK module, if the module is on the current classpath.
+ */
+public class STSProfileCredentialsServiceLoader implements ProfileCredentialsService {
+    private static final STSProfileCredentialsServiceLoader INSTANCE = new STSProfileCredentialsServiceLoader();
+
+    private ProfileCredentialsService profileCredentialsService;
+
+    private STSProfileCredentialsServiceLoader() {
+    }
+
+    @Override
+    public AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo) {
+        return new STSProfileCredentialsServiceProvider(targetRoleInfo);
+    }
+
+    public static STSProfileCredentialsServiceLoader getInstance() {
+        return INSTANCE;
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/securitytoken/STSProfileCredentialsServiceProvider.java
@@ -1,0 +1,58 @@
+package com.amazonaws.auth.profile.internal.securitytoken;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+
+/**
+ *
+ */
+public class STSProfileCredentialsServiceProvider implements AWSCredentialsProvider {
+    private static final String CLASS_NAME = "com.amazonaws.services.securitytoken.internal.STSProfileCredentialsService";
+    private static ProfileCredentialsService STS_CREDENTIALS_SERVICE;
+
+    private final RoleInfo roleInfo;
+    private AWSCredentialsProvider profileCredentialsProvider;
+
+    public STSProfileCredentialsServiceProvider(RoleInfo roleInfo) {
+        this.roleInfo = roleInfo;
+    }
+
+    private AWSCredentialsProvider getProfileCredentialsProvider() {
+        if (this.profileCredentialsProvider == null) {
+            this.profileCredentialsProvider = getProfileCredentialService().getAssumeRoleCredentialsProvider(roleInfo);
+        }
+
+        return this.profileCredentialsProvider;
+    }
+
+    private static ProfileCredentialsService getProfileCredentialService() {
+        if (STS_CREDENTIALS_SERVICE == null) {
+            try {
+                STS_CREDENTIALS_SERVICE = (ProfileCredentialsService) Class.forName(CLASS_NAME).newInstance();
+            } catch (ClassNotFoundException ex) {
+                throw new AmazonClientException("To use assume role profiles the aws-java-sdk-sts module must be on the class path.", ex);
+            } catch (InstantiationException ex) {
+                throw new AmazonClientException("Failed to instantiate " + CLASS_NAME, ex);
+            } catch (IllegalAccessException ex) {
+                throw new AmazonClientException("Failed to instantiate " + CLASS_NAME, ex);
+            }
+        }
+
+        return STS_CREDENTIALS_SERVICE;
+    }
+
+
+    @Override
+    public AWSCredentials getCredentials() {
+        return getProfileCredentialsProvider().getCredentials();
+    }
+
+    @Override
+    public void refresh() {
+        getProfileCredentialsProvider().refresh();
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/package-info.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/package-info.java
@@ -29,6 +29,24 @@
  * aws_access_key_id=AKIAZZZZZZZZZZ
  * aws_secret_access_key=xyz01234567890
  * </pre>
+ * <p>
+ * Role assumption is also supported for cross account access. The source profile credentials are
+ * used to assume the given role when the <pre>test</pre> profile is used. One requirement to use
+ * assume role profiles is that the STS SDK module be on the class path.
+ * <pre>
+ * [default]
+ * aws_access_key_id=AKIAXXXXXXXXXX
+ * aws_secret_access_key=abc01234567890
+ *
+ * [profile test]
+ * role_arn=arn:aws:iam::123456789012:role/role-name
+ * source_profile=default
+ * # Optionally, provide a session name
+ * # role_session_name=mysession
+ * # Optionally, provide an external id
+ * # external_id=abc01234567890
+ * </pre>
+ *
  *
  * <p>
  * You can use {@link com.amazonaws.auth.profile.ProfileCredentialsProvider} to

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/profile/CredentialProfilesTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/profile/CredentialProfilesTest.java
@@ -199,6 +199,42 @@ public class CredentialProfilesTest {
     }
 
     /**
+     * Tests loading a profile that assumes a role, but the source profile does not exist.
+     */
+    @Test
+    public void testRoleProfileWithNoSourceName() {
+        checkExpectedException(
+                "RoleProfileWithNoSourceName.tst",
+                AmazonClientException.class,
+                "Should throw an exception as there is a role profile with a missing source role"
+        );
+    }
+
+    /**
+     * Tests loading a profile that assumes a role, but the source profile does not exist.
+     */
+    @Test
+    public void testRoleProfileMissingSource() {
+        checkExpectedException(
+                "RoleProfileMissingSource.tst",
+                AmazonClientException.class,
+                "Should throw an exception as there is a role profile without a source specified"
+        );
+    }
+
+    /**
+     * Tests loading a profile that assumes a role, but the source profile does not exist.
+     */
+    @Test
+    public void testRoleProfileWithRoleSource() {
+        checkExpectedException(
+                "RoleProfileWithRoleSource.tst",
+                AmazonClientException.class,
+                "Should throw an exception as a role profile can not use a role profile as its source"
+        );
+    }
+
+    /**
      * Loads the file with the given name from the tst/resources/profile
      * directory. Returns a reference to the file.
      *

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/profile/ProfileCredentialsProviderTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/profile/ProfileCredentialsProviderTest.java
@@ -19,6 +19,10 @@ import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Map;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.profile.internal.securitytoken.ProfileCredentialsService;
+import com.amazonaws.auth.profile.internal.securitytoken.RoleInfo;
+import com.amazonaws.internal.StaticCredentialsProvider;
 import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -253,5 +257,71 @@ public class ProfileCredentialsProviderTest {
 
         Assert.assertEquals("credentialsAfterRefresh AWSAccessKeyId", "accessKey2", credentialsAfterRefresh.getAWSAccessKeyId());
         Assert.assertEquals("credentialsAfterRefresh AWSSecretKey", "secretAccessKey2", credentialsAfterRefresh.getAWSSecretKey());
+    }
+
+    @Test
+    public void testAssumeRole() throws Exception {
+        ProfilesConfigFile profilesFile = new ProfilesConfigFile(getLocationForTestFile("ProfileWithRole.tst"), new ProfileCredentialsService() {
+            @Override
+            public AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo) {
+                AWSCredentials credentials = targetRoleInfo.getLongLivedCredentialsProvider().getCredentials();
+                Assert.assertEquals("sourceProfile AWSAccessKeyId", "defaultAccessKey", credentials.getAWSAccessKeyId());
+                Assert.assertEquals("sourceProfile AWSSecretKey", "defaultSecretAccessKey", credentials.getAWSSecretKey());
+                Assert.assertEquals("role_arn", "arn:aws:iam::123456789012:role/testRole", targetRoleInfo.getRoleArn());
+                Assert.assertNull("external_id", targetRoleInfo.getExternalId());
+                Assert.assertTrue("role_session_name", targetRoleInfo.getRoleSessionName().startsWith("aws-sdk-java-"));
+                return new StaticCredentialsProvider(new BasicAWSCredentials("sessionAccessKey", "sessionSecretKey"));
+            }
+        });
+
+        ProfileCredentialsProvider profileCredentialsProvider = new ProfileCredentialsProvider(profilesFile, "test");
+        AWSCredentials credentials = profileCredentialsProvider.getCredentials();
+
+        Assert.assertEquals("sessionAccessKey", credentials.getAWSAccessKeyId());
+        Assert.assertEquals("sessionSecretKey", credentials.getAWSSecretKey());
+    }
+
+    @Test
+    public void testAssumeRoleWithNameAndExternalId() throws Exception {
+        ProfilesConfigFile profilesFile = new ProfilesConfigFile(getLocationForTestFile("ProfileWithRole2.tst"), new ProfileCredentialsService() {
+            @Override
+            public AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo) {
+                AWSCredentials credentials = targetRoleInfo.getLongLivedCredentialsProvider().getCredentials();
+                Assert.assertEquals("sourceProfile AWSAccessKeyId", "defaultAccessKey", credentials.getAWSAccessKeyId());
+                Assert.assertEquals("sourceProfile AWSSecretKey", "defaultSecretAccessKey", credentials.getAWSSecretKey());
+                Assert.assertEquals("role_arn", "arn:aws:iam::123456789012:role/testRole", targetRoleInfo.getRoleArn());
+                Assert.assertEquals("external_id", "testExternalId", targetRoleInfo.getExternalId());
+                Assert.assertEquals("role_session_name", "testSessionName", targetRoleInfo.getRoleSessionName());
+                return new StaticCredentialsProvider(new BasicAWSCredentials("sessionAccessKey", "sessionSecretKey"));
+            }
+        });
+
+        ProfileCredentialsProvider profileCredentialsProvider = new ProfileCredentialsProvider(profilesFile, "test");
+        AWSCredentials credentials = profileCredentialsProvider.getCredentials();
+
+        Assert.assertEquals("sessionAccessKey", credentials.getAWSAccessKeyId());
+        Assert.assertEquals("sessionSecretKey", credentials.getAWSSecretKey());
+    }
+
+    @Test
+    public void testAssumeRoleWithSourceAfterRole() throws Exception {
+        ProfilesConfigFile profilesFile = new ProfilesConfigFile(getLocationForTestFile("ProfileWithSourceAfterRole.tst"), new ProfileCredentialsService() {
+            @Override
+            public AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo) {
+                AWSCredentials credentials = targetRoleInfo.getLongLivedCredentialsProvider().getCredentials();
+                Assert.assertEquals("sourceProfile AWSAccessKeyId", "defaultAccessKey", credentials.getAWSAccessKeyId());
+                Assert.assertEquals("sourceProfile AWSSecretKey", "defaultSecretAccessKey", credentials.getAWSSecretKey());
+                Assert.assertEquals("role_arn", "arn:aws:iam::123456789012:role/testRole", targetRoleInfo.getRoleArn());
+                Assert.assertNull("external_id", targetRoleInfo.getExternalId());
+                Assert.assertTrue("role_session_name", targetRoleInfo.getRoleSessionName().startsWith("aws-sdk-java-"));
+                return new StaticCredentialsProvider(new BasicAWSCredentials("sessionAccessKey", "sessionSecretKey"));
+            }
+        });
+
+        ProfileCredentialsProvider profileCredentialsProvider = new ProfileCredentialsProvider(profilesFile, "test");
+        AWSCredentials credentials = profileCredentialsProvider.getCredentials();
+
+        Assert.assertEquals("sessionAccessKey", credentials.getAWSAccessKeyId());
+        Assert.assertEquals("sessionSecretKey", credentials.getAWSSecretKey());
     }
 }

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithRole.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithRole.tst
@@ -1,0 +1,7 @@
+[source]
+aws_access_key_id=defaultAccessKey
+aws_secret_access_key=defaultSecretAccessKey
+
+[test]
+source_profile=source
+role_arn=arn:aws:iam::123456789012:role/testRole

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithRole2.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithRole2.tst
@@ -1,0 +1,9 @@
+[source]
+aws_access_key_id=defaultAccessKey
+aws_secret_access_key=defaultSecretAccessKey
+
+[test]
+source_profile=source
+role_arn=arn:aws:iam::123456789012:role/testRole
+role_session_name=testSessionName
+external_id=testExternalId

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithSourceAfterRole.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/ProfileWithSourceAfterRole.tst
@@ -1,0 +1,7 @@
+[test]
+source_profile=source
+role_arn=arn:aws:iam::123456789012:role/testRole
+
+[source]
+aws_access_key_id=defaultAccessKey
+aws_secret_access_key=defaultSecretAccessKey

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileMissingSource.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileMissingSource.tst
@@ -1,0 +1,3 @@
+[test]
+source_profile=source
+role_arn=arn:aws:iam::123456789012:role/testRole

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileWithNoSourceName.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileWithNoSourceName.tst
@@ -1,0 +1,2 @@
+[test]
+role_arn=arn:aws:iam::123456789012:role/testRole

--- a/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileWithRoleSource.tst
+++ b/aws-java-sdk-core/src/test/resources/resources/profileconfig/RoleProfileWithRoleSource.tst
@@ -1,0 +1,11 @@
+[source]
+aws_access_key_id=defaultAccessKey
+aws_secret_access_key=defaultSecretAccessKey
+
+[test]
+source_profile=source
+role_arn=arn:aws:iam::123456789012:role/testRole
+
+[test2]
+source_profile=test
+role_arn=arn:aws:iam::123456789012:role/testRole2

--- a/aws-java-sdk-sts/pom.xml
+++ b/aws-java-sdk-sts/pom.xml
@@ -16,7 +16,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-core</artifactId>
-      <version>1.10.62</version>
+      <version>1.10.63-SNAPSHOT</version>
       <optional>false</optional>
     </dependency>
   </dependencies>

--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/services/securitytoken/internal/STSProfileCredentialsService.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/services/securitytoken/internal/STSProfileCredentialsService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2014-2016 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.securitytoken.internal;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.profile.internal.securitytoken.ProfileCredentialsService;
+import com.amazonaws.auth.profile.internal.securitytoken.RoleInfo;
+
+/**
+ * Loaded via reflection by the aws-java-sdk-core module when role assumption is configured in a
+ * credentials profile.
+ */
+public class STSProfileCredentialsService implements ProfileCredentialsService {
+    @Override
+    public AWSCredentialsProvider getAssumeRoleCredentialsProvider(RoleInfo targetRoleInfo) {
+        return new STSAssumeRoleSessionCredentialsProvider.Builder(targetRoleInfo.getRoleArn(), targetRoleInfo.getRoleSessionName())
+                .withLongLivedCredentialsProvider(targetRoleInfo.getLongLivedCredentialsProvider())
+                .withExternalId(targetRoleInfo.getExternalId())
+                .build();
+    }
+}


### PR DESCRIPTION
Supports cross-account access via IAM roles.

This functionality matches the implementation in botocore (used by boto3 and the CLI). I had to copy some functionality from the STS module. I am not really happy with `ProfileRoleCredentialsProvider.Factory`, but I couldn't think of a better way to support unit testing.