### PR TITLE
ExecutorService doesn't shutdown in all doXxx functions of TransferManager

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -675,6 +675,7 @@ public class TransferManager {
         UploadMonitor watcher = UploadMonitor.create(this, upload, executorService,
                                                      uploadCallable, putObjectRequest, listenerChain);
         upload.setMonitor(watcher);
+        executorService.shutdown();
 
         return upload;
     }
@@ -1136,6 +1137,7 @@ public class TransferManager {
                 executorService, lastFullyDownloadedPart, isDownloadParallel, resumeOnRetry));
         download.setMonitor(new DownloadMonitor(download, future));
         latch.countDown();
+        executorService.shutdown();
         return download;
     }
 


### PR DESCRIPTION
I don't know whether it's a problem or feature that `ExecutorService` in `TransferManager` doesn't `shutdown()` after it `submit()`s.

doXxx functions in `TransferManager` class may hang processes, when ExecutorService doesn't shutdown.

For `doUpload` and `doDownload`, process is hung using original code; while adding `executorService.showdown();` it works.

NOTE: If it is a bug, I've only fixed `doUpload` and `doDownload`.

My test code is below,
```
import java.io.File
import scala.util.Try
import com.amazonaws.services.s3.transfer.{Download, TransferManager}

object Fs {

  def upload(localFileName: String, bucketName: String, remoteFileName: String): Boolean = {
    val transferManager = new TransferManager
    val task = transferManager.upload(bucketName, remoteFileName, new File(localFileName))
    Try(task.waitForCompletion()).isSuccess
  }

  def download(localFileName: String, bucketName: String, remoteFileName: String): Boolean = {
    val transferManager = new TransferManager
    val task: Download = transferManager.download(bucketName, remoteFileName, new File(localFileName))
    Try(task.waitForCompletion()).isSuccess
  }

  // scala -cp target/scala-2.11/xxx-assembly.jar Fs /tmp/a.zip s3-bucket-name a.zip upload
  // scala -cp target/scala-2.11/xxx-assembly.jar Fs /tmp/a.zip s3-bucket-name a.zip download
  def main(args: Array[String]): Unit = {
    if (args.length < 4) sys.exit(0)
    val Array(localFileName, bucketName, remoteFileName, uploadOrDownload) = args.take(4)
    uploadOrDownload match {
      case "upload" => Fs.upload(localFileName, bucketName, remoteFileName)
      case "download" => Fs.download(localFileName, bucketName, remoteFileName)
      case _ => // do nothing
    }
  }
}
```
