### PR TITLE
Allow shared pool connections

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/client/impl/ApacheHttpClientFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/client/impl/ApacheHttpClientFactory.java
@@ -54,7 +54,8 @@ public class ApacheHttpClientFactory implements HttpClientFactory<ConnectionMana
                 .setKeepAliveStrategy(buildKeepAliveStrategy(settings))
                 .disableRedirectHandling()
                 .disableAutomaticRetries()
-                .setConnectionManager(ClientConnectionManagerFactory.wrap(cm));
+                .setConnectionManager(ClientConnectionManagerFactory.wrap(cm))
+                .setConnectionManagerShared(true);
 
         // By default http client enables Gzip compression. So we disable it
         // here.


### PR DESCRIPTION
This required for fixing issue of IllegalState exception in shared connections
Issue
http://stackoverflow.com/questions/37303954/com-amazonaws-amazonclientexception-unable-to-complete-transfer-connection-poo
and
https://forums.aws.amazon.com/message.jspa?messageID=532114#532353

Fix
http://stackoverflow.com/questions/29488106/java-lang-illegalstateexception-connection-pool-shut-down-while-using-spring-re