### PR TITLE
Avoid another extra getObjectMetadata request

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/GetObjectRequest.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/GetObjectRequest.java
@@ -108,6 +108,8 @@ public class GetObjectRequest extends AmazonWebServiceRequest implements
      */
     private Integer partNumber;
 
+    private Long lastModifiedTime;
+
     /**
      * Constructs a new {@link GetObjectRequest} with all the required parameters.
      *
@@ -121,7 +123,25 @@ public class GetObjectRequest extends AmazonWebServiceRequest implements
      * @see GetObjectRequest#GetObjectRequest(String, String, boolean)
      */
     public GetObjectRequest(String bucketName, String key) {
-        this(bucketName, key, null);
+        this(bucketName, key, (String) null);
+    }
+
+    /**
+     * Constructs a new {@link GetObjectRequest} with all the required parameters.
+     *
+     * @param bucketName
+     *            The name of the bucket containing the desired object.
+     * @param key
+     *            The key in the specified bucket under which the object is
+     *            stored.
+     * @param lastModifiedTime
+     *            Last modified time for the object known by the client
+     *
+     * @see GetObjectRequest#GetObjectRequest(String, String, String)
+     * @see GetObjectRequest#GetObjectRequest(String, String, boolean)
+     */
+    public GetObjectRequest(String bucketName, String key, Long lastModifiedTime) {
+        this(bucketName, key, null, lastModifiedTime);
     }
 
     /**
@@ -140,9 +160,31 @@ public class GetObjectRequest extends AmazonWebServiceRequest implements
      * @see GetObjectRequest#GetObjectRequest(String, String, boolean)
      */
     public GetObjectRequest(String bucketName, String key, String versionId) {
+        this(bucketName, key, versionId, null);
+    }
+
+    /**
+     * Constructs a new {@link GetObjectRequest} with all the required parameters.
+     *
+     * @param bucketName
+     *            The name of the bucket containing the desired object.
+     * @param key
+     *            The key in the specified bucket under which the object is
+     *            stored.
+     * @param versionId
+     *            The Amazon S3 version ID specifying a specific version of the
+     *            object to download.
+     * @param lastModifiedTime
+     *            Last modified time for the object known by the client
+     *
+     * @see GetObjectRequest#GetObjectRequest(String, String)
+     * @see GetObjectRequest#GetObjectRequest(String, String, boolean)
+     */
+    public GetObjectRequest(String bucketName, String key, String versionId, Long lastModifiedTime) {
         setBucketName(bucketName);
         setKey(key);
         setVersionId(versionId);
+        setLastModifiedTime(lastModifiedTime);
     }
 
     public GetObjectRequest(S3ObjectId s3ObjectId) {
@@ -1003,9 +1045,48 @@ public class GetObjectRequest extends AmazonWebServiceRequest implements
 
     /**
      * Fluent API to set the S3 object id for this request.
+     *
+     * @return This {@link GetObjectRequest}, enabling additional method
+     *         calls to be chained together.
      */
     public GetObjectRequest withS3ObjectId(S3ObjectId s3ObjectId) {
         setS3ObjectId(s3ObjectId);
         return this;
     }
+
+    /**
+     * Set last modified time known by the client. Useful to avoid roundtrip
+     * to S3 to fetch the metadata but not required
+     *
+     * @param lastModifiedTime
+     *            Last modified time (in milliseconds) for this object
+     */
+    public void setLastModifiedTime(Long lastModifiedTime) {
+        this.lastModifiedTime = lastModifiedTime;
+    }
+
+    /**
+     * Set last modified time known by the client. Useful to avoid roundtrip
+     * to S3 to fetch the metadata but not required
+     *
+     * @param lastModifiedTime
+     *            Last modified time (in milliseconds) for this object
+     *
+     * @return This {@link GetObjectRequest}, enabling additional method
+     *         calls to be chained together.
+     */
+    public GetObjectRequest withLastModifiedTime(Long lastModifiedTime) {
+        setLastModifiedTime(lastModifiedTime);
+        return this;
+    }
+
+    /**
+     * Get last modified time for this object (in milliseconds). Only if
+     * set previously
+     */
+    public Long getLastModifiedTime() {
+        return lastModifiedTime;
+    }
+
+
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/DownloadImpl.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/DownloadImpl.java
@@ -43,7 +43,6 @@ public class DownloadImpl extends AbstractTransfer implements Download {
 
     private final GetObjectRequest getObjectRequest;
     private final File file;
-    private final ObjectMetadata objectMetadata;
     private final ProgressListenerChain progressListenerChain;
 
     @Deprecated
@@ -51,16 +50,14 @@ public class DownloadImpl extends AbstractTransfer implements Download {
             ProgressListenerChain progressListenerChain, S3Object s3Object, TransferStateChangeListener listener,
             GetObjectRequest getObjectRequest, File file) {
         this(description, transferProgress, progressListenerChain, s3Object, listener,
-                getObjectRequest, file, null, false);
+                getObjectRequest, file, false);
     }
 
     public DownloadImpl(String description, TransferProgress transferProgress,
             ProgressListenerChain progressListenerChain, S3Object s3Object, TransferStateChangeListener listener,
-            GetObjectRequest getObjectRequest, File file,
-            ObjectMetadata objectMetadata, boolean isDownloadParallel) {
+            GetObjectRequest getObjectRequest, File file, boolean isDownloadParallel) {
         super(description, transferProgress, progressListenerChain, listener);
         this.s3Object = s3Object;
-        this.objectMetadata = objectMetadata;
         this.getObjectRequest = getObjectRequest;
         this.file = file;
         this.progressListenerChain = progressListenerChain;
@@ -77,7 +74,7 @@ public class DownloadImpl extends AbstractTransfer implements Download {
         if (s3Object != null) {
             return s3Object.getObjectMetadata();
         }
-        return objectMetadata;
+        return null;
     }
 
     /**
@@ -190,7 +187,7 @@ public class DownloadImpl extends AbstractTransfer implements Download {
                     getObjectRequest.getVersionId(), getObjectRequest.getRange(),
                     getObjectRequest.getResponseHeaders(), getObjectRequest.isRequesterPays(),
                     file.getAbsolutePath(), getLastFullyDownloadedPartNumber(),
-                    getObjectMetadata().getLastModified().getTime());
+                    getObjectRequest.getLastModifiedTime());
         }
         return null;
     }


### PR DESCRIPTION
If client already knows last modified time for S3 object,
there is no reason to pull object metadata from the S3 service
inside TransferManager just to retrieve this information again.