### PR TITLE
Suppress stderr logging by XpathUtils.documentFrom

### DIFF
--- a/aws-java-sdk-core/src/test/java/com/amazonaws/util/XpathUtilsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/util/XpathUtilsTest.java
@@ -37,17 +37,24 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.ByteBuffer;
 import java.util.Calendar;
 import java.util.Date;
 import java.util.GregorianCalendar;
 import java.util.SimpleTimeZone;
 
+import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.xpath.XPath;
 
+import org.junit.Assert;
 import org.junit.Test;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
+import org.xml.sax.SAXException;
+import org.xml.sax.SAXParseException;
 
 /**
  * Unit tests for the XpathUtils class.
@@ -225,4 +232,23 @@ public class XpathUtilsTest {
 
         assertEquals(null, asByteBuffer("Foo/Empty", document, xpath));
     }
+    
+    @Test
+    public void testFromDocumentDoesNotWriteToStderrWhenXmlInvalid() throws SAXException, IOException, ParserConfigurationException {
+        PrintStream err = System.err;
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try {
+            PrintStream err2 = new PrintStream(bytes);
+            System.setErr(err2);
+            // invalid xml
+            XpathUtils.documentFrom("a");
+            Assert.fail();
+        } catch (SAXParseException e) {
+            //ensure nothing written to stderr
+            assertEquals(0, bytes.toByteArray().length);
+        } finally {
+            System.setErr(err);
+        }
+    }
+    
 }


### PR DESCRIPTION
as discussed in #952.

The default Xerces error handler outputs to stderr when it has a problem parsing xml. This can generate alerts for users of containers like glassfish because stderr is mapped to ERROR log lines by default.

This PR suppresses logging to stderr by overriding the Xerces error handler.

The PR includes a unit test that fails on the original code.