### PR TITLE
Ammend Javadoc @NotThreadSafe message

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/annotation/NotThreadSafe.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/annotation/NotThreadSafe.java
@@ -20,7 +20,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Documenting annotation to indicate a thread is not thread-safe and should not be used in a multi-threaded context.
+ * Documenting annotation to indicate a class is not thread-safe and should not be used in a multi-threaded context.
  *
  * @see ThreadSafe
  */


### PR DESCRIPTION
As opposed to https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-core/src/main/java/com/amazonaws/annotation/ThreadSafe.java#L22