### PR TITLE
support case-insensitive header field for HTTP response header

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/HttpResponse.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/HttpResponse.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Represents an HTTP response returned by an AWS service in response to a
@@ -37,7 +38,7 @@ public class HttpResponse {
     private String statusText;
     private int statusCode;
     private InputStream content;
-    private Map<String, String> headers = new HashMap<String, String>();
+    private Map<String, String> headers = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
     private HttpContext context;
 
     /**


### PR DESCRIPTION
According to RFC 2616 section 4.2 HTTP header fields should be processed case insensitive (http://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2):

> Each header field consists of a name followed by a colon (":") and the field value. Field names are case-insensitive.

I found that _ServerSideEncryptionHeaderHandler_ uses raw response header, then it causes an error with case-sensitive. Also this issue is not limited to only s3 service.

```java
public class ServerSideEncryptionHeaderHandler <T extends ServerSideEncryptionResult> implements HeaderHandler<T>{

    /* (non-Javadoc)
     * @see com.amazonaws.services.s3.internal.HeaderHandler#handle(java.lang.Object, com.amazonaws.http.HttpResponse)
     */
    @Override
    public void handle(T result, HttpResponse response) {
        result.setSSEAlgorithm(response.getHeaders().get(Headers.SERVER_SIDE_ENCRYPTION));
        result.setSSECustomerAlgorithm(response.getHeaders().get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM));
        result.setSSECustomerKeyMd5(response.getHeaders().get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5));
    }
}
```

* https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServerSideEncryptionHeaderHandler.java#L31

Using _TreeMap_ solves it as the same as _ObjectMetadata.metadata_, I think.

* https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java#L58

## Reference

* https://github.com/aws/aws-sdk-java/pull/590