### PR TITLE
Use upper camel case conversion for JSON element names (lambda)

### DIFF
--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactory.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactory.java
@@ -27,6 +27,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -72,7 +73,8 @@ public final class LambdaInvokerFactory {
 
     private static final ObjectMapper MAPPER = new ObjectMapper()
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY);
+            .enable(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+            .setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE);
 
     /**
      * Creates a new Lambda invoker implementing the given interface and wrapping the given {@code AWSLambda} client.


### PR DESCRIPTION
This PR is to make the JSON serialization/deserialization behaviour compatible with AWS Lambda service.

For instance, when an input data based on the following POJO is passed to a Lambda function through aws-java-sdk-lambda SDK library, the Lambda function receives an empty data instead.

```
        private String eventSource;

        /**
         * Gets the event source
         * @return event source
         */
        public String getEventSource() {
            return eventSource;
        }

        /**
         * Sets the event source
         * @param eventSource A string containing the event source
         */
        public void setEventSource(String eventSource) {
            this.eventSource = eventSource;
        }
```
(this is a snippet from https://github.com/aws/aws-lambda-java-libs/blob/master/aws-lambda-java-events/src/main/java/com/amazonaws/services/lambda/runtime/events/SNSEvent.java)

The raw string after the serialization (by ObjectMapper in LambdaInvokerFactory) is below.

`{"eventSource":"foobar"}`

This results in an empty input to the Lambda function even if the same POJO is used. Not 'eventSource' but 'EventSource' seems to be expected for the JSON deserialization logic in AWS Lambda service. So if upper camel case conversion rule is applied to the ObjectMapper in LambdaInvokerFactory, the raw string becomes `{"EventSource":"foobar"}` and then works perfectly.

Fix #1344