### PR TITLE
fix dynamodbv2.document.Item.withJSON to work with any json string

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/Item.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/Item.java
@@ -908,7 +908,7 @@ public class Item {
     public Item withJSON(String attrName, String json) {
         checkInvalidAttribute(attrName, json);
         attributes.put(attrName,
-            valueConformer.transform(Jackson.fromJsonString(json, Map.class)));
+            valueConformer.transform(Jackson.fromJsonString(json, Object.class)));
         return this;
     }
 


### PR DESCRIPTION
Previous code only allowed withJSON to take json encoded maps. I've tested this code change with json encoded strings for maps, arrays and simple values (string, number, null values) which i believe covers all the cases.