### PR TITLE
DynamoDBv2 Atomic Increment Counter Support

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAtomicInteger.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAtomicInteger.java
@@ -1,0 +1,23 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by magrnw on 3/3/17.
+ */
+@DynamoDB
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD})
+public @interface DynamoDBAtomicInteger {
+    String attributeName() default "";
+
+    /**
+     * The value to increment the attribute by upon update calls being invoked
+     *
+     * @return
+     */
+    int incr() default 1;
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementor.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementor.java
@@ -1,0 +1,8 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+/**
+ * Created by magrnw on 3/3/17.
+ */
+public interface DynamoDBAutoIncrementor {
+    public DynamoDBAutoIncrementorStrategy getGenerateStrategy();
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementorStrategy.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementorStrategy.java
@@ -6,6 +6,12 @@ package com.amazonaws.services.dynamodbv2.datamodeling;
 public class DynamoDBAutoIncrementorStrategy {
     private Integer incrBy;
 
+    public DynamoDBAutoIncrementorStrategy() {}
+
+    public DynamoDBAutoIncrementorStrategy(int incr) {
+        this.incrBy = incr;
+    }
+
     public Integer getIncrBy() {
         return incrBy;
     }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementorStrategy.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBAutoIncrementorStrategy.java
@@ -1,0 +1,16 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+/**
+ * Created by magrnw on 3/3/17.
+ */
+public class DynamoDBAutoIncrementorStrategy {
+    private Integer incrBy;
+
+    public Integer getIncrBy() {
+        return incrBy;
+    }
+
+    public void setIncrBy(Integer incrBy) {
+        this.incrBy = incrBy;
+    }
+}

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -664,7 +664,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
          * @param object            The model object to be saved.
          * @param clazz             The domain class of the object.
          * @param tableName         The table name.
-         * @param saveConifg        The mapper configuration used for this save.
+         * @param saveConfig        The mapper configuration used for this save.
          * @param saveExpression    The save expression, including the user-provided conditions and an optional logic operator.
          */
         public SaveObjectHandler(

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperFieldModel.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperFieldModel.java
@@ -443,6 +443,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
         public Map<KeyType,List<String>> globalSecondaryIndexNames();
         public List<String> localSecondaryIndexNames();
         public DynamoDBAutoGenerator<V> autoGenerator();
+        public DynamoDBAutoIncrementor autoIncrementor();
 
         static final class Immutable<V> implements Properties<V> {
             private final String attributeName;
@@ -451,6 +452,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
             private final Map<KeyType,List<String>> globalSecondaryIndexNames;
             private final List<String> localSecondaryIndexNames;
             private final DynamoDBAutoGenerator<V> autoGenerator;
+            private final DynamoDBAutoIncrementor autoIncrementor;
 
             public Immutable(final Properties<V> properties) {
                 this.attributeName = properties.attributeName();
@@ -459,6 +461,7 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
                 this.globalSecondaryIndexNames = properties.globalSecondaryIndexNames();
                 this.localSecondaryIndexNames = properties.localSecondaryIndexNames();
                 this.autoGenerator = properties.autoGenerator();
+                this.autoIncrementor = properties.autoIncrementor();
             }
 
             @Override
@@ -489,6 +492,11 @@ public class DynamoDBMapperFieldModel<T,V> implements DynamoDBAutoGenerator<V>, 
             @Override
             public final DynamoDBAutoGenerator<V> autoGenerator() {
                 return this.autoGenerator;
+            }
+
+            @Override
+            public DynamoDBAutoIncrementor autoIncrementor() {
+                return this.autoIncrementor;
             }
         }
     }

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
@@ -382,6 +382,22 @@ final class StandardAnnotationMaps {
             }
             return Collections.<String>emptyList();
         }
+
+        @Override
+        public DynamoDBAutoIncrementor autoIncrementor() {
+
+            final DynamoDBAtomicInteger atomicInteger = actualOf(DynamoDBAtomicInteger.class);
+            if (null != atomicInteger) {
+                final DynamoDBAutoIncrementor autoIncrementor = new DynamoDBAutoIncrementor() {
+                    @Override
+                    public DynamoDBAutoIncrementorStrategy getGenerateStrategy() {
+                        return new DynamoDBAutoIncrementorStrategy(atomicInteger.incr());
+                    }
+                };
+                return autoIncrementor;
+            }
+            return null;
+        }
     }
 
     /**

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AtomicIntegerFunctionalTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/AtomicIntegerFunctionalTest.java
@@ -1,0 +1,27 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBAsyncClient;
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClient;
+import com.amazonaws.services.dynamodbv2.pojos.AtomicInteger;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+/**
+ * Created by magrnw on 3/3/17.
+ */
+public class AtomicIntegerFunctionalTest {
+
+
+    @Test
+    public void testGenerateModelAtomicInteger() {
+        DynamoDBMapperConfig config = DynamoDBMapperConfig.DEFAULT.merge(DynamoDBMapperConfig.DEFAULT);
+
+        DynamoDBMapper mapper = new DynamoDBMapper(new AmazonDynamoDBAsyncClient());
+        final DynamoDBMapperTableModel<AtomicInteger> model = mapper.getTableModel(AtomicInteger.class, config);
+
+        System.out.println(model);
+    }
+
+}

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardModelFactoriesTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardModelFactoriesTest.java
@@ -760,6 +760,19 @@ public class StandardModelFactoriesTest {
         assertEquals(java.util.Currency.getInstance("CAD"), val.generate(null));
     }
 
+    @Test
+    public void testAtomicIntegerIncrValue() {
+        final Object obj = new AutoKeyAndVal<Integer>() {
+            @DynamoDBAtomicInteger(attributeName = "AI", incr = 2)
+            public Integer getVal() { return super.getVal(); }
+            public void setVal(final Integer val) { super.setVal(val); }
+        };
+
+        final DynamoDBMapperTableModel<Object> model = getTable(obj);
+        final DynamoDBMapperFieldModel<Object, Object> val = model.field("val");
+        System.out.println(val);
+    }
+
     /**
      * Test mappings.
      */

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/pojos/AtomicInteger.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/pojos/AtomicInteger.java
@@ -1,9 +1,6 @@
 package com.amazonaws.services.dynamodbv2.pojos;
 
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAtomicInteger;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+import com.amazonaws.services.dynamodbv2.datamodeling.*;
 
 /**
  * Created by magrnw on 3/3/17.
@@ -19,6 +16,9 @@ public class AtomicInteger {
 
     @DynamoDBAtomicInteger(attributeName = "AI", incr = 2)
     private Integer atomicInt;
+
+    @DynamoDBVersionAttribute(attributeName = "version")
+    private Integer version;
 
     public String getJobId() {
         return jobId;
@@ -42,5 +42,13 @@ public class AtomicInteger {
 
     public void setAtomicInt(Integer atomicInt) {
         this.atomicInt = atomicInt;
+    }
+
+    public Integer getVersion() {
+        return version;
+    }
+
+    public void setVersion(Integer version) {
+        this.version = version;
     }
 }

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/pojos/AtomicInteger.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/pojos/AtomicInteger.java
@@ -1,0 +1,46 @@
+package com.amazonaws.services.dynamodbv2.pojos;
+
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAtomicInteger;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBAttribute;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBHashKey;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBTable;
+
+/**
+ * Created by magrnw on 3/3/17.
+ */
+@DynamoDBTable(tableName = "atomicIntTable")
+public class AtomicInteger {
+
+    @DynamoDBHashKey(attributeName = "jobId")
+    private String jobId;
+
+    @DynamoDBAttribute(attributeName = "val")
+    private String val;
+
+    @DynamoDBAtomicInteger(attributeName = "AI", incr = 2)
+    private Integer atomicInt;
+
+    public String getJobId() {
+        return jobId;
+    }
+
+    public void setJobId(String jobId) {
+        this.jobId = jobId;
+    }
+
+    public String getVal() {
+        return val;
+    }
+
+    public void setVal(String val) {
+        this.val = val;
+    }
+
+    public Integer getAtomicInt() {
+        return atomicInt;
+    }
+
+    public void setAtomicInt(Integer atomicInt) {
+        this.atomicInt = atomicInt;
+    }
+}

--- a/aws-java-sdk-osgi/dependency-reduced-pom.xml
+++ b/aws-java-sdk-osgi/dependency-reduced-pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>aws-java-sdk-pom</artifactId>
     <groupId>com.amazonaws</groupId>
-    <version>1.11.98</version>
+    <version>1.11.99-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <groupId>com.amazonaws</groupId>
@@ -95,979 +95,15 @@
         <plugins>
           <plugin>
             <artifactId>maven-javadoc-plugin</artifactId>
-            <version>2.9.1</version>
             <executions>
-              <execution>
-                <id>attach-javadocs</id>
-                <goals>
-                  <goal>jar</goal>
-                </goals>
-                <configuration>
-                  <minmemory>128m</minmemory>
-                  <maxmemory>2g</maxmemory>
-                  <includeDependencySources>true</includeDependencySources>
-                  <show>public</show>
-                  <defaultexcludes>yes</defaultexcludes>
-                  <stylesheetfile>com/amazonaws/JavaDoc.css</stylesheetfile>
-                  <author>false</author>
-                  <version>true</version>
-                  <use>false</use>
-                  <notree>true</notree>
-                  <nodeprecatedlist>true</nodeprecatedlist>
-                  <windowtitle>AWS SDK for Java - 1.11.98</windowtitle>
-                  <encoding>UTF-8</encoding>
-                  <docencoding>UTF-8</docencoding>
-                  <doctitle>AWS SDK for Java API Reference - 1.11.98</doctitle>
-                  <packagesheader>AWS SDK for Java</packagesheader>
-                  <docfilessubdirs>true</docfilessubdirs>
-                  <taglets>
-                    <taglet>
-                      <tagletClass>com.amazonaws.codesamples.SampleCodeTaglet</tagletClass>
-                      <tagletArtifact>
-                        <groupId>com.amazonaws</groupId>
-                        <artifactId>aws-java-sdk-samples</artifactId>
-                        <version>LATEST</version>
-                      </tagletArtifact>
-                    </taglet>
-                  </taglets>
-                  <groups>
-                    <group>
-                      <title>Amazon S3</title>
-                      <packages>com.amazonaws.services.s3*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Glacier</title>
-                      <packages>com.amazonaws.services.glacier*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon DynamoDB</title>
-                      <packages>com.amazonaws.services.dynamo*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2</title>
-                      <packages>com.amazonaws.services.ec2*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SimpleDB</title>
-                      <packages>com.amazonaws.services.simpledb*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SQS</title>
-                      <packages>com.amazonaws.services.sqs*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SNS</title>
-                      <packages>com.amazonaws.services.sns*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Relational Database Service</title>
-                      <packages>com.amazonaws.services.rds*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Route 53</title>
-                      <packages>com.amazonaws.services.route53*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Simple Workflow Service</title>
-                      <packages>com.amazonaws.services.simplework*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic MapReduce</title>
-                      <packages>com.amazonaws.services.elasticmapreduce*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Simple Email Service</title>
-                      <packages>com.amazonaws.services.simpleemail*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic Load Balancing</title>
-                      <packages>com.amazonaws.services.elasticloadbalancing*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudSearch</title>
-                      <packages>com.amazonaws.services.cloudsearch*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch</title>
-                      <packages>com.amazonaws.services.cloudwatch*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch Logs</title>
-                      <packages>com.amazonaws.services.logs*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch Events</title>
-                      <packages>com.amazonaws.services.cloudwatchevents*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudFront</title>
-                      <packages>com.amazonaws.services.cloudfront*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudDirectory</title>
-                      <packages>com.amazonaws.services.clouddirectory*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Cognito</title>
-                      <packages>com.amazonaws.services.cognito*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon AutoScaling</title>
-                      <packages>com.amazonaws.services.autoscaling*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Kinesis</title>
-                      <packages>com.amazonaws.services.kinesis*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Redshift</title>
-                      <packages>com.amazonaws.services.redshift*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon ElastiCache</title>
-                      <packages>com.amazonaws.services.elasticache*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic Transcoder</title>
-                      <packages>com.amazonaws.services.elastictranscoder*</packages>
-                    </group>
-                    <group>
-                      <title>AWS OpsWorks</title>
-                      <packages>com.amazonaws.services.opsworks*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudFormation</title>
-                      <packages>com.amazonaws.services.cloudformation*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Data Pipeline</title>
-                      <packages>com.amazonaws.services.datapipeline*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Direct Connect</title>
-                      <packages>com.amazonaws.services.directconnect*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Elastic Beanstalk</title>
-                      <packages>com.amazonaws.services.elasticbeanstalk*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Identity and Access Management</title>
-                      <packages>com.amazonaws.services.identity*</packages>
-                    </group>
-                    <group>
-                      <title>AWS ImportExport</title>
-                      <packages>com.amazonaws.services.importexport*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Security Token Service</title>
-                      <packages>com.amazonaws.services.securitytoken*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Storage Gateway Service</title>
-                      <packages>com.amazonaws.services.storagegateway*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Support</title>
-                      <packages>com.amazonaws.services.support*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudTrail</title>
-                      <packages>com.amazonaws.services.cloudtrail*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Config</title>
-                      <packages>com.amazonaws.services.config*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Certificate Manager</title>
-                      <packages>com.amazonaws.services.certificatemanager*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Key Management</title>
-                      <packages>com.amazonaws.services.kms*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodeDeploy</title>
-                      <packages>com.amazonaws.services.codedeploy*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Lambda</title>
-                      <packages>com.amazonaws.services.lambda*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2 Container Service</title>
-                      <packages>com.amazonaws.services.ecs*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudHSM</title>
-                      <packages>com.amazonaws.services.cloudhsm*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Simple Systems Management Service</title>
-                      <packages>com.amazonaws.services.simplesystemsmanagement*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon WorkSpaces</title>
-                      <packages>com.amazonaws.services.workspaces*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Machine Learning</title>
-                      <packages>com.amazonaws.services.machinelearning*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Directory Service</title>
-                      <packages>com.amazonaws.services.directory*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic File System</title>
-                      <packages>com.amazonaws.services.elasticfilesystem*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodePipeline</title>
-                      <packages>com.amazonaws.services.codepipeline*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodeCommit</title>
-                      <packages>com.amazonaws.services.codecommit*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Device Farm</title>
-                      <packages>com.amazonaws.services.devicefarm*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elasticsearch Service</title>
-                      <packages>com.amazonaws.services.elasticsearch*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Marketplace Commerce Analytics</title>
-                      <packages>com.amazonaws.services.marketplacecommerceanalytics*</packages>
-                    </group>
-                    <group>
-                      <title>AWS WAF</title>
-                      <packages>com.amazonaws.services.waf*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Inspector Service</title>
-                      <packages>com.amazonaws.services.inspector*</packages>
-                    </group>
-                    <group>
-                      <title>AWS IoT</title>
-                      <packages>com.amazonaws.services.iot*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon API Gateway</title>
-                      <packages>com.amazonaws.services.apigateway*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2 Container Registry</title>
-                      <packages>com.amazonaws.services.ecr*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon GameLift</title>
-                      <packages>com.amazonaws.services.gamelift*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Database Migration Service</title>
-                      <packages>com.amazonaws.services.databasemigrationservice*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Marketplace Metering Service</title>
-                      <packages>com.amazonaws.services.marketplacemetering*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Cognito Identity Provider</title>
-                      <packages>com.amazonaws.services.cognitoidp*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Application Discovery Service</title>
-                      <packages>com.amazonaws.services.applicationdiscovery*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Application Auto Scaling</title>
-                      <packages>com.amazonaws.services.applicationautoscaling*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Snowball</title>
-                      <packages>com.amazonaws.services.snowball*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Service Catalog</title>
-                      <packages>com.amazonaws.services.servicecatalog*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Budgets</title>
-                      <packages>com.amazonaws.services.budgets*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Server Migration</title>
-                      <packages>com.amazonaws.services.servermigration*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Rekognition</title>
-                      <packages>com.amazonaws.services.rekognition*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Polly</title>
-                      <packages>com.amazonaws.services.polly*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Lightsail</title>
-                      <packages>com.amazonaws.services.lightsail*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon AppStream</title>
-                      <packages>com.amazonaws.services.appstream*</packages>
-                    </group>
-                    <group>
-                      <title>AWS X-Ray</title>
-                      <packages>com.amazonaws.services.xray*</packages>
-                    </group>
-                    <group>
-                      <title>AWS OpsWorks for Chef Automate</title>
-                      <packages>com.amazonaws.services.opsworkscm*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Pinpoint</title>
-                      <packages>com.amazonaws.services.pinpoint*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Step Functions</title>
-                      <packages>com.amazonaws.services.stepfunctions*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Shield</title>
-                      <packages>com.amazonaws.services.shield*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Health APIs and Notifications</title>
-                      <packages>com.amazonaws.services.health*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Cost and Usage Report</title>
-                      <packages>com.amazonaws.services.costandusagereport*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Code Build</title>
-                      <packages>com.amazonaws.services.codebuild*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Batch</title>
-                      <packages>com.amazonaws.services.batch*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Lex</title>
-                      <packages>com.amazonaws.services.lex*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Mechanical Turk Requester</title>
-                      <packages>com.amazonaws.services.mechanicalturkrequester*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Organizations</title>
-                      <packages>com.amazonaws.services.organizations*</packages>
-                    </group>
-                    <group>
-                      <title>Common</title>
-                      <packages>com.amazonaws*</packages>
-                    </group>
-                  </groups>
-                  <header>&lt;!-- Scripts for Syntax Highlighter START--&gt;
-                  &lt;script id="syntaxhighlight_script_core" type="text/javascript" src = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/scripts/shCore.js"&gt;
-                  &lt;/script&gt;
-                  &lt;script id="syntaxhighlight_script_java" type="text/javascript" src = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/scripts/shBrushJava.js"&gt;
-                  &lt;/script&gt;
-                  &lt;link id="syntaxhighlight_css_core" rel="stylesheet" type="text/css" href = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/styles/shCoreDefault.css"/&gt;
-                  &lt;link id="syntaxhighlight_css_theme" rel="stylesheet" type="text/css" href = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/styles/shThemeDefault.css"/&gt;
-                  &lt;!-- Scripts for Syntax Highlighter END--&gt;
-                  &lt;div&gt;
-                      &lt;!-- BEGIN-SECTION --&gt;
-                      &lt;div id="divsearch" style="float:left;"&gt;
-                          &lt;span id="lblsearch" for="searchQuery"&gt;
-                              &lt;label&gt;Search&lt;/label&gt;
-                          &lt;/span&gt;
-
-                          &lt;form id="nav-search-form" target="_parent" method="get" action="http://docs.aws.amazon.com/search/doc-search.html#facet_doc_guide=API+Reference&amp;facet_doc_product=AWS+SDK+for+Java"&gt;
-                              &lt;div id="nav-searchfield-outer" class="nav-sprite"&gt;
-                                  &lt;div class="nav-searchfield-inner nav-sprite"&gt;
-                                      &lt;div id="nav-searchfield-width"&gt;
-                                          &lt;input id="nav-searchfield" name="searchQuery"&gt;
-                                          &lt;/div&gt;
-                                      &lt;/div&gt;
-                                  &lt;/div&gt;
-                                  &lt;div id="nav-search-button" class="nav-sprite"&gt;
-                                      &lt;button type="submit" style="border: 0;background: transparent;padding: 0;"&gt;
-                                          &lt;img src="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/search-button.png" width="40" height="37" alt="submit"&gt;
-                                      &lt;/button&gt;
-                                  &lt;/div&gt;
-                                      &lt;input name="searchPath" type="hidden" value="documentation-guide" /&gt;
-                                      &lt;input name="this_doc_product" type="hidden" value="AWS SDK for Java" /&gt;
-                                      &lt;input name="this_doc_guide" type="hidden" value="API Reference" /&gt;
-                                      &lt;input name="doc_locale" type="hidden" value="en_us" /&gt;
-                                  &lt;/form&gt;
-                              &lt;/div&gt;
-                              &lt;!-- END-SECTION --&gt;
-
-                              &lt;!-- BEGIN-FEEDBACK-SECTION --&gt;
-                              &lt;div id="feedback-section"&gt;
-                                  &lt;h3&gt;Did this page help you?&lt;/h3&gt;
-                                  &lt;div id="feedback-link-sectioin"&gt;
-                                      &lt;a id="go_cti" target="_blank" style="display:inline;"&gt;Submit feedback...&lt;/a&gt;
-                                  &lt;/div&gt;
-
-                              &lt;/div&gt;
-                              &lt;script type="text/javascript"&gt;
-                                  window.onload = function(){
-                                  /* Dynamically add feedback links */
-                                  var javadoc_root_name = "/javadoc/";
-                                  var javadoc_path = location.href.substring(0, location.href.lastIndexOf(javadoc_root_name) + javadoc_root_name.length);
-                                  var file_path = location.href.substring(location.href.lastIndexOf(javadoc_root_name) + javadoc_root_name.length);
-                                  var sdk_name = encodeURI("AWS SDK for Java");
-                                  var encoded_path = encodeURI(location.href);
-
-                                  var feedback_tellmore_url = "https://docs-feedback.aws.amazon.com/feedback.jsp?hidden_service_name=" + sdk_name + "&amp;topic_url=" + encoded_path;
-
-                                  if(file_path != "overview-frame.html") {
-                                  document.getElementById("go_cti").setAttribute("href", feedback_tellmore_url);
-                                  } else {
-                                  document.getElementById("feedback-section").outerHTML = "AWS SDK for Java";
-                                  document.getElementById("divsearch").outerHTML = "";
-                                  }
-                                  };
-                              &lt;/script&gt;
-                              &lt;!-- END-FEEDBACK-SECTION --&gt;
-
-                          &lt;/div&gt;</header>
-                  <footer>&lt;div&gt;
-                              &lt;!-- Script for Syntax Highlighter START --&gt;
-                              &lt;script type="text/javascript"&gt;
-                                  SyntaxHighlighter.all()
-                              &lt;/script&gt;
-                              &lt;!-- Script for Syntax Highlighter END --&gt;
-                          &lt;/div&gt;
-                          
-                          &lt;script src="http://a0.awsstatic.com/chrome/js/1.0.46/jquery.1.9.js" type="text/javascript"&gt;&lt;/script&gt;
-                          &lt;script&gt;
-                          jQuery(function ($) {
-                          $("div.header").prepend('&lt;!--REGION_DISCLAIMER_DO_NOT_REMOVE--&gt;');
-                          });
-                          &lt;/script&gt;
-                          &lt;!-- BEGIN-URCHIN-TRACKER --&gt;
-                          &lt;script src="http://l0.awsstatic.com/js/urchin.js" type="text/javascript"&gt;&lt;/script&gt;
-                          &lt;script type="text/javascript"&gt;urchinTracker();&lt;/script&gt;
-                          &lt;!-- END-URCHIN-TRACKER --&gt;
-
-                          &lt;!-- SiteCatalyst code version: H.25.2. Copyright 1996-2012 Adobe, Inc. All Rights Reserved.
-                          More info available at http://www.omniture.com --&gt;
-                          &lt;script type="text/javascript" src="https://media.amazonwebservices.com/js/sitecatalyst/s_code.min.js" /&gt;
-                      &lt;script type="text/javascript"&gt;
-                      s.prop66='AWS SDK for Java';
-                      s.eVar66='D=c66';
-                      s.prop65='API Reference';
-                      s.eVar65='D=c65';
-                      var s_code=s.t();
-                      if (s_code) document.write(s_code);
-                      &lt;/script&gt;
-                      &lt;script language="JavaScript" type="text/javascript"&gt;
-                      &lt;!--if(navigator.appVersion.indexOf('MSIE')&gt;=0)document.write(unescape('%3C')+'\!-'+'-')
-                      //--&gt;
-                      &lt;/script&gt;
-                      &lt;noscript&gt;
-                      &lt;img src="http://amazonwebservices.d2.sc.omtrdc.net/b/ss/awsamazondev/1/H.25.2--NS/0" height="1" width="1" border="0" alt="" /&gt;
-                  &lt;/noscript&gt;
-                  &lt;!--/DO NOT REMOVE/--&gt;
-                  &lt;!-- End SiteCatalyst code version: H.25.2. --&gt;</footer>
-                  <bottom>Copyright &amp;#169; 2013 Amazon Web Services, Inc. All Rights Reserved.</bottom>
-                  <excludePackageNames>*.internal:*.transform</excludePackageNames>
-                </configuration>
-              </execution>
               <execution>
                 <id>javadoc-jar</id>
                 <phase>package</phase>
                 <goals>
                   <goal>jar</goal>
                 </goals>
-                <configuration>
-                  <minmemory>128m</minmemory>
-                  <maxmemory>2g</maxmemory>
-                  <includeDependencySources>true</includeDependencySources>
-                  <show>public</show>
-                  <defaultexcludes>yes</defaultexcludes>
-                  <stylesheetfile>com/amazonaws/JavaDoc.css</stylesheetfile>
-                  <author>false</author>
-                  <version>true</version>
-                  <use>false</use>
-                  <notree>true</notree>
-                  <nodeprecatedlist>true</nodeprecatedlist>
-                  <windowtitle>AWS SDK for Java - 1.11.98</windowtitle>
-                  <encoding>UTF-8</encoding>
-                  <docencoding>UTF-8</docencoding>
-                  <doctitle>AWS SDK for Java API Reference - 1.11.98</doctitle>
-                  <packagesheader>AWS SDK for Java</packagesheader>
-                  <docfilessubdirs>true</docfilessubdirs>
-                  <taglets>
-                    <taglet>
-                      <tagletClass>com.amazonaws.codesamples.SampleCodeTaglet</tagletClass>
-                      <tagletArtifact>
-                        <groupId>com.amazonaws</groupId>
-                        <artifactId>aws-java-sdk-samples</artifactId>
-                        <version>LATEST</version>
-                      </tagletArtifact>
-                    </taglet>
-                  </taglets>
-                  <groups>
-                    <group>
-                      <title>Amazon S3</title>
-                      <packages>com.amazonaws.services.s3*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Glacier</title>
-                      <packages>com.amazonaws.services.glacier*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon DynamoDB</title>
-                      <packages>com.amazonaws.services.dynamo*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2</title>
-                      <packages>com.amazonaws.services.ec2*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SimpleDB</title>
-                      <packages>com.amazonaws.services.simpledb*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SQS</title>
-                      <packages>com.amazonaws.services.sqs*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon SNS</title>
-                      <packages>com.amazonaws.services.sns*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Relational Database Service</title>
-                      <packages>com.amazonaws.services.rds*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Route 53</title>
-                      <packages>com.amazonaws.services.route53*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Simple Workflow Service</title>
-                      <packages>com.amazonaws.services.simplework*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic MapReduce</title>
-                      <packages>com.amazonaws.services.elasticmapreduce*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Simple Email Service</title>
-                      <packages>com.amazonaws.services.simpleemail*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic Load Balancing</title>
-                      <packages>com.amazonaws.services.elasticloadbalancing*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudSearch</title>
-                      <packages>com.amazonaws.services.cloudsearch*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch</title>
-                      <packages>com.amazonaws.services.cloudwatch*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch Logs</title>
-                      <packages>com.amazonaws.services.logs*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudWatch Events</title>
-                      <packages>com.amazonaws.services.cloudwatchevents*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudFront</title>
-                      <packages>com.amazonaws.services.cloudfront*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon CloudDirectory</title>
-                      <packages>com.amazonaws.services.clouddirectory*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Cognito</title>
-                      <packages>com.amazonaws.services.cognito*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon AutoScaling</title>
-                      <packages>com.amazonaws.services.autoscaling*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Kinesis</title>
-                      <packages>com.amazonaws.services.kinesis*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Redshift</title>
-                      <packages>com.amazonaws.services.redshift*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon ElastiCache</title>
-                      <packages>com.amazonaws.services.elasticache*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic Transcoder</title>
-                      <packages>com.amazonaws.services.elastictranscoder*</packages>
-                    </group>
-                    <group>
-                      <title>AWS OpsWorks</title>
-                      <packages>com.amazonaws.services.opsworks*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudFormation</title>
-                      <packages>com.amazonaws.services.cloudformation*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Data Pipeline</title>
-                      <packages>com.amazonaws.services.datapipeline*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Direct Connect</title>
-                      <packages>com.amazonaws.services.directconnect*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Elastic Beanstalk</title>
-                      <packages>com.amazonaws.services.elasticbeanstalk*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Identity and Access Management</title>
-                      <packages>com.amazonaws.services.identity*</packages>
-                    </group>
-                    <group>
-                      <title>AWS ImportExport</title>
-                      <packages>com.amazonaws.services.importexport*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Security Token Service</title>
-                      <packages>com.amazonaws.services.securitytoken*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Storage Gateway Service</title>
-                      <packages>com.amazonaws.services.storagegateway*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Support</title>
-                      <packages>com.amazonaws.services.support*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudTrail</title>
-                      <packages>com.amazonaws.services.cloudtrail*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Config</title>
-                      <packages>com.amazonaws.services.config*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Certificate Manager</title>
-                      <packages>com.amazonaws.services.certificatemanager*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Key Management</title>
-                      <packages>com.amazonaws.services.kms*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodeDeploy</title>
-                      <packages>com.amazonaws.services.codedeploy*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Lambda</title>
-                      <packages>com.amazonaws.services.lambda*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2 Container Service</title>
-                      <packages>com.amazonaws.services.ecs*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CloudHSM</title>
-                      <packages>com.amazonaws.services.cloudhsm*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Simple Systems Management Service</title>
-                      <packages>com.amazonaws.services.simplesystemsmanagement*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon WorkSpaces</title>
-                      <packages>com.amazonaws.services.workspaces*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Machine Learning</title>
-                      <packages>com.amazonaws.services.machinelearning*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Directory Service</title>
-                      <packages>com.amazonaws.services.directory*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elastic File System</title>
-                      <packages>com.amazonaws.services.elasticfilesystem*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodePipeline</title>
-                      <packages>com.amazonaws.services.codepipeline*</packages>
-                    </group>
-                    <group>
-                      <title>AWS CodeCommit</title>
-                      <packages>com.amazonaws.services.codecommit*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Device Farm</title>
-                      <packages>com.amazonaws.services.devicefarm*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Elasticsearch Service</title>
-                      <packages>com.amazonaws.services.elasticsearch*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Marketplace Commerce Analytics</title>
-                      <packages>com.amazonaws.services.marketplacecommerceanalytics*</packages>
-                    </group>
-                    <group>
-                      <title>AWS WAF</title>
-                      <packages>com.amazonaws.services.waf*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Inspector Service</title>
-                      <packages>com.amazonaws.services.inspector*</packages>
-                    </group>
-                    <group>
-                      <title>AWS IoT</title>
-                      <packages>com.amazonaws.services.iot*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon API Gateway</title>
-                      <packages>com.amazonaws.services.apigateway*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon EC2 Container Registry</title>
-                      <packages>com.amazonaws.services.ecr*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon GameLift</title>
-                      <packages>com.amazonaws.services.gamelift*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Database Migration Service</title>
-                      <packages>com.amazonaws.services.databasemigrationservice*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Marketplace Metering Service</title>
-                      <packages>com.amazonaws.services.marketplacemetering*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Cognito Identity Provider</title>
-                      <packages>com.amazonaws.services.cognitoidp*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Application Discovery Service</title>
-                      <packages>com.amazonaws.services.applicationdiscovery*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Application Auto Scaling</title>
-                      <packages>com.amazonaws.services.applicationautoscaling*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Snowball</title>
-                      <packages>com.amazonaws.services.snowball*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Service Catalog</title>
-                      <packages>com.amazonaws.services.servicecatalog*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Budgets</title>
-                      <packages>com.amazonaws.services.budgets*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Server Migration</title>
-                      <packages>com.amazonaws.services.servermigration*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Rekognition</title>
-                      <packages>com.amazonaws.services.rekognition*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Polly</title>
-                      <packages>com.amazonaws.services.polly*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Lightsail</title>
-                      <packages>com.amazonaws.services.lightsail*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon AppStream</title>
-                      <packages>com.amazonaws.services.appstream*</packages>
-                    </group>
-                    <group>
-                      <title>AWS X-Ray</title>
-                      <packages>com.amazonaws.services.xray*</packages>
-                    </group>
-                    <group>
-                      <title>AWS OpsWorks for Chef Automate</title>
-                      <packages>com.amazonaws.services.opsworkscm*</packages>
-                    </group>
-                    <group>
-                      <title>Amazon Pinpoint</title>
-                      <packages>com.amazonaws.services.pinpoint*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Step Functions</title>
-                      <packages>com.amazonaws.services.stepfunctions*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Shield</title>
-                      <packages>com.amazonaws.services.shield*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Health APIs and Notifications</title>
-                      <packages>com.amazonaws.services.health*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Cost and Usage Report</title>
-                      <packages>com.amazonaws.services.costandusagereport*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Code Build</title>
-                      <packages>com.amazonaws.services.codebuild*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Batch</title>
-                      <packages>com.amazonaws.services.batch*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Lex</title>
-                      <packages>com.amazonaws.services.lex*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Mechanical Turk Requester</title>
-                      <packages>com.amazonaws.services.mechanicalturkrequester*</packages>
-                    </group>
-                    <group>
-                      <title>AWS Organizations</title>
-                      <packages>com.amazonaws.services.organizations*</packages>
-                    </group>
-                    <group>
-                      <title>Common</title>
-                      <packages>com.amazonaws*</packages>
-                    </group>
-                  </groups>
-                  <header>&lt;!-- Scripts for Syntax Highlighter START--&gt;
-                  &lt;script id="syntaxhighlight_script_core" type="text/javascript" src = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/scripts/shCore.js"&gt;
-                  &lt;/script&gt;
-                  &lt;script id="syntaxhighlight_script_java" type="text/javascript" src = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/scripts/shBrushJava.js"&gt;
-                  &lt;/script&gt;
-                  &lt;link id="syntaxhighlight_css_core" rel="stylesheet" type="text/css" href = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/styles/shCoreDefault.css"/&gt;
-                  &lt;link id="syntaxhighlight_css_theme" rel="stylesheet" type="text/css" href = "http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/syntaxhighlight/styles/shThemeDefault.css"/&gt;
-                  &lt;!-- Scripts for Syntax Highlighter END--&gt;
-                  &lt;div&gt;
-                      &lt;!-- BEGIN-SECTION --&gt;
-                      &lt;div id="divsearch" style="float:left;"&gt;
-                          &lt;span id="lblsearch" for="searchQuery"&gt;
-                              &lt;label&gt;Search&lt;/label&gt;
-                          &lt;/span&gt;
-
-                          &lt;form id="nav-search-form" target="_parent" method="get" action="http://docs.aws.amazon.com/search/doc-search.html#facet_doc_guide=API+Reference&amp;facet_doc_product=AWS+SDK+for+Java"&gt;
-                              &lt;div id="nav-searchfield-outer" class="nav-sprite"&gt;
-                                  &lt;div class="nav-searchfield-inner nav-sprite"&gt;
-                                      &lt;div id="nav-searchfield-width"&gt;
-                                          &lt;input id="nav-searchfield" name="searchQuery"&gt;
-                                          &lt;/div&gt;
-                                      &lt;/div&gt;
-                                  &lt;/div&gt;
-                                  &lt;div id="nav-search-button" class="nav-sprite"&gt;
-                                      &lt;button type="submit" style="border: 0;background: transparent;padding: 0;"&gt;
-                                          &lt;img src="http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/resources/search-button.png" width="40" height="37" alt="submit"&gt;
-                                      &lt;/button&gt;
-                                  &lt;/div&gt;
-                                      &lt;input name="searchPath" type="hidden" value="documentation-guide" /&gt;
-                                      &lt;input name="this_doc_product" type="hidden" value="AWS SDK for Java" /&gt;
-                                      &lt;input name="this_doc_guide" type="hidden" value="API Reference" /&gt;
-                                      &lt;input name="doc_locale" type="hidden" value="en_us" /&gt;
-                                  &lt;/form&gt;
-                              &lt;/div&gt;
-                              &lt;!-- END-SECTION --&gt;
-
-                              &lt;!-- BEGIN-FEEDBACK-SECTION --&gt;
-                              &lt;div id="feedback-section"&gt;
-                                  &lt;h3&gt;Did this page help you?&lt;/h3&gt;
-                                  &lt;div id="feedback-link-sectioin"&gt;
-                                      &lt;a id="go_cti" target="_blank" style="display:inline;"&gt;Submit feedback...&lt;/a&gt;
-                                  &lt;/div&gt;
-
-                              &lt;/div&gt;
-                              &lt;script type="text/javascript"&gt;
-                                  window.onload = function(){
-                                  /* Dynamically add feedback links */
-                                  var javadoc_root_name = "/javadoc/";
-                                  var javadoc_path = location.href.substring(0, location.href.lastIndexOf(javadoc_root_name) + javadoc_root_name.length);
-                                  var file_path = location.href.substring(location.href.lastIndexOf(javadoc_root_name) + javadoc_root_name.length);
-                                  var sdk_name = encodeURI("AWS SDK for Java");
-                                  var encoded_path = encodeURI(location.href);
-
-                                  var feedback_tellmore_url = "https://docs-feedback.aws.amazon.com/feedback.jsp?hidden_service_name=" + sdk_name + "&amp;topic_url=" + encoded_path;
-
-                                  if(file_path != "overview-frame.html") {
-                                  document.getElementById("go_cti").setAttribute("href", feedback_tellmore_url);
-                                  } else {
-                                  document.getElementById("feedback-section").outerHTML = "AWS SDK for Java";
-                                  document.getElementById("divsearch").outerHTML = "";
-                                  }
-                                  };
-                              &lt;/script&gt;
-                              &lt;!-- END-FEEDBACK-SECTION --&gt;
-
-                          &lt;/div&gt;</header>
-                  <footer>&lt;div&gt;
-                              &lt;!-- Script for Syntax Highlighter START --&gt;
-                              &lt;script type="text/javascript"&gt;
-                                  SyntaxHighlighter.all()
-                              &lt;/script&gt;
-                              &lt;!-- Script for Syntax Highlighter END --&gt;
-                          &lt;/div&gt;
-                          
-                          &lt;script src="http://a0.awsstatic.com/chrome/js/1.0.46/jquery.1.9.js" type="text/javascript"&gt;&lt;/script&gt;
-                          &lt;script&gt;
-                          jQuery(function ($) {
-                          $("div.header").prepend('&lt;!--REGION_DISCLAIMER_DO_NOT_REMOVE--&gt;');
-                          });
-                          &lt;/script&gt;
-                          &lt;!-- BEGIN-URCHIN-TRACKER --&gt;
-                          &lt;script src="http://l0.awsstatic.com/js/urchin.js" type="text/javascript"&gt;&lt;/script&gt;
-                          &lt;script type="text/javascript"&gt;urchinTracker();&lt;/script&gt;
-                          &lt;!-- END-URCHIN-TRACKER --&gt;
-
-                          &lt;!-- SiteCatalyst code version: H.25.2. Copyright 1996-2012 Adobe, Inc. All Rights Reserved.
-                          More info available at http://www.omniture.com --&gt;
-                          &lt;script type="text/javascript" src="https://media.amazonwebservices.com/js/sitecatalyst/s_code.min.js" /&gt;
-                      &lt;script type="text/javascript"&gt;
-                      s.prop66='AWS SDK for Java';
-                      s.eVar66='D=c66';
-                      s.prop65='API Reference';
-                      s.eVar65='D=c65';
-                      var s_code=s.t();
-                      if (s_code) document.write(s_code);
-                      &lt;/script&gt;
-                      &lt;script language="JavaScript" type="text/javascript"&gt;
-                      &lt;!--if(navigator.appVersion.indexOf('MSIE')&gt;=0)document.write(unescape('%3C')+'\!-'+'-')
-                      //--&gt;
-                      &lt;/script&gt;
-                      &lt;noscript&gt;
-                      &lt;img src="http://amazonwebservices.d2.sc.omtrdc.net/b/ss/awsamazondev/1/H.25.2--NS/0" height="1" width="1" border="0" alt="" /&gt;
-                  &lt;/noscript&gt;
-                  &lt;!--/DO NOT REMOVE/--&gt;
-                  &lt;!-- End SiteCatalyst code version: H.25.2. --&gt;</footer>
-                  <bottom>Copyright &amp;#169; 2013 Amazon Web Services, Inc. All Rights Reserved.</bottom>
-                  <excludePackageNames>*.internal:*.transform</excludePackageNames>
-                </configuration>
               </execution>
             </executions>
-            <inherited>true</inherited>
             <configuration>
               <minmemory>128m</minmemory>
               <maxmemory>2g</maxmemory>
@@ -1080,10 +116,10 @@
               <use>false</use>
               <notree>true</notree>
               <nodeprecatedlist>true</nodeprecatedlist>
-              <windowtitle>AWS SDK for Java - 1.11.98</windowtitle>
+              <windowtitle>AWS SDK for Java - ${project.version}</windowtitle>
               <encoding>UTF-8</encoding>
               <docencoding>UTF-8</docencoding>
-              <doctitle>AWS SDK for Java API Reference - 1.11.98</doctitle>
+              <doctitle>AWS SDK for Java API Reference - ${project.version}</doctitle>
               <packagesheader>AWS SDK for Java</packagesheader>
               <docfilessubdirs>true</docfilessubdirs>
               <taglets>
@@ -1544,7 +580,6 @@
                   &lt;!--/DO NOT REMOVE/--&gt;
                   &lt;!-- End SiteCatalyst code version: H.25.2. --&gt;</footer>
               <bottom>Copyright &amp;#169; 2013 Amazon Web Services, Inc. All Rights Reserved.</bottom>
-              <excludePackageNames>*.internal:*.transform</excludePackageNames>
             </configuration>
           </plugin>
         </plugins>
@@ -1559,30 +594,16 @@
             <version>2.7</version>
             <executions>
               <execution>
-                <id>default-testResources</id>
-                <phase>process-test-resources</phase>
-                <goals>
-                  <goal>testResources</goal>
-                </goals>
-              </execution>
-              <execution>
-                <id>default-resources</id>
-                <phase>process-resources</phase>
-                <goals>
-                  <goal>resources</goal>
-                </goals>
-              </execution>
-              <execution>
                 <id>copy-resources</id>
                 <phase>process-resources</phase>
                 <goals>
                   <goal>copy-resources</goal>
                 </goals>
                 <configuration>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files}</outputDirectory>
                   <resources>
                     <resource>
