### PR TITLE
prevent LambdaSerializationException on toString()

### DIFF
--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactory.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactory.java
@@ -113,14 +113,13 @@ public final class LambdaInvokerFactory {
 
         @Override
         public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
-
-            LambdaFunction annotation = validateInterfaceMethod(method, args);
-
-            InvokeRequest invokeRequest = buildInvokeRequest(method, annotation, args == null ? null : args[0]);
-
-            InvokeResult invokeResult = awsLambda.invoke(invokeRequest);
-
-            return processInvokeResult(method, invokeResult);
+            if(method.getName().equals("toString")) return this.toString();
+            else {
+                LambdaFunction annotation = validateInterfaceMethod(method, args);
+                InvokeRequest invokeRequest = buildInvokeRequest(method, annotation, args == null ? null : args[0]);
+                InvokeResult invokeResult = awsLambda.invoke(invokeRequest);
+                return processInvokeResult(method, invokeResult);
+            }
         }
 
         /**


### PR DESCRIPTION
When calling `toString()` on interface class (after `LambdaInvokerFactory.build`), exception gets thrown: `No LambdaFunction annotation for method toString`.
=> `toString` should be object method, **not invoked** method

**e.g.**
```Java
interface MyService {
	@LambdaFunction(functionName = "lambdaFunction")
	void lambdaFunction();
}
```
```Java
public static void main(String[] args) {
    AWSLambdaClient lambdaClient = new AWSLambdaClient();
    lambdaClient.configureRegion(Regions.US_EAST_1);
    MyService myService = LambdaInvokerFactory.build(MyService.class, lambdaClient);

    System.out.println(myService);
}

```
## Exception:
```
Exception in thread "main" com.amazonaws.services.lambda.invoke.LambdaSerializationException: No LambdaFunction annotation for method toString
	at com.amazonaws.services.lambda.invoke.LambdaInvokerFactory$LambdaInvocationHandler.validateInterfaceMethod(LambdaInvokerFactory.java:134)
	at com.amazonaws.services.lambda.invoke.LambdaInvokerFactory$LambdaInvocationHandler.invoke(LambdaInvokerFactory.java:117)
	at $Proxy9.toString(Unknown Source)
```

### Annotating doesn't work either:
```Java
interface MyService
{
	@LambdaFunction(functionName = "lambdaFunction")
	void lambdaFunction();

	@LambdaFunction(functionName = "toString")
	String toString();
}
```