### PR TITLE
Add "Connection" to ignoredHeaders

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractS3ResponseHandler.java
@@ -31,6 +31,7 @@ import com.amazonaws.services.s3.Headers;
 import com.amazonaws.services.s3.S3ResponseMetadata;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.util.DateUtils;
+import org.apache.http.HttpHeaders;
 
 /**
  * Abstract HTTP response handler for Amazon S3 responses. Provides common
@@ -55,6 +56,7 @@ public abstract class AbstractS3ResponseHandler<T>
         ignoredHeaders.add(Headers.SERVER);
         ignoredHeaders.add(Headers.REQUEST_ID);
         ignoredHeaders.add(Headers.EXTENDED_REQUEST_ID);
+        ignoredHeaders.add(HttpHeaders.CONNECTION);
     }
 
     /**


### PR DESCRIPTION
When dealing with object metadata, the Connection header may seep into
the metadata map of the ObjectMetadata object, such that when a CopyObjectRequest
is used by cloning the metadata of the source for use at destination, a presence
of the Connection header causes the AWS4Signer to fail as it ends up signing
such a header but the S3 server does not accept this.

Since a Connection header is unnecessary for the purposes of Object Metadata,
it should be ignored by default in the response handler's handling of selective
headers.

Here's an example of why a clone may be used by S3 users: https://github.com/cloudera/hadoop-common/blob/cdh5.5.2-release/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L1113-L1120, where a Close-Connection response will seep in and cause an error such as below (notice the presence of "connection" in the SignedHeaders part, something that is not normally present, thereby not used by the server when it recomputes signatures to match):

```
2016-03-29 19:59:30,120 DEBUG [s3a-transfer-shared--pool1-t35] org.apache.http.wire: >> "Authorization: AWS4-HMAC-SHA256 Credential=XXX/20160329/eu-central-1/s3/aws4_request, SignedHeaders=accept-ranges;connection;content-length;content-type;etag;host;last-modified;user-agent;x-amz-acl;x-amz-content-sha256;x-amz-copy-source;x-amz-date;x-amz-metadata-directive;x-amz-server-side-encryption;x-amz-version-id, Signature=MNOPQRSTUVWXYZ[\r][\n]"
…
com.amazonaws.services.s3.model.AmazonS3Exception: The request signature we calculated does not match the signature you provided. Check your key and signing method. (Service: Amazon S3; Status Code: 403; Error Code: SignatureDoesNotMatch; Request ID: ABC), S3 Extended Request ID: XYZ
```