-                      <directory>/var/sdk/additional-files-to-copy</directory>
+                      <directory>${zip.generation.additional.files.sources}</directory>
                     </resource>
                   </resources>
                 </configuration>
@@ -1599,66 +620,6 @@
                 <goals>
                   <goal>copy</goal>
                 </goals>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>javax.mail</groupId>
-                      <artifactId>javax.mail-api</artifactId>
-                      <version>1.4.6</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.freemarker</groupId>
-                      <artifactId>freemarker</artifactId>
-                      <version>2.3.9</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.aspectj</groupId>
-                      <artifactId>aspectjrt</artifactId>
-                      <version>1.8.2</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.springframework</groupId>
-                      <artifactId>spring-beans</artifactId>
-                      <version>3.0.7.RELEASE</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.springframework</groupId>
-                      <artifactId>spring-core</artifactId>
-                      <version>3.0.7.RELEASE</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.springframework</groupId>
-                      <artifactId>spring-context</artifactId>
-                      <version>3.0.7.RELEASE</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.springframework</groupId>
-                      <artifactId>spring-test</artifactId>
-                      <version>3.0.7.RELEASE</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
-                    </artifactItem>
-                  </artifactItems>
-                </configuration>
               </execution>
             </executions>
             <configuration>
@@ -1666,58 +627,58 @@
                 <artifactItem>
                   <groupId>javax.mail</groupId>
                   <artifactId>javax.mail-api</artifactId>
