### PR TITLE
Removed superfluous word from error message

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBReflector.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBReflector.java
@@ -265,10 +265,10 @@ class DynamoDBReflector {
                     setter = getter.getDeclaringClass().getMethod(setterName, getter.getReturnType());
                 } catch ( NoSuchMethodException e ) {
                     throw new DynamoDBMappingException("Expected a public, one-argument method called " + setterName
-                            + " on class " + getter.getDeclaringClass(), e);
+                            + " on " + getter.getDeclaringClass(), e);
                 } catch ( SecurityException e ) {
                     throw new DynamoDBMappingException("No access to public, one-argument method called " + setterName
-                            + " on class " + getter.getDeclaringClass(), e);
+                            + " on " + getter.getDeclaringClass(), e);
                 }
                 setterCache.put(getter, setter);
             }


### PR DESCRIPTION
getter.getDeclaringClass() prints: "class theClassTheErrorOrginatedFrom"
Therefore, the word 'class' is repeated & confusing.