### PR TITLE
performance bottleneck fix for issue #1215

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/TransferManager.java
@@ -1258,12 +1258,7 @@ public class TransferManager {
         for ( S3ObjectSummary summary : objectSummaries ) {
             // TODO: non-standard delimiters
             File f = new File(destinationDirectory, summary.getKey());
-            File parentFile = f.getParentFile();
-
-            if ( !parentFile.exists() && !parentFile.mkdirs() ) {
-                throw new RuntimeException("Couldn't create parent directories for " + f.getAbsolutePath());
-            }
-
+           
             // All the single-file downloads share the same
             // MultipleFileTransferProgressUpdatingListener and
             // MultipleFileTransferStateChangeListener


### PR DESCRIPTION
A depth first directory traversal leads to unnecessary network calls to S3 API and drastically reduces performance. In case of recursive download with prefix, simple listing and filtering of object keys should be sufficient.

Details:  https://github.com/aws/aws-sdk-java/issues/1215