### PR TITLE
Fix for downloading a directory from s3 with a file of size 0

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1207,8 +1207,7 @@ public class TransferManager {
             // MultipleFileTransferStateChangeListener
             GetObjectRequest req = new GetObjectRequest(summary.getBucketName(), summary.getKey())
                     .<GetObjectRequest>withGeneralProgressListener(
-                                            listener)
-                    .withRange(0L);
+                                            listener);
             downloads.add((DownloadImpl) doDownload(
                             req,
                             f,


### PR DESCRIPTION
This PR contains a fix for a minor issue with downloading directories from s3. 

If the directory or any subdirectories contain a file with 0 bytes in it, then downloadDirectory fails. 

This bug started affecting the tool I work on after we upgraded the sdk to the most recent version. I did some digging, and found that the bug was introduced in 1.11.29. 


Here's the error when you try to download a directory from s3 with a file of size 0:

> com.amazonaws.services.s3.model.AmazonS3Exception: The requested range is not satisfiable (Service: Amazon S3; Status Code: 416; Error Code: InvalidRange; Request ID: xxxxxxxxxxxxxxx)
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.handleErrorResponse(AmazonHttpClient.java:1529) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeOneRequest(AmazonHttpClient.java:1167) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeHelper(AmazonHttpClient.java:948) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.doExecute(AmazonHttpClient.java:661) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.executeWithTimer(AmazonHttpClient.java:635) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.execute(AmazonHttpClient.java:618) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutor.access$300(AmazonHttpClient.java:586) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient$RequestExecutionBuilderImpl.execute(AmazonHttpClient.java:573) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.http.AmazonHttpClient.execute(AmazonHttpClient.java:445) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.AmazonS3Client.invoke(AmazonS3Client.java:4039) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.AmazonS3Client.getObject(AmazonS3Client.java:1305) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.transfer.DownloadTaskImpl.getS3ObjectStream(DownloadTaskImpl.java:42) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.transfer.DownloadCallable.retryableDownloadS3ObjectToFile(DownloadCallable.java:298) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.transfer.DownloadCallable.call(DownloadCallable.java:134) ~[thing-0.1.jar:0.1]
>         at com.amazonaws.services.s3.transfer.DownloadCallable.call(DownloadCallable.java:51) ~[thing-0.1.jar:0.1]
>         at java.util.concurrent.FutureTask.run(FutureTask.java:266) ~[na:1.8.0_51]
>         at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142) ~[na:1.8.0_51]
>         at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617) ~[na:1.8.0_51]
>         at java.lang.Thread.run(Thread.java:745) [na:1.8.0_51]
> 

