### PR TITLE
Exposing a way to set search requests to use HTTP POST for AmazonClou…

### DIFF
--- a/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/AmazonCloudSearchDomainClient.java
+++ b/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/AmazonCloudSearchDomainClient.java
@@ -323,8 +323,12 @@ public class AmazonCloudSearchDomainClient extends AmazonWebServiceClient
         try {
             awsRequestMetrics.startEvent(Field.RequestMarshallTime);
             try {
-                request = new SearchRequestMarshaller().marshall(super
-                        .beforeMarshalling(searchRequest));
+                // Check if user wants to perform a large request using HTTP POST. Use HTTP GET otherwise.
+                if (searchRequest.getHttpMethod() == HttpMethodName.POST) {
+                    request = new LargeSearchRequestMarshaller().marshall(super.beforeMarshalling(searchRequest));
+                } else {
+                    request = new SearchRequestMarshaller().marshall(super.beforeMarshalling(searchRequest));
+                }
                 // Binds the request metrics to the current request.
                 request.setAWSRequestMetrics(awsRequestMetrics);
             } finally {

--- a/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/model/SearchRequest.java
+++ b/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/model/SearchRequest.java
@@ -18,6 +18,7 @@ package com.amazonaws.services.cloudsearchdomain.model;
 
 import java.io.Serializable;
 import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.http.HttpMethodName;
 
 /**
  * <p>
@@ -467,7 +468,26 @@ public class SearchRequest extends AmazonWebServiceRequest implements
      * There are currently no options supported for statistics.
      * </p>
      */
-    private String stats;
+    private String  stats;
+    /**
+     * <p>
+     * Specifies the HTTP method you want to use to send requests directly to your domain's search endpoint.
+     * </p>
+     * <p>
+     * Take into account that the maximum size of a search request submitted via GET is 8190 bytes,
+     * including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however,
+     * keep in mind that large, complex requests take longer to process and are more likely to time out.
+     * </p>
+     * <p>
+     * Defaults to {@link HttpMethodName#GET}
+     * </p>
+     * <p>
+     * For more information, see <a href=
+     * "http://docs.aws.amazon.com/cloudsearch/latest/developerguide/submitting-search-requests.html"
+     * >Submitting Search Requests to an Amazon CloudSearch Domain</a> in the <i>Amazon CloudSearch Developer Guide</i>.
+     * </p>
+     */
+    private HttpMethodName httpMethod = HttpMethodName.GET;
 
     /**
      * <p>
@@ -484,7 +504,7 @@ public class SearchRequest extends AmazonWebServiceRequest implements
      * "http://docs.aws.amazon.com/cloudsearch/latest/developerguide/paginating-results.html"
      * >Paginating Results</a> in the <i>Amazon CloudSearch Developer Guide</i>.
      * </p>
-     * 
+     *
      * @param cursor
      *        Retrieves a cursor value you can use to page through large result
      *        sets. Use the <code>size</code> parameter to control the number of
@@ -1640,6 +1660,70 @@ public class SearchRequest extends AmazonWebServiceRequest implements
 
     public SearchRequest withHighlight(String highlight) {
         setHighlight(highlight);
+        return this;
+    }
+
+    /**
+     * <p>
+     * Sets the HTTP method you want to use to send requests directly to your domain's search endpoint.
+     * </p>
+     * <p>
+     * Take into account that the maximum size of a search request submitted via GET is 8190 bytes,
+     * including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however,
+     * keep in mind that large, complex requests take longer to process and are more likely to time out.
+     * </p>
+     * <p>
+     * Default values is {@link HttpMethodName#GET}
+     * </p>
+     * <p>
+     * For more information, see <a href=
+     * "http://docs.aws.amazon.com/cloudsearch/latest/developerguide/submitting-search-requests.html"
+     * >Submitting Search Requests to an Amazon CloudSearch Domain</a> in the <i>Amazon CloudSearch Developer Guide</i>.
+     * </p>
+     */
+    public void setHttpMethod(HttpMethodName httpMethod) {
+        this.httpMethod = httpMethod;
+    }
+
+    /**
+     * <p>
+     * Gets the HTTP method that will be used to send requests directly to your domain's search endpoint.
+     * </p>
+     * <p>
+     * Take into account that the maximum size of a search request submitted via GET is 8190 bytes,
+     * including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however,
+     * keep in mind that large, complex requests take longer to process and are more likely to time out.
+     * </p>
+     * <p>
+     * For more information, see <a href=
+     * "http://docs.aws.amazon.com/cloudsearch/latest/developerguide/submitting-search-requests.html"
+     * >Submitting Search Requests to an Amazon CloudSearch Domain</a> in the <i>Amazon CloudSearch Developer Guide</i>.
+     * </p>
+     */
+    public HttpMethodName getHttpMethod() {
+        return this.httpMethod;
+    }
+
+    /**
+     * <p>
+     * Sets the HTTP method you want to use to send requests directly to your domain's search endpoint.
+     * </p>
+     * <p>
+     * Take into account that the maximum size of a search request submitted via GET is 8190 bytes,
+     * including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however,
+     * keep in mind that large, complex requests take longer to process and are more likely to time out.
+     * </p>
+     * <p>
+     * Default values is {@link HttpMethodName#GET}
+     * </p>
+     * <p>
+     * For more information, see <a href=
+     * "http://docs.aws.amazon.com/cloudsearch/latest/developerguide/submitting-search-requests.html"
+     * >Submitting Search Requests to an Amazon CloudSearch Domain</a> in the <i>Amazon CloudSearch Developer Guide</i>.
+     * </p>
+     */
+    public SearchRequest withHttpMethod(HttpMethodName httpMethod) {
+        setHttpMethod(httpMethod);
         return this;
     }
 
@@ -3524,6 +3608,8 @@ public class SearchRequest extends AmazonWebServiceRequest implements
             sb.append("FilterQuery: " + getFilterQuery() + ",");
         if (getHighlight() != null)
             sb.append("Highlight: " + getHighlight() + ",");
+        if (getHttpMethod() != null)
+            sb.append(("HTTP method: " + getHttpMethod() + ","));
         if (getPartial() != null)
             sb.append("Partial: " + getPartial() + ",");
         if (getQuery() != null)
@@ -3580,6 +3666,11 @@ public class SearchRequest extends AmazonWebServiceRequest implements
             return false;
         if (other.getHighlight() != null
                 && other.getHighlight().equals(this.getHighlight()) == false)
+            return false;
+        if (other.getHttpMethod() == null ^ this.getHttpMethod() == null)
+            return false;
+        if (other.getHttpMethod() != null
+            && other.getHttpMethod().equals(this.getHttpMethod()) == false)
             return false;
         if (other.getPartial() == null ^ this.getPartial() == null)
             return false;
@@ -3645,6 +3736,8 @@ public class SearchRequest extends AmazonWebServiceRequest implements
                 + ((getFilterQuery() == null) ? 0 : getFilterQuery().hashCode());
         hashCode = prime * hashCode
                 + ((getHighlight() == null) ? 0 : getHighlight().hashCode());
+        hashCode = prime * hashCode
+                   + ((getHttpMethod() == null) ? 0 : getHttpMethod().hashCode());
         hashCode = prime * hashCode
                 + ((getPartial() == null) ? 0 : getPartial().hashCode());
         hashCode = prime * hashCode

--- a/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/LargeSearchRequestMarshaller.java
+++ b/aws-java-sdk-cloudsearch/src/main/java/com/amazonaws/services/cloudsearchdomain/model/transform/LargeSearchRequestMarshaller.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2010-2016 Amazon.com, Inc. or its affiliates. All Rights
+ * Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.cloudsearchdomain.model.transform;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.DefaultRequest;
+import com.amazonaws.Request;
+import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.services.cloudsearchdomain.model.SearchRequest;
+import com.amazonaws.transform.Marshaller;
+import com.amazonaws.util.StringUtils;
+
+import java.io.ByteArrayInputStream;
+
+/**
+ * Marshaller used to handle large search requests.
+ */
+public class LargeSearchRequestMarshaller implements Marshaller<Request<SearchRequest>, SearchRequest> {
+
+    public Request<SearchRequest> marshall(SearchRequest searchRequest) {
+
+        if (searchRequest == null) {
+            throw new AmazonClientException("Invalid argument passed to marshall(...)");
+        }
+
+        Request<SearchRequest> request = new DefaultRequest<SearchRequest>(searchRequest, "AmazonCloudSearchDomain");
+
+        request.setHttpMethod(HttpMethodName.POST);
+
+        String uriResourcePath = "/2013-01-01/search";
+
+        final StringBuilder requestContent = new StringBuilder();
+        requestContent.append("format=sdk");
+        requestContent.append("&pretty=true");
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getCursor())) {
+            requestContent.append("&cursor=").append(StringUtils.fromString(searchRequest.getCursor()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getExpr())) {
+            requestContent.append("&expr=").append(StringUtils.fromString(searchRequest.getExpr()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getFacet())) {
+            requestContent.append("&facet=").append(StringUtils.fromString(searchRequest.getFacet()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getFilterQuery())) {
+            requestContent.append("&fq=").append(StringUtils.fromString(searchRequest.getFilterQuery()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getHighlight())) {
+            requestContent.append("&highlight=").append(StringUtils.fromString(searchRequest.getHighlight()));
+        }
+
+        if (searchRequest.isPartial() != null) {
+            requestContent.append("&partial=").append(StringUtils.fromBoolean(searchRequest.isPartial()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getQuery())) {
+            requestContent.append("&q=").append(StringUtils.fromString(searchRequest.getQuery()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getQueryOptions())) {
+            requestContent.append("&q.options=").append(StringUtils.fromString(searchRequest.getQueryOptions()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getQueryParser())) {
+            requestContent.append("&q.parser=").append(StringUtils.fromString(searchRequest.getQueryParser()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getReturn())) {
+            requestContent.append("&return=").append(StringUtils.fromString(searchRequest.getReturn()));
+        }
+
+        if (searchRequest.getSize() != null) {
+            requestContent.append("&size=").append(StringUtils.fromLong(searchRequest.getSize()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getSort())) {
+            requestContent.append("&sort=").append(StringUtils.fromString(searchRequest.getSort()));
+        }
+
+        if (searchRequest.getStart() != null) {
+            requestContent.append("&start=").append(StringUtils.fromLong(searchRequest.getStart()));
+        }
+
+        if (!StringUtils.isNullOrEmpty(searchRequest.getStats())) {
+            requestContent.append("&stats=").append(StringUtils.fromString(searchRequest.getStats()));
+        }
+
+        // Set the URI resource path.
+        request.setResourcePath(uriResourcePath.replaceAll("//", "/"));
+
+        // Get parameters to pass them as a POST content.
+        request.setContent(new ByteArrayInputStream(requestContent.toString().getBytes()));
+
+        return request;
+    }
+
+}


### PR DESCRIPTION
Hi all,

We have been working with AWS CloudSearch for a while and it has been a good experience, nonetheless we found that there is a limitation for the search request size when doing a GET request.

There are few search requests on our end that are bigger than 8190 bytes. We have reviewed them and the complexity is not that hard, so, we would like to perform a POST request for these corner cases as CloudSearch documentation mention: "... The maximum size of a search request submitted via GET is 8190 bytes, including the HTTP method, URI, and protocol version. You can submit larger requests using HTTP POST; however, keep in mind that large, complex requests take longer to process and are more likely to time out. For more information..."

However we found that the Java AWS SDK does not allow the developer to send a POST request for larger requests. So, we ended-up forking the official SDK repository in order to implement that functionality and eventually share that with the rest of the community since we know they are also requesting such functionality.

Note that the code changes were intended to fulfill the initial requirements at https://github.com/aws/aws-sdk-java/issues/660 and also to be compliant with official CloudSearch documentation.

Best regards!

P.S: Please note that the fix will apply not only to AmazonCloudSearchDomainClient but also to AmazonCloudSearchDomainAsyncClient