### PR TITLE
Documentation fix for MultipleFileUpload

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/MultipleFileUpload.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/MultipleFileUpload.java
@@ -18,7 +18,7 @@ import java.util.Collection;
 
 
 /**
- * Multiple file download of an entire virtual directory.
+ * Multiple file upload of an entire virtual directory.
  */
 public interface  MultipleFileUpload extends Transfer {
 


### PR DESCRIPTION
This PR fixes a typo. The description of the interface MultipleFileUpload does not match the intended specified behavior.