### PR TITLE
Method to retrieve messageId of last email sent when using JavaMail

### DIFF
--- a/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
+++ b/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
@@ -37,6 +37,7 @@ import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.simpleemail.model.RawMessage;
 import com.amazonaws.services.simpleemail.model.SendRawEmailRequest;
+import com.amazonaws.services.simpleemail.model.SendRawEmailResult;
 import com.amazonaws.util.VersionInfoUtils;
 
 /**
@@ -64,6 +65,8 @@ public class AWSJavaMailTransport extends Transport {
     private final String accessKey;
     private final String secretKey;
     private final String httpsEndpoint;
+
+    private String lastMessageId = null;
 
     public AWSJavaMailTransport(Session session, URLName urlname) {
         super(session, urlname);
@@ -263,7 +266,8 @@ public class AWSJavaMailTransport extends Transport {
 
         try {
             appendUserAgent(req, USER_AGENT);
-            this.emailService.sendRawEmail(req);
+            SendRawEmailResult resp = this.emailService.sendRawEmail(req);
+            lastMessageId = resp.getMessageId();
             sent = m.getAllRecipients();
             unsent = new Address[0];
             invalid = new Address[0];
@@ -355,4 +359,15 @@ public class AWSJavaMailTransport extends Transport {
 
     private static final String USER_AGENT = AWSJavaMailTransport.class.getName() + "/" + VersionInfoUtils.getVersion();
 
+    /**
+     * <p>
+     * The unique message identifier ot the last message sent by <code>sendMessage</code>
+     * </p>
+     *
+     * @return The unique message identifier sent by the last
+     *         <code>sendMessage</code> action.
+     */
+    public String getLastMessageId() {
+        return lastMessageId;
+    }
 }


### PR DESCRIPTION
This PR exposes the `Message-Id` of the emails that are sent using the `aws` JavaMail provider. As far as I know there was no other way of doing this except for switching to the 'native' SDK.

The `Message-Id` is useful for tracking email delivery and bounces.

I'm submitting this under the Apache 2.0 license.