### PR TITLE
1005 S3 - Tagging S3 Objects using the TransferManager uploadDirectory

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
 package com.amazonaws.services.s3.transfer;
 
 import com.amazonaws.services.s3.model.ObjectTagging;
@@ -11,15 +25,17 @@ import java.io.File;
  */
 public interface ObjectTaggingProvider {
 
-    /*This method is called for every file that is uploaded by <code>TransferManager</code>
-     * and gives an opportunity to specify the metadata for the file.
+    /**
+     * This method is called for every file that is uploaded by <code>TransferManager</code>
+     * and gives an opportunity to specify the tags for the file.
      *
      * @param file
 	 * 			The file being uploaded.
-     *
-     * @param tags
-	 * 			The tags for the file. You can modify this object to specify
-	 * your own tags.
+	 *
+	 * @return ObjectTagging
+	 *          The ObjectTagging to be used in the PutObjectRequest withTagging call.
+	 *
+	 * {@link TransferManager#uploadDirectory}
 	 */
-    public void provideObjectTags(final File file, final ObjectTagging tags);
+    public ObjectTagging provideObjectTags(final File file);
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
@@ -20,8 +20,10 @@ import java.io.File;
 import java.util.List;
 
 /**
- * This is the callback interface which is used by TransferManager.uploadDirectory {@link TransferManager#uploadDirectory(String, String, File, boolean, ObjectMetadataProvider, ObjectTaggingProvider)} and
- * TransferManager.uploadFileList {@link TransferManager#uploadFileList(String, String, File, List, ObjectMetadataProvider, ObjectTaggingProvider)}. The callback is invoked for each file that is uploaded by
+ * This is the callback interface which is used by {@link TransferManager#uploadDirectory(String,
+ * String, File, boolean, ObjectMetadataProvider, ObjectTaggingProvider)} and
+ * {@link TransferManager#uploadFileList(String, String, File, List, ObjectMetadataProvider,
+ * ObjectTaggingProvider)}. The callback is invoked for each file that is uploaded by
  * <code>TransferManager</code> and given an opportunity to specify the tags for each file.
  */
 public interface ObjectTaggingProvider {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
@@ -1,0 +1,25 @@
+package com.amazonaws.services.s3.transfer;
+
+import com.amazonaws.services.s3.model.ObjectTagging;
+
+import java.io.File;
+
+/**
+ * This is the callback interface which is used by TransferManager.uploadDirectory and
+ * TransferManager.uploadFileList. The callback is invoked for each file that is uploaded by
+ * <code>TransferManager</code> and given an opportunity to specify the tags for each file.
+ */
+public interface ObjectTaggingProvider {
+
+    /*This method is called for every file that is uploaded by <code>TransferManager</code>
+     * and gives an opportunity to specify the metadata for the file.
+     *
+     * @param file
+	 * 			The file being uploaded.
+     *
+     * @param tags
+	 * 			The tags for the file. You can modify this object to specify
+	 * your own tags.
+	 */
+    public void provideObjectTags(final File file, final ObjectTagging tags);
+}

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/ObjectTaggingProvider.java
@@ -17,10 +17,11 @@ package com.amazonaws.services.s3.transfer;
 import com.amazonaws.services.s3.model.ObjectTagging;
 
 import java.io.File;
+import java.util.List;
 
 /**
- * This is the callback interface which is used by TransferManager.uploadDirectory and
- * TransferManager.uploadFileList. The callback is invoked for each file that is uploaded by
+ * This is the callback interface which is used by TransferManager.uploadDirectory {@link TransferManager#uploadDirectory(String, String, File, boolean, ObjectMetadataProvider, ObjectTaggingProvider)} and
+ * TransferManager.uploadFileList {@link TransferManager#uploadFileList(String, String, File, List, ObjectMetadataProvider, ObjectTaggingProvider)}. The callback is invoked for each file that is uploaded by
  * <code>TransferManager</code> and given an opportunity to specify the tags for each file.
  */
 public interface ObjectTaggingProvider {
@@ -35,7 +36,6 @@ public interface ObjectTaggingProvider {
 	 * @return ObjectTagging
 	 *          The ObjectTagging to be used in the PutObjectRequest withTagging call.
 	 *
-	 * {@link TransferManager#uploadDirectory}
 	 */
     public ObjectTagging provideObjectTags(final File file);
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1323,7 +1323,7 @@ public class TransferManager {
      *            files found in subdirectories will be included with an
      *            appropriate concatenation to the key prefix.
      * @param metadataProvider
-     * 			  A callback of type <code>ObjectMetadataProvider</code> which
+     *            A callback of type <code>ObjectMetadataProvider</code> which
      *            is used to provide metadata for each file being uploaded.
      */
     public MultipleFileUpload uploadDirectory(String bucketName, String virtualDirectoryKeyPrefix, File directory, boolean includeSubdirectories, ObjectMetadataProvider metadataProvider) {
@@ -1359,10 +1359,10 @@ public class TransferManager {
      *            files found in subdirectories will be included with an
      *            appropriate concatenation to the key prefix.
      * @param metadataProvider
-     * 			  A callback of type <code>ObjectMetadataProvider</code> which
+     *            A callback of type <code>ObjectMetadataProvider</code> which
      *            is used to provide metadata for each file being uploaded.
      * @param taggingProvider
-     * 			  A callback of type <code>ObjectTaggingProvider</code> which
+     *            A callback of type <code>ObjectTaggingProvider</code> which
      *            is used to provide the tags for each file being uploaded.
      * @return
      */
@@ -1526,8 +1526,7 @@ public class TransferManager {
                             .replaceAll("\\\\", "/");
 
                     ObjectMetadata metadata = new ObjectMetadata();
-                    List<Tag> listTags = new ArrayList<Tag>();
-                    ObjectTagging tagSet = new ObjectTagging(listTags);
+                    ObjectTagging objectTagging = new ObjectTagging();
 
                     // Invoke the callback if it's present.
                     // The callback allows the user to customize the metadata
@@ -1539,7 +1538,7 @@ public class TransferManager {
                     // The callback allows the user to customize the tags
                     // for each file being uploaded.
                     if(taggingProvider != null) {
-                        taggingProvider.provideObjectTags(f, tagSet);
+                        objectTagging = taggingProvider.provideObjectTags(f);
                     }
 
                     // All the single-file uploads share the same
@@ -1549,7 +1548,7 @@ public class TransferManager {
                             new PutObjectRequest(bucketName,
                                     virtualDirectoryKeyPrefix + key, f)
                                     .withMetadata(metadata)
-                                    .withTagging(tagSet)
+                                    .withTagging(objectTagging)
                                     .<PutObjectRequest> withGeneralProgressListener(
                                             listener), transferListener, null, null));
                 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1526,7 +1526,7 @@ public class TransferManager {
                             .replaceAll("\\\\", "/");
 
                     ObjectMetadata metadata = new ObjectMetadata();
-                    ObjectTagging objectTagging = new ObjectTagging();
+                    ObjectTagging objectTagging = new ObjectTagging(new ArrayList<Tag>());
 
                     // Invoke the callback if it's present.
                     // The callback allows the user to customize the metadata

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1526,7 +1526,7 @@ public class TransferManager {
                             .replaceAll("\\\\", "/");
 
                     ObjectMetadata metadata = new ObjectMetadata();
-                    ObjectTagging objectTagging = new ObjectTagging(new ArrayList<Tag>());
+                    ObjectTagging objectTagging = null;
 
                     // Invoke the callback if it's present.
                     // The callback allows the user to customize the metadata

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1450,6 +1450,20 @@ public class TransferManager {
     }
 
     /**
+     * Uploads all specified files to the bucket named, constructing
+     * relative keys depending on the commonParentDirectory given.
+     * <p>
+     * S3 will overwrite any existing objects that happen to have the same key,
+     * just as when uploading individual files, so use with caution.
+     * </p>
+     * <p>
+     * If you are uploading <a href="http://aws.amazon.com/kms/">AWS
+     * KMS</a>-encrypted objects, you need to specify the correct region of the
+     * bucket on your client and configure AWS Signature Version 4 for added
+     * security. For more information on how to do this, see
+     * http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingAWSSDK.html#
+     * specify-signature-version
+     * </p>
      *
      * @param bucketName
      *            The name of the bucket to upload objects to.

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -42,7 +42,6 @@ import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import com.amazonaws.services.s3.model.S3ObjectSummary;
 import com.amazonaws.services.s3.model.ObjectTagging;
-import com.amazonaws.services.s3.model.Tag;
 import com.amazonaws.services.s3.transfer.Transfer.TransferState;
 import com.amazonaws.services.s3.transfer.exception.FileLockException;
 import com.amazonaws.services.s3.transfer.internal.CopyCallable;


### PR DESCRIPTION
#1005 adding the ObjectTaggingProvider Interface to be used to specify the tagging (the same way it is used to specify the callback to specify the metadata to each file).
Adding 2 methods to the TransferManager to upload a directory and a list of files using the ObjectTaggingProvider