### PR TITLE
S3 Pre-sign signature calculation changed?

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -235,7 +235,7 @@ public class AWS4Signer extends AbstractAWSSigner implements
         addPreSignInformationToRequest(request, sanitizedCredentials,
                 signerRequestParams, timeStamp, expirationInSeconds);
 
-        final String contentSha256 = calculateContentHashPresign(request);
+        final String contentSha256 = "UNSIGNED-PAYLOAD";
 
         final String canonicalRequest = createCanonicalRequest(request,
                 contentSha256);


### PR DESCRIPTION
for pre-sign requests, it seems that S3 will use "UNSIGNED-PAYLOAD".
calculating the actual payload and sending them to S3 will result in an error message.
S3 will report that the "String-To-Sign" value uses "UNSIGNED-PAYLOAD".
AWS PHP SDK has a function called "getPresignedPayload" with returns this constant
This looks new as the php code change looks recent.
Ref:
https://github.com/aws/aws-sdk-php/pull/998
https://github.com/aws/aws-sdk-php/blob/master/src/Signature/S3SignatureV4.php