### PR TITLE
Null safe check for allowing excetion follow up

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -447,7 +447,9 @@ public class AmazonHttpClient {
                     clientExecutionTimer.startTimer(getClientExecutionTimeout(request.getOriginalRequest())));
             return doExecute(request, responseHandler, errorResponseHandler, executionContext);
         } finally {
-            executionContext.getClientExecutionTrackerTask().cancelTask();
+            if (executionContext.getClientExecutionTrackerTask() != null) {
+                executionContext.getClientExecutionTrackerTask().cancelTask();
+            }
         }
     }
 


### PR DESCRIPTION
With jvm <= 1.6 a NoSuchMethodException is thrown while building the ClientExecutionTrackerTask, and later on, it is tried to be used in the finally {}, generating a new NPE:

![image](https://cloud.githubusercontent.com/assets/40089/18574381/d362a21a-7bcc-11e6-88c0-c1a077665947.png)

So, the original NSME is not shown to the user, but the NPE is.