### PR TITLE
#701 Added ClientConfiguration to Cloud Watch Metrics configurations

### DIFF
--- a/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/CloudWatchMetricConfig.java
+++ b/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/CloudWatchMetricConfig.java
@@ -17,6 +17,7 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.http.annotation.NotThreadSafe;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.metrics.AwsSdkMetrics;
 
@@ -78,6 +79,9 @@ public class CloudWatchMetricConfig {
 
     /** Credentials for the uploader to communicate with Amazon CloudWatch */
     private AWSCredentialsProvider credentialsProvider;
+    
+    /** ClientConfiguration for connecting to Amazon CloudWatch */
+    private ClientConfiguration clientConfiguration;
 
     /**
      * Number of milliseconds to wait before the polling of the metrics queue
@@ -109,7 +113,28 @@ public class CloudWatchMetricConfig {
         this.credentialsProvider = credentialsProvider;
     }
 
-    public CloudWatchMetricConfig withCredentialsProvider(AWSCredentialsProvider credentialsProvider) {
+    /**
+     * Returns the Client Configuration used to connect to
+     * Amazon CloudWatch.
+     */
+    public ClientConfiguration getClientConfiguration() {
+		return clientConfiguration;
+	}
+
+    /**
+     * Sets the Client Configuration. This client
+     * configuration is used by the uploader thread to connect to Amazon CloudWatch.
+     */
+	public void setClientConfiguration(ClientConfiguration clientConfiguration) {
+		this.clientConfiguration = clientConfiguration;
+	}
+	
+	public CloudWatchMetricConfig withClientConfiguration(ClientConfiguration clientConfiguration) {
+		setClientConfiguration(clientConfiguration);
+        return this;
+    }
+
+	public CloudWatchMetricConfig withCredentialsProvider(AWSCredentialsProvider credentialsProvider) {
         setCredentialsProvider(credentialsProvider);
         return this;
     }

--- a/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/DefaultMetricCollectorFactory.java
+++ b/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/DefaultMetricCollectorFactory.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.metrics.internal.cloudwatch;
 
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.SDKGlobalConfiguration;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.metrics.AwsSdkMetrics;
@@ -39,6 +40,7 @@ public class DefaultMetricCollectorFactory
         Integer qSize = AwsSdkMetrics.getMetricQueueSize();
         Long timeoutMilli = AwsSdkMetrics.getQueuePollTimeoutMilli();
         CloudWatchMetricConfig config = new CloudWatchMetricConfig();
+        ClientConfiguration clientConfig = new ClientConfiguration();
         if (provider != null)
             config.setCredentialsProvider(provider);
         if (region != null) {
@@ -49,6 +51,7 @@ public class DefaultMetricCollectorFactory
             config.setMetricQueueSize(qSize.intValue());
         if (timeoutMilli != null)
             config.setQueuePollTimeoutMilli(timeoutMilli.longValue());
+        config.setClientConfiguration(clientConfig);
         MetricCollectorSupport.startSingleton(config);
         return MetricCollectorSupport.getInstance();
     }

--- a/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/MetricUploaderThread.java
+++ b/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/MetricUploaderThread.java
@@ -39,10 +39,23 @@ class MetricUploaderThread extends Thread {
             BlockingQueue<MetricDatum> queue) {
         this(config,
              queue,
-             config.getCredentialsProvider() == null
-             ? new AmazonCloudWatchClient()
-             : new AmazonCloudWatchClient(config.getCredentialsProvider()));
+             createCloudWatchClient(config));
     }
+
+	private static AmazonCloudWatchClient createCloudWatchClient(CloudWatchMetricConfig config) {
+		AmazonCloudWatchClient amazonCloudWatchClient = null;
+		if (config.getCredentialsProvider() == null && config.getClientConfiguration() == null) {
+			amazonCloudWatchClient = new AmazonCloudWatchClient();
+		} else if (config.getCredentialsProvider() != null && config.getClientConfiguration() == null) {
+			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getCredentialsProvider());
+		} else if (config.getClientConfiguration() != null && config.getCredentialsProvider() == null) {
+			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getClientConfiguration());
+		} else if (config.getClientConfiguration() != null && config.getCredentialsProvider() == null) {
+			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getCredentialsProvider(),
+					config.getClientConfiguration());
+		}
+		return amazonCloudWatchClient;
+	}
 
     MetricUploaderThread(CloudWatchMetricConfig config,
         BlockingQueue<MetricDatum> queue,

--- a/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/MetricUploaderThread.java
+++ b/aws-java-sdk-cloudwatchmetrics/src/main/java/com/amazonaws/metrics/internal/cloudwatch/MetricUploaderThread.java
@@ -50,7 +50,7 @@ class MetricUploaderThread extends Thread {
 			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getCredentialsProvider());
 		} else if (config.getClientConfiguration() != null && config.getCredentialsProvider() == null) {
 			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getClientConfiguration());
-		} else if (config.getClientConfiguration() != null && config.getCredentialsProvider() == null) {
+		} else if (config.getClientConfiguration() != null && config.getCredentialsProvider() != null) {
 			amazonCloudWatchClient = new AmazonCloudWatchClient(config.getCredentialsProvider(),
 					config.getClientConfiguration());
 		}


### PR DESCRIPTION
CloudWatchMetricConfig - added ClientConfiguration depedency to be used for setting client params
MetricUploaderThread - Now uses ClientConfiguration to construct aws cloudwatch client
DefaultMetricCollectorFactory - Now uses client configuration 