### PR TITLE
Add setMultipartUploadThreshold(int) for Hadoop 2.7 S3A FS

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManagerConfiguration.java
@@ -14,6 +14,8 @@
  */
 package com.amazonaws.services.s3.transfer;
 
+import java.lang.Deprecated;
+
 import static com.amazonaws.services.s3.internal.Constants.*;
 
 /**
@@ -194,25 +196,33 @@ public class TransferManagerConfiguration {
     }
 
     /**
-     * Sets the size threshold in bytes for when to use multi-part copy
-     * requests. Copy requests for objects over this size will automatically use
-     * a multi-part copy strategy, while copy requests for objects smaller than
-     * this threshold will use a single connection to copy the whole object.
+     * Sets the size threshold in bytes for when to use multipart uploads.
+     * Uploads over this size will automatically use a multipart upload
+     * strategy, while uploads smaller than this threshold will use a single
+     * connection to upload the whole object.
+     * <p>
+     * Multipart uploads are easier to recover from and potentially faster
+     * than single part uploads, especially when the upload parts can be
+     * uploaded in parallel as with files. Due to additional network
+     * communication, small uploads should use a single
+     * connection for the upload.
      *
-     * This accepts an int parameter for backward compatibility for Hadoop 2.7 and S3A filesystem
-     * See details (on introduced incompatibility and fix targeted for 2.8) here:
+     * This reversed the backward incompatibility with Hadoop 2.7 and S3A filesystem
+     * introduced in AWS SDK v1.7.6 in this commit:
+     * https://github.com/aws/aws-sdk-java/commit/8736d216089151ebae73353ed629757ef349ecdb
+     *
+     * See details (on error message, and fix targeted for Hadoop 2.8) here:
      * - https://issues.apache.org/jira/browse/HADOOP-12420
      * - https://issues.apache.org/jira/browse/HADOOP-12496
      * - https://issues.apache.org/jira/browse/HADOOP-12269
      * Once Hadoop 2.8 (which uses aws-sdk 1.10.6 or later) is used commonly, this may be removed
      *
-     * @param multipartCopyThreshold
-     *            The size threshold in bytes for when to use multi part copy.
-     *
-     * @deprecated replaced by {@link #setMultipartCopyThreshold(long)}
+     * @param multipartUploadThreshold
+     *            The size threshold in bytes for when to use multipart
+     *            uploads.
      */
-    @Deprecated
-    public void setMultipartCopyThreshold(int multipartCopyThreshold) {
-        setMultipartCopyThreshold((long) multipartCopyThreshold);
+    @Deprecated // can be removed when Hadoop v2.8 is the common version
+    public void setMultipartUploadThreshold(int multipartUploadThreshold) {
+        setMultipartUploadThreshold((long) multipartUploadThreshold);
     }
 }


### PR DESCRIPTION
replaced previous PR https://github.com/aws/aws-sdk-java/pull/637

reverting backward incompatibility introduced in https://github.com/aws/aws-sdk-java/pull/201

patch released under Apache 2.0 license