### PR TITLE
Issue #547: Field level POJO accessors

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
@@ -69,9 +69,10 @@ final class StandardAnnotationMaps {
             defaultName = fieldName;
         }
 
-        FieldMap<T> annotations = of(declaredField, defaultName);
-        annotations.putAll(getter);
+        final FieldMap<T> annotations = new FieldMap<T>(targetType, defaultName);
         annotations.putAll(targetType);
+        annotations.putAll(declaredField);
+        annotations.putAll(getter);
         return annotations;
     }
 
@@ -82,7 +83,6 @@ final class StandardAnnotationMaps {
         annotations.putAll(declaredField);
         return annotations;
     }
-
 
 
     /**

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardAnnotationMaps.java
@@ -69,12 +69,21 @@ final class StandardAnnotationMaps {
             defaultName = fieldName;
         }
 
+        FieldMap<T> annotations = of(declaredField, defaultName);
+        annotations.putAll(getter);
+        annotations.putAll(targetType);
+        return annotations;
+    }
+
+    static final <T> FieldMap<T> of(Field declaredField, String defaultName) {
+        final Class<T> targetType = (Class<T>) declaredField.getType();
         final FieldMap<T> annotations = new FieldMap<T>(targetType, defaultName);
         annotations.putAll(targetType);
         annotations.putAll(declaredField);
-        annotations.putAll(getter);
         return annotations;
     }
+
+
 
     /**
      * Common type-conversions properties.

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardBeanProperties.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/StandardBeanProperties.java
@@ -241,11 +241,14 @@ final class StandardBeanProperties {
         }
 
         private void putMissing(Class<T> clazz, boolean inherited) {
-            for (final Field field : clazz.getFields()) {
+            for (final Field field : clazz.getDeclaredFields()) {
                 String name = field.getName();
                 Method getter = getGetter(name, clazz);
                 FieldMap<V> annotations = StandardAnnotationMaps.<V>of(field, field.getName());
-                if (null == getter && !annotations.ignored()) {
+                if (null == getter
+                        && !annotations.ignored()
+                        // Don't include this$0, etc
+                        && !field.getName().startsWith("this")) {
                     final Reflect<T,V> reflect = new FieldReflect<T,V>(field);
                     final Bean<T,V> bean = new Bean<T,V>(field, annotations, reflect);
                     if (put(bean.properties().attributeName(), bean) != null) {


### PR DESCRIPTION
Immutable entity support (https://github.com/aws/aws-sdk-java/issues/547) - I could see using a pattern where-in the domain entity is immutable for "store" behavior.  Although, it seems unlikely as the predominate case as I'd likely have some form of transfer object to marshal state to/from the DB where-in I have setters/getters.

Just an option for an implementation that solves this concern as I myself might want to do something similar in some of our use-cases.

Thought this was an interesting problem to solve, here's one possible implementation.     Might consider re-using reflectutils rather than directly using java.lang.*... Also might not want to invoke field.set when setter not available...

Tests are needed by this implementation, willing to add them if this is worthy of eventually merging.