### PR TITLE
Fix for the MalformedPolicy error code on custom policy with null ipRange

### DIFF
--- a/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/util/SignerUtils.java
+++ b/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/util/SignerUtils.java
@@ -63,9 +63,11 @@ public class SignerUtils {
                 + "\"DateLessThan\":{\"AWS:EpochTime\":"
                 + MILLISECONDS.toSeconds(activeFrom.getTime())
                 + "}"
-                + ",\"IpAddress\":{\"AWS:SourceIp\":\""
-                + ipAddress
-                + "\"}"
+                + (ipAddress == null
+                   ? ""
+                   : ",\"IpAddress\":{\"AWS:SourceIp\":\""
+                     + ipAddress + "\"}"
+                  )
                 + (expiresOn == null
                    ? ""
                    : ",\"DateGreaterThan\":{\"AWS:EpochTime\":"


### PR DESCRIPTION
Fix for the MalformedPolicy error code when passing a null to the optional ipRange variable in getCookiesForCustomPolicy method.