### PR TITLE
Doc fix for `ClientConfiguration::getProxyUsername`

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -699,8 +699,8 @@ public class ClientConfiguration {
      * object, or if not provided, checks the value of the Java system
      * property for proxy user name according to {@link #getProtocol()}:
      * i.e. if protocol is https, returns the value of the system
-     * property https.proxyUsername, otherwise returns value of
-     * http.proxyUsername.
+     * property https.proxyUser, otherwise returns value of
+     * http.proxyUser.
      *
      * @return The optional proxy user name the configured client will use if connecting through a
      *         proxy.


### PR DESCRIPTION
* this method returns the `http(s).proxyUser` system property,
  not `http(s).proxyUsername`.

Hello. I believe this small documentation update is warranted based on the content of the `getProxyUsernameProperty()` method.  The system property is correct in code but incorrect when reading the documentation.