-                  <version>1.4.6</version>
+                  <version>${javax.mail.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.freemarker</groupId>
                   <artifactId>freemarker</artifactId>
-                  <version>2.3.9</version>
+                  <version>${freemarker.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.aspectj</groupId>
                   <artifactId>aspectjrt</artifactId>
-                  <version>1.8.2</version>
+                  <version>${aspectj.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.springframework</groupId>
                   <artifactId>spring-beans</artifactId>
-                  <version>3.0.7.RELEASE</version>
+                  <version>${spring.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.springframework</groupId>
                   <artifactId>spring-core</artifactId>
-                  <version>3.0.7.RELEASE</version>
+                  <version>${spring.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.springframework</groupId>
                   <artifactId>spring-context</artifactId>
-                  <version>3.0.7.RELEASE</version>
+                  <version>${spring.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
                 <artifactItem>
                   <groupId>org.springframework</groupId>
                   <artifactId>spring-test</artifactId>
-                  <version>3.0.7.RELEASE</version>
+                  <version>${spring.version}</version>
                   <type>jar</type>
                   <overWrite>true</overWrite>
-                  <outputDirectory>/home/tomcat/.jenkins/jobs/StageRelease/workspace/aws-java-sdk-osgi/target/zip-additional-files/third-party/lib</outputDirectory>
+                  <outputDirectory>${zip.generation.additional.files.third-party.lib}</outputDirectory>
                 </artifactItem>
               </artifactItems>
             </configuration>
@@ -1732,12 +693,6 @@
                 <goals>
                   <goal>single</goal>
                 </goals>
-                <configuration>
-                  <descriptors>
-                    <descriptor>src/assembly/sdk-zip-archive-assembly.xml</descriptor>
-                  </descriptors>
-                  <tarLongFileMode>gnu</tarLongFileMode>
-                </configuration>
               </execution>
             </executions>
             <configuration>
@@ -1750,7 +705,6 @@
           <plugin>
             <groupId>org.codehaus.mojo</groupId>
             <artifactId>exec-maven-plugin</artifactId>
-            <version>1.5.0</version>
             <executions>
               <execution>
                 <phase>package</phase>
@@ -1758,9 +712,9 @@
                   <goal>exec</goal>
                 </goals>
                 <configuration>
-                  <workingDirectory>target/aws-java-sdk-osgi-1.11.98-sdk-zip-archive-assembly/</workingDirectory>
+                  <workingDirectory>target/${project.build.finalName}-${zip.assembly.id}/</workingDirectory>
                   <executable>zip</executable>
-                  <commandlineArgs>-r ../aws-java-sdk.zip .</commandlineArgs>
+                  <commandlineArgs>-r ../${zip.artifact.name} .</commandlineArgs>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
This is just a PoC, not ready to consider yet - using this branch as a sandbox for trying this out more of an experiment than something that might be useful.

Provides the ability to call mapper.save(T) and increment a field rather than using the lower level API.   The increment value is supplied in the model configuration via the following annotation

```
@DynamoDBAtomicInteger(attributeName = "counter", incr = 5)
private Integer counter;
```

Each time model is saved the attribute 'counter' is incremented by 5.   The existing pattern for accomplishing the same is to use the lower level UpdateItemRequest interface and call updateItem. 

More than likely another verb on the mapper interface (incr perhaps) would be created to expose this functionality that way only the key needs to be supplied in the model, otherwise unless the attributes on save are preserved it will squash the values as persisted.   The save functionality would ignore this particular field in the model instead of performing the incr behavior and defer to the incr verb.

There's possibly a way to link in with the existing generate functionality so this behavior isn't a silo - that's a little unclear, first time I've used dynamodb...