### PR TITLE
Fixed incorrect exception error messages in isValidV2BucketName()

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/BucketNameUtils.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/BucketNameUtils.java
@@ -91,14 +91,14 @@ public enum BucketNameUtils {
 
             return exception(
                 throwOnError,
-                "Bucket name must not be formatted as an IP Address"
+		"Bucket name should be between 3 and 63 characters long"
             );
         }
 
         if (ipAddressPattern.matcher(bucketName).matches()) {
             return exception(
                     throwOnError,
-                    "Bucket name should be between 3 and 63 characters long"
+                    "Bucket name must not be formatted as an IP Address"
             );
         }
 


### PR DESCRIPTION
The exception messages for S3 bucket length and IP address pattern were swapped, causing confusing log entires when bucket name was too long.