### PR TITLE
update query request for expression names, values

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/QuerySpec.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/QuerySpec.java
@@ -30,6 +30,7 @@ import com.amazonaws.services.dynamodbv2.document.KeyAttribute;
 import com.amazonaws.services.dynamodbv2.document.PrimaryKey;
 import com.amazonaws.services.dynamodbv2.document.QueryFilter;
 import com.amazonaws.services.dynamodbv2.document.RangeKeyCondition;
+import com.amazonaws.services.dynamodbv2.document.internal.InternalUtils;
 import com.amazonaws.services.dynamodbv2.model.ConditionalOperator;
 import com.amazonaws.services.dynamodbv2.model.QueryRequest;
 import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
@@ -183,6 +184,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
             this.nameMap = null;
         else
             this.nameMap = Collections.unmodifiableMap(new LinkedHashMap<String, String>(nameMap));
+        getRequest().withExpressionAttributeNames(this.nameMap);
         return this;
     }
     public Map<String, Object> getValueMap() {
@@ -198,6 +200,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
             this.valueMap = null;
         else
             this.valueMap = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(valueMap));
+        getRequest().withExpressionAttributeValues(InternalUtils.fromSimpleMap(thisValueMap));
         return this;
     }
 

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/QuerySpec.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/spec/QuerySpec.java
@@ -200,7 +200,7 @@ public class QuerySpec extends AbstractCollectionSpec<QueryRequest> {
             this.valueMap = null;
         else
             this.valueMap = Collections.unmodifiableMap(new LinkedHashMap<String, Object>(valueMap));
-        getRequest().withExpressionAttributeValues(InternalUtils.fromSimpleMap(thisValueMap));
+        getRequest().withExpressionAttributeValues(InternalUtils.fromSimpleMap(this.valueMap));
         return this;
     }
 


### PR DESCRIPTION
@hansonchar @manikandanrs I tried setting expression names and values directly on QuerySpec and it didnt work. Probably, QueryExpressionSpec works, but this should be fixed anyway. It can impede people from using Key Condition expressions.