### PR TITLE
Invalid javascript header, not complaint with the embedded IANA reference

### DIFF
--- a/aws-java-sdk-s3/src/main/resources/mime.types
+++ b/aws-java-sdk-s3/src/main/resources/mime.types
@@ -38,6 +38,7 @@ application/index.vnd
 application/iotp
 application/ipp
 application/isup
+application/javascript	js
 application/mac-binhex40	hqx
 application/mac-compactpro	cpt
 application/macwriteii
@@ -353,7 +354,6 @@ application/x-futuresplash	spl
 application/x-gtar		gtar
 application/x-gzip		gz
 application/x-hdf		hdf
-application/x-javascript	js
 application/x-java-jnlp-file	jnlp
 application/x-koan		skp skd skt skm
 application/x-latex		latex


### PR DESCRIPTION
As described in http://www.ietf.org/rfc/rfc4329.txt application/x-javascript was temporary but not final and therefore this should be changed, while (new) embedded (tv) browsers do support IANA standards, but could perhaps not-know/skip application/x-javascript support which will mean that Javascript will not be executed.

I do understand that many plugins depend on this reference (like the Jenkins S3 plugin), but this is invalid. Any input about use-cases that could be impacted?

Same issue with `v2` version: https://github.com/aws/aws-sdk-java-v2/pull/69 and https://wiki.jenkins.io/display/JENKINS/S3+Plugin is using this file for example.