### PR TITLE
Add support for session tokens in SystemPropertiesCredentialsProvider

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -48,7 +48,10 @@ public class SDKGlobalConfiguration {
     public static final String ACCESS_KEY_SYSTEM_PROPERTY = "aws.accessKeyId";
 
     /** System property name for the AWS secret key */
-    public  static final String SECRET_KEY_SYSTEM_PROPERTY = "aws.secretKey";
+    public static final String SECRET_KEY_SYSTEM_PROPERTY = "aws.secretKey";
+
+    /** System property name for the STS session token */
+    public static final String SESSION_TOKEN_SYSTEM_PROPERTY = "aws.sessionToken";
 
     /**
      * System property for overriding the Amazon EC2 Instance Metadata Service

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
@@ -51,7 +51,7 @@ public class SystemPropertiesCredentialsProvider implements AWSCredentialsProvid
         if (StringUtils.isNullOrEmpty(sessionToken)) {
             return new BasicAWSCredentials(accessKey, secretKey);
         } else {
-            return new BasicAWSSessionCredentials(accessKey, secretKey, sessionToken);
+            return new BasicSessionCredentials(accessKey, secretKey, sessionToken);
         }
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SystemPropertiesCredentialsProvider.java
@@ -16,6 +16,7 @@ package com.amazonaws.auth;
 
 import static com.amazonaws.SDKGlobalConfiguration.ACCESS_KEY_SYSTEM_PROPERTY;
 import static com.amazonaws.SDKGlobalConfiguration.SECRET_KEY_SYSTEM_PROPERTY;
+import static com.amazonaws.SDKGlobalConfiguration.SESSION_TOKEN_SYSTEM_PROPERTY;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.util.StringUtils;
@@ -35,6 +36,9 @@ public class SystemPropertiesCredentialsProvider implements AWSCredentialsProvid
         String secretKey =
             StringUtils.trim(System.getProperty(SECRET_KEY_SYSTEM_PROPERTY));
 
+        String sessionToken =
+            StringUtils.trim(System.getProperty(SESSION_TOKEN_SYSTEM_PROPERTY));
+
         if (StringUtils.isNullOrEmpty(accessKey)
                 || StringUtils.isNullOrEmpty(secretKey)) {
 
@@ -44,7 +48,11 @@ public class SystemPropertiesCredentialsProvider implements AWSCredentialsProvid
                     + SECRET_KEY_SYSTEM_PROPERTY + ")");
         }
 
-        return new BasicAWSCredentials(accessKey, secretKey);
+        if (StringUtils.isNullOrEmpty(sessionToken)) {
+            return new BasicAWSCredentials(accessKey, secretKey);
+        } else {
+            return new BasicAWSSessionCredentials(accessKey, secretKey, sessionToken);
+        }
     }
 
     @Override


### PR DESCRIPTION
This is a small change to add support to the `SystemPropertiesCredentialsProvider` for reading STS session tokens from the JVM properties. Currently other providers such as `EnvironmentVariableCredentialsProvider` support STS tokens, but there's no way to change the environment at runtime.

I want to be able to run a boot-up process to assume an IAM role with STS and 'install' the keys into the system properties so that any library using the AWS SDK works seamlessly and I don't need to thread a custom credentials provider implementation throughout the system.