### PR TITLE
Fix race condition bug inside of AWS4Signer.presignRequest() causing …

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java
@@ -229,8 +229,8 @@ public class AWS4Signer extends AbstractAWSSigner implements
                 AWS4_SIGNING_ALGORITHM);
 
         // Add the important parameters for v4 signing
-        final String timeStamp = AWS4SignerUtils.formatTimestamp(System
-                .currentTimeMillis());
+        final String timeStamp = signerRequestParams
+                .getFormattedSigningDateTime();
 
         addPreSignInformationToRequest(request, sanitizedCredentials,
                 signerRequestParams, timeStamp, expirationInSeconds);

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWS4SignerTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWS4SignerTest.java
@@ -119,6 +119,32 @@ public class AWS4SignerTest {
                 request.getHeaders().get("Authorization"));
     }
 
+    @Test
+    public void testPresigning() throws Exception {
+
+        final String EXPECTED_AMZ_SIGNATURE = "bf7ae1c2f266d347e290a2aee7b126d38b8a695149d003b9fab2ed1eb6d6ebda";
+        final String EXPECTED_AMZ_CREDENTIALS = "access/19810216/us-east-1/demo/aws4_request";
+        final String EXPECTED_AMZ_HEADER = "19810216T063000Z";
+        final String EXPECTED_AMZ_EXPIRES = "604800";
+
+        AWSCredentials credentials = new BasicAWSCredentials("access", "secret");
+        // Test request without 'x-amz-sha256' header
+        Request<?> request = generateBasicRequest();
+
+        Calendar c = new GregorianCalendar();
+        c.set(1981, 1, 16, 6, 30, 0);
+        c.setTimeZone(TimeZone.getTimeZone("UTC"));
+
+        signer.setOverrideDate(c.getTime());
+        signer.setServiceName("demo");
+
+        signer.presignRequest(request, credentials, null);
+        assertEquals(EXPECTED_AMZ_SIGNATURE, request.getParameters().get("X-Amz-Signature").get(0));
+        assertEquals(EXPECTED_AMZ_CREDENTIALS, request.getParameters().get("X-Amz-Credential").get(0));
+        assertEquals(EXPECTED_AMZ_HEADER, request.getParameters().get("X-Amz-Date").get(0));
+        assertEquals(EXPECTED_AMZ_EXPIRES, request.getParameters().get("X-Amz-Expires").get(0));
+    }
+
     /**
      * Tests that if passed anonymous credentials, signer will not generate a signature
      */


### PR DESCRIPTION
…randomly wrong signed URLs

The `AWS4Signer.presignRequest()`-method, which is used to generate presigned S3 URLs, is not always signing correctly. 

Sometimes the presigned URL is wrong because the necessary AWS timestamp is generated twice based on a `System.currentTimeMillis()`-call. If the two calls don't happen within the same second the signingString is generated with a different timestamp as the one added to the signed request. Therefore S3 checks the signature against the wrong timestamp. 

The expected behavior (see http://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-query-string-auth.html) defines `X-Amz-Date` as 
> The date in ISO 8601 format, for example, 20130721T201207Z. This value must match the date value used to calculate the signature.. 

The `sign()`-method uses the same timestamp for both as expected (see https://github.com/flofreud/aws-sdk-java/blob/476490e1a1017dc664c90ad66122a1a645a3dc46/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWS4Signer.java#L174).

This PR fix the issue and adds a basic test case for the `presign()`-method.



