### PR TITLE
Removed an outdated reference to a guide that no longer exists.

### DIFF
--- a/src/samples/AmazonSimpleQueueService/README.md
+++ b/src/samples/AmazonSimpleQueueService/README.md
@@ -28,4 +28,4 @@ The basic steps for running the Amazon SQS sample are:
 
 **NOTE:** The sample also includes an Ant build.xml file to run the sample.
 
-For detailed description on how to work with Amazon SQS using Java. see the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_.
+For detailed description on how to work with Amazon SQS using Java, see the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_.

--- a/src/samples/AmazonSimpleQueueService/README.md
+++ b/src/samples/AmazonSimpleQueueService/README.md
@@ -28,4 +28,4 @@ The basic steps for running the Amazon SQS sample are:
 
 **NOTE:** The sample also includes an Ant build.xml file to run the sample.
 
-See the [Amazon SQS Getting Started Guide](http://docs.amazonwebservices.com/AWSSimpleQueueService/latest/SQSGettingStartedGuide/) for step-by-step instructions on running this sample.
+See the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_ for step-by-step description of this sample.

--- a/src/samples/AmazonSimpleQueueService/README.md
+++ b/src/samples/AmazonSimpleQueueService/README.md
@@ -28,4 +28,4 @@ The basic steps for running the Amazon SQS sample are:
 
 **NOTE:** The sample also includes an Ant build.xml file to run the sample.
 
-See the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_ for step-by-step description of this sample.
+For detailed description on how to work with Amazon SQS using Java. see the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_.

--- a/src/samples/AmazonSimpleQueueService/README.md
+++ b/src/samples/AmazonSimpleQueueService/README.md
@@ -28,4 +28,4 @@ The basic steps for running the Amazon SQS sample are:
 
 **NOTE:** The sample also includes an Ant build.xml file to run the sample.
 
-For detailed description on how to work with Amazon SQS using Java, see the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_.
+For detailed descriptions on how to work with Amazon SQS using Java, see the [tutorials](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html) in the _Amazon SQS Developer Guide_.


### PR DESCRIPTION
The _Amazon SQS Getting Started Guide_ has been retired. The most current information is in the _Amazon SQS Developer Guide_: http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-tutorials.html