### PR TITLE
Bug fixed when sending null in AttributeUpdate

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/internal/InternalUtils.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/internal/InternalUtils.java
@@ -110,6 +110,8 @@ public enum InternalUtils {
             } else if (attribute.getAttributeValues() != null) {
                 attributeToUpdate.withValue(toAttributeValue(attribute
                         .getAttributeValues()));
+            } else {
+                attributeToUpdate.withValue(toAttributeValue(null));
             }
             result.put(attribute.getAttributeName(), attributeToUpdate);
         }


### PR DESCRIPTION
When trying to send null in AttributeUpdate.put the call to updateItem is failing. Here is the piece of code which will fail without this fix.

``` 
final DynamoDB dynamoDB = new DynamoDB(amazonDynamoDBClient);
final Table table = dynamoDB.getTable(TABLE_NAME);
final AttributeUpdate attributeUpdate = new AttributeUpdate("test").put(null);
table.updateItem(PARTITION_KEY_NAME, PARTITION_KEY_VALUE, SORT_KEY_NAME, SORT_KEY_VALUE, attributeUpdate);  
```