### PR TITLE
Make partSize field of UploadPartRequest required and non-primitive

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -3146,13 +3146,15 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         final String key        = uploadPartRequest.getKey();
         final String uploadId   = uploadPartRequest.getUploadId();
         final int partNumber    = uploadPartRequest.getPartNumber();
-        final long partSize     = uploadPartRequest.getPartSize();
+        final Long partSize     = uploadPartRequest.getPartSize();
         rejectNull(bucketName,
             "The bucket name parameter must be specified when uploading a part");
         rejectNull(key,
             "The key parameter must be specified when uploading a part");
         rejectNull(uploadId,
             "The upload ID parameter must be specified when uploading a part");
+        rejectNull(partSize,
+                "The part size parameter must be specified when uploading a part");
         Request<UploadPartRequest> request = createRequest(bucketName, key, uploadPartRequest, HttpMethodName.PUT);
         request.addParameter("uploadId", uploadId);
         request.addParameter("partNumber", Integer.toString(partNumber));

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/UploadPartRequest.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/UploadPartRequest.java
@@ -33,7 +33,7 @@ import com.amazonaws.event.ProgressListener;
  * -signature-version
  * </p>
  * <p>
- * Required Parameters: BucketName, Key, UploadId, PartNumber
+ * Required Parameters: BucketName, Key, UploadId, PartNumber, PartSize
  */
 public class UploadPartRequest extends AmazonWebServiceRequest implements
         SSECustomerKeyProvider, S3DataSource, Serializable {
@@ -67,7 +67,7 @@ public class UploadPartRequest extends AmazonWebServiceRequest implements
     private int partNumber;
 
     /** The size of this part, in bytes. */
-    private long partSize;
+    private Long partSize;
 
     /**
      * The optional, but recommended, MD5 hash of the content of this part. If
@@ -313,7 +313,7 @@ public class UploadPartRequest extends AmazonWebServiceRequest implements
      *
      * @return the size of this part, in bytes.
      */
-    public long getPartSize() {
+    public Long getPartSize() {
         return partSize;
     }
 
@@ -323,7 +323,7 @@ public class UploadPartRequest extends AmazonWebServiceRequest implements
      * @param partSize
      *            the size of this part, in bytes.
      */
-    public void setPartSize(long partSize) {
+    public void setPartSize(Long partSize) {
         this.partSize = partSize;
     }
 
@@ -337,7 +337,7 @@ public class UploadPartRequest extends AmazonWebServiceRequest implements
      *
      * @return This updated UploadPartRequest object.
      */
-    public UploadPartRequest withPartSize(long partSize) {
+    public UploadPartRequest withPartSize(Long partSize) {
         this.partSize = partSize;
         return this;
     }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadCallable.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadCallable.java
@@ -254,7 +254,7 @@ public class UploadCallable implements Callable<UploadResult> {
                 if (uploadPartRequest.getPartSize() >= Integer.MAX_VALUE) {
                     inputStream.mark(Integer.MAX_VALUE);
                 } else {
-                    inputStream.mark((int)uploadPartRequest.getPartSize());
+                    inputStream.mark(uploadPartRequest.getPartSize().intValue());
                 }
             }
             partETags.add(s3.uploadPart(uploadPartRequest).getPartETag());


### PR DESCRIPTION
Fixes #1360

When passing `withInputStream` into `UploadPartRequest` it's easy to forgot adding `withPartSize` value. Since it's primitive, java makes it 0 and complete upload will fail at the completion stage. 

This PR makes it `Long` object and adds `rejectNull` validation