### PR TITLE
Fix spelling error in CloudFront AmazonClientException message.

### DIFF
--- a/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/CloudFrontUrlSigner.java
+++ b/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/CloudFrontUrlSigner.java
@@ -190,7 +190,7 @@ public enum CloudFrontUrlSigner {
                     ;
             return signedUrl;
         } catch (InvalidKeyException e) {
-            throw new AmazonClientException("Coudln't sign url", e);
+            throw new AmazonClientException("Couldn't sign url", e);
         }
     }
 


### PR DESCRIPTION
Found a typo, gave it a fix.