### PR TITLE
Moving parent directory creation up

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/DownloadCallable.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/DownloadCallable.java
@@ -125,6 +125,7 @@ final class DownloadCallable implements Callable<File> {
             }
 
             download.setState(TransferState.InProgress);
+            ServiceUtils.createParentDirectoryIfNecessary(dstfile);
 
             if (isDownloadParallel) {
                 downloadInParallel(ServiceUtils.getPartCount(req, s3));
@@ -196,9 +197,7 @@ final class DownloadCallable implements Callable<File> {
      * Merges all the individual part Files into dstFile
      */
     private void combineFiles() throws Exception {
-        if (!ServiceUtils.createParentDirectoryIfNecessary(dstfile)) {
-            truncateDestinationFileIfNecessary();
-        }
+        truncateDestinationFileIfNecessary();
 
         for (Future<File> f : futureFiles) {
             File partFile = f.get();


### PR DESCRIPTION
Fix for #853 so that parent directory is always created before any files (tmp or otherwise) are created during parallel file downloads.

Follow-on from #854 