### PR TITLE
Fix overflow problem (#874)

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
@@ -77,7 +77,7 @@ public class PredefinedBackoffStrategies {
             this.maxBackoffTime = ValidationUtils.assertIsPositive(maxBackoffTime, "Max backoff");
         }
 
-        @Override
+        @Override*5
         public long delayBeforeNextRetry(AmazonWebServiceRequest originalRequest,
                                         AmazonClientException exception,
                                         int retriesAttempted) {
@@ -102,8 +102,10 @@ public class PredefinedBackoffStrategies {
         public long delayBeforeNextRetry(AmazonWebServiceRequest originalRequest,
                                          AmazonClientException exception,
                                          int retriesAttempted) {
+            long potentialWait = 1L << retriesAttempted * baseDelay;
             return (retriesAttempted > MAX_RETRIES) ? maxBackoffTime :
-                    Math.min(((1 << retriesAttempted) * baseDelay), maxBackoffTime);
+                    (potentialWait < 0  ? maxBackoffTime :
+                    Math.min(potentialWait, maxBackoffTime));
         }
     }
 


### PR DESCRIPTION
An overflow occured while calculating the expoential backoff.

as MAX_RETRIES is 30, with baseDelay of 5000 you will get to an overflow
at the calculation baseDelay * (1 << retriesAttempted), a negative value will
be returned from Math.min , and passed as the delay value to the call
to Thread.sleep, causing an exception.

My fix checks if the multiplication yields an overflow, and if so will return
the maxBackoffTime, if not it will return the minimum between the multiplication
and the max backoff time