### PR TITLE
Remove unnecessary use of JAXB

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java
@@ -14,10 +14,6 @@
  */
 package com.amazonaws.util;
 
-import javax.xml.bind.DatatypeConverter;
-
-import com.amazonaws.log.InternalLogFactory;
-
 /**
  * A Base 64 codec API.
  *
@@ -33,17 +29,8 @@ public enum Base64 {
      * Returns a base 64 encoded string of the given bytes.
      */
     public static String encodeAsString(byte ... bytes) {
-        if (bytes == null)
+        if (bytes == null) {
             return null;
-        try {
-            return DatatypeConverter.printBase64Binary(bytes);
-        } catch (NullPointerException ex) {
-            // https://netbeans.org/bugzilla/show_bug.cgi?id=224923
-            // https://issues.apache.org/jira/browse/CAMEL-4893
-
-            // Note the converter should eventually be initialized and printBase64Binary should start working again
-            InternalLogFactory.getLog(Base64.class)
-                .debug("Recovering from JAXB bug: https://netbeans.org/bugzilla/show_bug.cgi?id=224923", ex);
         }
         return bytes.length == 0 ? "" : CodecUtils.toStringDirect(codec.encode(bytes));
     }


### PR DESCRIPTION
In the latest Java 9 ea build (118), the default modules for compile and
runtime were changed (see
http://mail.openjdk.java.net/pipermail/jdk9-dev/2016-May/004309.html).
In particular, java.xml.bind was removed. There is exactly one use of it
here: using DatatypeConverter to encode a base64 string. However, the
Base64Codec used by the Base64 class here already supports encoding. In
version 1.8.3 of the sdk, this was mysteriously changed to use jaxb.

This PR changes the method back to using Base64Codec, as it was before
1230cff. There is no need to use jaxb here, especially since it will
simply not work with java 9 without requiring extra arguments in the
java command line.