### PR TITLE
Updating S3AbortableInputStream#close abort delegation

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3AbortableInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3AbortableInputStream.java
@@ -179,10 +179,7 @@ public final class S3AbortableInputStream extends SdkFilterInputStream {
                     "Not all bytes were read from the S3ObjectInputStream, aborting HTTP connection. This is likely an error and " +
                     "may result in sub-optimal behavior. Request only the bytes you need via a ranged GET or drain the input " +
                     "stream after use.");
-            if (httpRequest != null) {
-                httpRequest.abort();
-            }
-            IOUtils.closeQuietly(in, null);
+            abort();
         }
     }
 


### PR DESCRIPTION
Updating S3AbortableInputStream#close to delegate to S3ObjectInputStream#abort if there is any data remaining in the stream.
    
This is now consistent with the current documentation, and also ensurers that super.abort() is being triggered (which was being done by S3AbortableInputStream#abort and not S3AbortableInputStream#close). Therefore the abort behaviour via abort and close are now consistent.
