### PR TITLE
Use 8k buffers when downloading into file

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
@@ -68,6 +68,9 @@ public class ServiceUtils {
     public static final boolean OVERWRITE_MODE = false;
 
     private static final SkipMd5CheckStrategy skipMd5CheckStrategy = SkipMd5CheckStrategy.INSTANCE;
+    
+    // Preferred buffer size of JVM's native FileOutputStream.write() implementation.
+    private static final int DEFAULT_BUFFER_SIZE = 8192;
 
     @Deprecated
     protected static final DateUtils dateUtils = new DateUtils();
@@ -302,7 +305,7 @@ public class ServiceUtils {
             }
             outputStream = new BufferedOutputStream(new FileOutputStream(
                     dstfile, appendData));
-            byte[] buffer = new byte[8192];
+            byte[] buffer = new byte[DEFAULT_BUFFER_SIZE];
             int bytesRead;
             while ((bytesRead = s3Object.getObjectContent().read(buffer)) > -1) {
                 outputStream.write(buffer, 0, bytesRead);

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/ServiceUtils.java
@@ -302,7 +302,7 @@ public class ServiceUtils {
             }
             outputStream = new BufferedOutputStream(new FileOutputStream(
                     dstfile, appendData));
-            byte[] buffer = new byte[1024*10];
+            byte[] buffer = new byte[8192];
             int bytesRead;
             while ((bytesRead = s3Object.getObjectContent().read(buffer)) > -1) {
                 outputStream.write(buffer, 0, bytesRead);


### PR DESCRIPTION
Writes <= 8k use a stack-allocated buffer whereas larger writes will malloc() / free() a fresh buffer for each write. Since there doesn't appear to be any particular reason to use a 10k buffer, it makes sense to align with the "preferred" buffer size of the JVM of 8k. See http://hg.openjdk.java.net/jdk8u/jdk8u/jdk/file/601a2304ff4a/src/share/native/java/io/io_util.c#l58