### PR TITLE
Fix overflow problem (#874)

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
@@ -14,12 +14,12 @@
  */
 package com.amazonaws.retry;
 
+import java.util.Random;
+
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.util.ValidationUtils;
-
-import java.util.Random;
 
 /**
  * This class includes a set of pre-defined backoff policies.
@@ -59,8 +59,8 @@ public class PredefinedBackoffStrategies {
         public long delayBeforeNextRetry(AmazonWebServiceRequest originalRequest,
                                          AmazonClientException exception,
                                          int retriesAttempted) {
-            long ceil =  calculateExponentialDelay(retriesAttempted, baseDelay, maxBackoffTime);
-            return random.nextLong() % (ceil + 1);
+            int ceil =  (int)calculateExponentialDelay(retriesAttempted, baseDelay, maxBackoffTime);
+            return random.nextInt(ceil + 1);
         }
     }
 
@@ -80,8 +80,8 @@ public class PredefinedBackoffStrategies {
         public long delayBeforeNextRetry(AmazonWebServiceRequest originalRequest,
                                         AmazonClientException exception,
                                         int retriesAttempted) {
-            long ceil =  calculateExponentialDelay(retriesAttempted, baseDelay, maxBackoffTime);
-            return (ceil / 2) + (random.nextLong() % ((ceil / 2) + 1));
+            int ceil =  (int)calculateExponentialDelay(retriesAttempted, baseDelay, maxBackoffTime);
+            return (ceil / 2) + (long)random.nextInt((ceil / 2) + 1);
         }
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/retry/PredefinedBackoffStrategies.java
@@ -14,12 +14,12 @@
  */
 package com.amazonaws.retry;
 
-import java.util.Random;
-
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.util.ValidationUtils;
+
+import java.util.Random;
 
 /**
  * This class includes a set of pre-defined backoff policies.


### PR DESCRIPTION
An overflow occured while calculating the expoential backoff.

as MAX_RETRIES is 30, with baseDelay of 5000 you will get to an overflow
at the calculation baseDelay * (1 << retriesAttempted), a negative value will
be returned from Math.min , and passed as the delay value to the call
to Thread.sleep, causing an exception.

Comment for maintainers:
There was too much noise on my previous pull-request, I apologize for that, 
I submitted a pull request with your suggestions.