### PR TITLE
Daemonizing the sts thread used for the credential refresh

### DIFF
--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/RefreshableTask.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/RefreshableTask.java
@@ -22,10 +22,7 @@ import com.amazonaws.annotation.ThreadSafe;
 import com.amazonaws.internal.SdkPredicate;
 import com.amazonaws.util.ValidationUtils;
 
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
@@ -60,7 +57,14 @@ class RefreshableTask<T> {
     /**
      * Single threaded executor to asynchronous refresh the value.
      */
-    private final ExecutorService executor = Executors.newSingleThreadExecutor();
+    private final ExecutorService executor = Executors.newSingleThreadExecutor(new ThreadFactory() {
+        @Override
+        public Thread newThread(Runnable runnable) {
+            Thread thread = Executors.defaultThreadFactory().newThread(runnable);
+            thread.setDaemon(true);
+            return thread;
+        }
+    });
 
     /**
      * Used to ensure only one thread at any given time refreshes the value.


### PR DESCRIPTION
This commit demonizes the threads used by the RefreshableTask object to refresh STS credentials as needed. Without this, any clients that use STS credentials and are held (possibly in other daemon threads) past the refresh timer will cause the JVM to hang on destruction.