### PR TITLE
Added mapping for 'us-east-1' to the S3 Region.fromValue method

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/Region.java
@@ -232,8 +232,9 @@ public enum Region {
 
     /**
      * Returns the Amazon S3 Region enumeration value representing the specified Amazon
-     * S3 Region ID string. If specified string doesn't map to a known Amazon S3
-     * Region, then an <code>IllegalArgumentException</code> is thrown.
+     * S3 Region ID string. If specified string is 'null', 'us-east-1', or 'US',
+     * then {@link #US_Standard} is returned, and if specified string doesn't map
+     * to a known Amazon S3 Region, then an <code>IllegalArgumentException</code> is thrown.
      *
      * @param s3RegionId
      *            The Amazon S3 region ID string.
@@ -245,9 +246,8 @@ public enum Region {
      *             If the specified value does not map to one of the known
      *             Amazon S3 regions.
      */
-    public static Region fromValue(final String s3RegionId) throws IllegalArgumentException
-    {
-        if (s3RegionId == null || s3RegionId.equals("US"))
+    public static Region fromValue(final String s3RegionId) throws IllegalArgumentException {
+        if (null == s3RegionId || "US".equals(s3RegionId) || "us-east-1".equals(s3RegionId))
             return Region.US_Standard;
         for (Region region : Region.values()) {
             List<String> regionIds = region.regionIds;


### PR DESCRIPTION
This is a logical default as US_Standard is us-east-1l

This will also help avoid confusion as other APIs return 'us-east-1'