### PR TITLE
Jackson dependencies updated to last version: 2.9.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,8 +149,8 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.1</jackson.databind.version>
+      <jackson.version>2.9.2</jackson.version>
+      <jackson.databind.version>2.9.2</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
I updated the version of jackson jars to the last available currently. This is because I'm using Snyk to detect vulnerabilities in my projects. This SDK uses jackson-* version 2.6.7, which are vulnerable to:

- [CWE-502: Deserialization of Untrusted Data](https://cwe.mitre.org/data/definitions/502.html)
- [FasterXML/jackson-core issue 315](https://github.com/FasterXML/jackson-core/issues/315)
- [FasterXML/jackson-core PR 322](https://github.com/FasterXML/jackson-core/pull/322)

I changed pom.xml and run mvn test. All tests passed.