### PR TITLE
Fix NPE fault in Regions.fromName

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 target/
 *settings.xml
+.idea
+*iml
+*~
+.*~

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/regions/Regions.java
@@ -71,7 +71,7 @@ public enum Regions {
      */
     public static Regions fromName(String regionName) {
         for (Regions region : Regions.values()) {
-            if (regionName.equals(region.getName())) {
+            if (region.getName().equals(regionName)) {
                 return region;
             }
         }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/regions/RegionsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/regions/RegionsTest.java
@@ -52,6 +52,21 @@ public class RegionsTest {
                             unknown.getEndpoint());
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void fromName_whenRegionNameNull_throwsIllegalArgumentException() {
+        Regions.fromName(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromName_whenRegionNameEmpty_throwsIllegalArgumentException() {
+        Regions.fromName("");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void fromName_whenRegionNameInvalid_throwsIllegalArgumentException() {
+        Regions.fromName("northpole");
+    }
+
     private static class AmazonServiceClient extends AmazonWebServiceClient {
         
         public AmazonServiceClient() {


### PR DESCRIPTION
This change reverses the lhs and rhs of the .equals method used in Regions.fromName to avoid an NPE. Also adds relevant tests.