### PR TITLE
Adding versionId support to AmazonS3URI

### DIFF
--- a/aws-java-sdk-s3/pom.xml
+++ b/aws-java-sdk-s3/pom.xml
@@ -25,6 +25,11 @@
       <version>1.11.2</version>
       <optional>false</optional>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
@@ -28,11 +28,14 @@ public class AmazonS3URI {
     private static final Pattern ENDPOINT_PATTERN =
         Pattern.compile("^(.+\\.)?s3[.-]([a-z0-9-]+)\\.");
 
+    private static final Pattern VERSION_ID_PATTERN = Pattern.compile("[&;]");
+
     private final URI uri;
 
     private final boolean isPathStyle;
     private final String bucket;
     private final String key;
+    private final String versionId;
     private final String region;
 
     /**
@@ -77,6 +80,7 @@ public class AmazonS3URI {
         // s3://*
         if ("s3".equalsIgnoreCase(uri.getScheme())) {
             this.region = null;
+            this.versionId = null;
             this.isPathStyle = false;
             this.bucket = uri.getAuthority();
 
@@ -164,12 +168,33 @@ public class AmazonS3URI {
             }
         }
 
+        this.versionId = parseVersionId(uri.getRawQuery());
+
         if ("amazonaws".equals(matcher.group(2))) {
             // No region specified
             this.region = null;
         } else {
             this.region = matcher.group(2);
         }
+    }
+
+    /**
+     * Attempts to parse a versionId parameter from the query
+     * string.
+     *
+     * @param query the query string to parse (possibly null)
+     * @return the versionId (possibly null)
+     */
+    private static String parseVersionId(String query) {
+        if (query != null) {
+            String[] params = VERSION_ID_PATTERN.split(query);
+            for (String param : params) {
+                if (param.startsWith("versionId=")) {
+                    return decode(param.substring(10));
+                }
+            }
+        }
+        return null;
     }
 
     /**
@@ -200,6 +225,13 @@ public class AmazonS3URI {
      */
     public String getKey() {
         return key;
+    }
+
+    /**
+     * @return the version id parsed from the URI (or null if no version specified)
+     */
+    public String getVersionId() {
+        return versionId;
     }
 
     /**
@@ -359,6 +391,7 @@ public class AmazonS3URI {
         if (!uri.equals(that.uri)) return false;
         if (bucket != null ? !bucket.equals(that.bucket) : that.bucket != null) return false;
         if (key != null ? !key.equals(that.key) : that.key != null) return false;
+        if (versionId != null ? !versionId.equals(that.versionId) : that.versionId != null) return false;
         return region != null ? region.equals(that.region) : that.region == null;
     }
 
@@ -368,6 +401,7 @@ public class AmazonS3URI {
         result = 31 * result + (isPathStyle ? 1 : 0);
         result = 31 * result + (bucket != null ? bucket.hashCode() : 0);
         result = 31 * result + (key != null ? key.hashCode() : 0);
+        result = 31 * result + (versionId != null ? versionId.hashCode() : 0);
         result = 31 * result + (region != null ? region.hashCode() : 0);
         return result;
     }

--- a/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/AmazonS3URITest.java
+++ b/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/AmazonS3URITest.java
@@ -1,0 +1,135 @@
+package com.amazonaws.services.s3;
+
+import java.net.URI;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * Tests for {@code AmazonS3URI}.
+ */
+public class AmazonS3URITest {
+
+    @Test
+    public void testNoQueryParams() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertNull(uri.getVersionId());
+    }
+
+    @Test
+    public void testUnrelatedQueryParams() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?unrelated=true"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertNull(uri.getVersionId());
+    }
+
+    @Test
+    public void testVersionId() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=abc123"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertEquals("abc123", uri.getVersionId());
+    }
+
+    @Test
+    public void testEncodedVersionId() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=%61%62%63%26123"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertEquals("abc&123", uri.getVersionId());
+    }
+
+    @Test
+    public void testMultipleQueryParams() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?unrelated=true&versionId=%61%62%63123&unrelated=true"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertEquals("abc123", uri.getVersionId());
+    }
+
+    @Test
+    public void testMultipleQueryParamsWithSemicolons() {
+        AmazonS3URI uri  = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?unrelated=true;versionId=abc%3B%31%32%33;unrelated=true"));
+
+        Assert.assertEquals("bucket", uri.getBucket());
+        Assert.assertEquals("key", uri.getKey());
+        Assert.assertEquals("us-west-2", uri.getRegion());
+        Assert.assertEquals("abc;123", uri.getVersionId());
+    }
+
+    @Test
+    public void testEquals() {
+        AmazonS3URI one = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"));
+
+        AmazonS3URI two = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"));
+
+        Assert.assertEquals(one, two);
+        Assert.assertEquals(one.hashCode(), two.hashCode());
+    }
+
+    @Test
+    public void testEqualsWithVersionId() {
+        AmazonS3URI one = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=abc123"));
+
+        AmazonS3URI two = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=abc123"));
+
+        Assert.assertEquals(one, two);
+        Assert.assertEquals(one.hashCode(), two.hashCode());
+    }
+
+    @Test
+    public void testNotEquals() {
+        AmazonS3URI one = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"));
+
+        AmazonS3URI two = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/otherkey"));
+
+        Assert.assertNotEquals(one, two);
+        Assert.assertNotEquals(one.hashCode(), two.hashCode());
+    }
+
+    @Test
+    public void testNotEqualsWithVersionId() {
+        AmazonS3URI one = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=abc123"));
+
+        AmazonS3URI two = new AmazonS3URI(URI.create(
+                "https://s3-us-west-2.amazonaws.com/bucket/key"
+                + "?versionId=def456"));
+
+        Assert.assertNotEquals(one, two);
+        Assert.assertNotEquals(one.hashCode(), two.hashCode());
+    }
+}


### PR DESCRIPTION
Hi from oscon! Partially fixes #714 (I couldn't find any way of communicating ETag in the URI?). Tests in a separate commit in case those'll cause conflicts with your non-public test code - feel free to drop that one if you need to (or get your test code up here on github and I'll rebase :)). Contributed under the Apache 2.0 license.