### PR TITLE
Fixes bug where createSigner doesn't check AND update the cache, it only checks it.

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -3249,7 +3249,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
 
             if ((signer instanceof AWSS3V4Signer) && noExplicitRegionProvided(request)) {
 
-                String region = bucketRegionCache.get(bucketName);
+                String region = fetchRegionFromCache(bucketName);
                 if (region != null) {
                      // If cache contains the region for the bucket, create an endpoint for the region and
                      // update the request with that endpoint.


### PR DESCRIPTION
In `AmazonS3Client.java`, in `createSigner` method we get unexpected behavior when looking up the region for a bucket name. 

When the request doesn't have an explicit region set, but has a specific bucket it is trying to talk to, we see `bucketRegionCache.get(bucketName)` called which only checks against the local cache to find the region location for `bucketName`. When this fails as it is not yet in the cache, it will default to the `AmazonS3Client` default, `us-east-1`.

We would expect that when not in the local cache, it will make a network call to figure which region that bucket is in. 

This PR resolves this issue