### PR TITLE
add support for S3ContextAwareCredentialsProvider (Requesting Feedback/Comments)

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -2885,7 +2885,11 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
             // delegate directly to it.
             ((Presigner) signer).presignRequest(
                     request,
-                    CredentialUtils.getCredentialsProvider(request.getOriginalRequest(), awsCredentialsProvider).getCredentials(),
+                            CredentialUtils.getCredentialsProvider(request.getOriginalRequest(),
+                                    awsCredentialsProvider instanceof S3ContextAwareCredentialsProvider ?
+                                            ((S3ContextAwareCredentialsProvider) awsCredentialsProvider).getCredentialsProvider(bucketName, key) :
+                                            awsCredentialsProvider
+                            ).getCredentials(),
                     req.getExpiration()
             );
         } else {
@@ -3603,7 +3607,11 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         resourcePath = resourcePath.replaceAll("(?<=/)/", "%2F");
 
         new S3QueryStringSigner(methodName.toString(), resourcePath, expiration)
-            .sign(request, CredentialUtils.getCredentialsProvider(request.getOriginalRequest(), awsCredentialsProvider).getCredentials());
+            .sign(request, CredentialUtils.getCredentialsProvider(request.getOriginalRequest(),
+                    awsCredentialsProvider instanceof S3ContextAwareCredentialsProvider ?
+                            ((S3ContextAwareCredentialsProvider) awsCredentialsProvider).getCredentialsProvider(bucketName, key) :
+                            awsCredentialsProvider
+            ).getCredentials());
 
         // The Amazon S3 DevPay token header is a special exception and can be safely moved
         // from the request's headers into the query string to ensure that it travels along
@@ -4221,7 +4229,10 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
                         new S3V4AuthErrorRetryStrategy(buildDefaultEndpointResolver(getProtocol(request), bucket, key)));
             }
 
-            executionContext.setCredentialsProvider(CredentialUtils.getCredentialsProvider(request.getOriginalRequest(), awsCredentialsProvider));
+            executionContext.setCredentialsProvider(CredentialUtils.getCredentialsProvider(request.getOriginalRequest(),
+                    awsCredentialsProvider instanceof S3ContextAwareCredentialsProvider ?
+                            ((S3ContextAwareCredentialsProvider) awsCredentialsProvider).getCredentialsProvider(bucket, key) :
+                            awsCredentialsProvider));
 
             validateRequestBeforeTransmit(request);
             response = client.execute(request, responseHandler, errorResponseHandler, executionContext);

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/S3ContextAwareCredentialsProvider.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/S3ContextAwareCredentialsProvider.java
@@ -1,0 +1,15 @@
+package com.amazonaws.services.s3;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+
+/**
+ * Type of {@link AWSCredentialsProvider} which can be provided the bucket name and key in order to vary
+ * which credential provider is used for a given S3 operation. When an {@link AmazonS3Client} is constructed with
+ * a provider of this type, the {@link AmazonS3Client} will provide the bucketName and key as context to the
+ * {@link #getCredentialsProvider(String, String)} method for each operation.
+ */
+public interface S3ContextAwareCredentialsProvider extends AWSCredentialsProvider {
+
+    public AWSCredentialsProvider getCredentialsProvider(final String bucketName, final String key);
+
+}


### PR DESCRIPTION
Hello there,

We are *constantly* dealing with multi-account permissions related issues with S3 in our development environment.  We have hundreds of developers working over dozens of accounts who are very good at using the wrong credential to try to read/write to a particular bucket with the wrong credential or the wrong object ownership settings.  It's a seemingly never-ending pain point for us.

We would *very* much like a solution for which we can provide a "smarter" credential source which automatically sources the most relevant credential for interacting with a particular bucket/key and thus by default also provides the most correct ownership of a particular object.  The following PR is I think the minimum viable change which allows this functionality, but I'm open to some other approach.   Basically it would allow us to provide our own logic for sourcing the credentials; we just need the hooks to send back the bucket/key name so we can make the appropriate decisions in our own logic.

I considered just having a wrapper over all of the AmazonS3Client methods and adapting them into the equivalent method that takes a AmazonWebServiceRequest (in which we could also automatically set the provider), but this seems like a lot of boilerplate code (that would also be subject to breakage every time a new method is created) for a change that can logically be made in just a few places.

I reiterate that this is a huge pain point for us and something I'd really like to get addressed without having to fork the SDK and then constantly have to backport updates.

I also noticed that there do not seem to be any S3-related tests or am I just not looking in the right place? I'd be happy to add the relevant tests as well but I'm not really sure what the paradigm is for testing the s3 package.

Thanks for reading,
Jay Zarfoss (Platform Security @ Netflix)