### PR TITLE
Allow overriding the httpclient/httpcore versions

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -21,7 +21,12 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
-      <version>4.3.6</version>
+      <version>${httpcomponents.httpclient.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpcore</artifactId>
+      <version>${httpcomponents.httpcore.version}</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,8 @@
     <aspectj.version>1.8.2</aspectj.version>
     <spring.version>3.0.7.RELEASE</spring.version>
     <jackson.version>2.5.3</jackson.version>
+    <httpcomponents.httpclient.version>4.3.6</httpcomponents.httpclient.version>
+    <httpcomponents.httpcore.version>4.3.3</httpcomponents.httpcore.version>
     <jre.version>1.6</jre.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>


### PR DESCRIPTION
We would like to be able to override the httpcomponents versions bundled by the AWS SDK through the command line.

mvn package -Dhttpcomponents.httpcore.version=4.3.3 -Dhttpcomponents.httpclient.version=4.3.6

This way we can independently update the httpclient/httpcore versions.
