### PR TITLE
Travis build to skip code generator for JDK6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,20 @@ jdk:
   - oraclejdk7
   - openjdk6
   - oraclejdk8
+env:
+  - MODULES_TO_SKIP=\!aws-java-sdk-osgi
+  - MODULES_TO_SKIP=\!aws-java-sdk-osgi,\!aws-java-sdk-code-generator
+matrix:
+  exclude:
+    - jdk: openjdk6
+      env: MODULES_TO_SKIP=\!aws-java-sdk-osgi
+    - jdk: openjdk7
+      env: MODULES_TO_SKIP=\!aws-java-sdk-osgi,\!aws-java-sdk-code-generator
+    - jdk: oraclejdk7  
+      env: MODULES_TO_SKIP=\!aws-java-sdk-osgi,\!aws-java-sdk-code-generator
+    - jdk: oraclejdk8  
+      env: MODULES_TO_SKIP=\!aws-java-sdk-osgi,\!aws-java-sdk-code-generator  
+    
 install: /bin/true
 sudo: false
-script: mvn install -pl \!aws-java-sdk-osgi
-
+script: mvn install -pl ${MODULES_TO_SKIP}


### PR DESCRIPTION
Update travis build configuration to skip code generator for JDK6