### PR TITLE
Added log message to AmazonHttpClient.getNonNullResponseHandler

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java
@@ -529,6 +529,8 @@ public class AmazonHttpClient {
 
                 @Override
                 public T handle(HttpResponse response) throws Exception {
+                    String warning = "There's no custom error handler set. Specify it in client's requestExecutionBuilder.";
+                    log.warn(warning);
                     return null;
                 }
 


### PR DESCRIPTION
When instance of `AmazonHttpClient` is created there should be set `errorResponseHandler` of `requestExecutionBuilder`. Otherwise `nonNullResposeHandler` will be used, which, in fact, does nothing but returns null instead of exception object. Then it goes to `handleErrorResponse` method and tries to do the following ` exception.fillInStackTrace();`, which means  `NullPointerException`. As a result we have `NullPointerException` instead of any information about request's response. My suggestion is to at least log warning with pointing out the root cause of this problem: there's no custom error handler set.