### PR TITLE
bump the version of jackson

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -150,8 +150,8 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.1</jackson.databind.version>
+      <jackson.version>2.9.2</jackson.version>
+      <jackson.databind.version>2.9.2</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
[Snyk](https://snyk.io) reports a vulnerability in:
- `com.fasterxml.jackson.core:jackson-databind@2.6.7.1`. See [here](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519) and [here](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31520)
- `com.fasterxml.jackson.core:jackson-core@2.6.7`. See [here](https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507)

```console
$ snyk test --file=aws-java-sdk-core/pom.xml

✗ High severity vulnerability found on com.fasterxml.jackson.core:jackson-databind@2.6.7.1
- desc: Deserialization of Untrusted Data
- info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31507
- from: com.amazonaws:aws-java-sdk-core@1.11.227-SNAPSHOT > com.fasterxml.jackson.core:jackson-databind@2.6.7.1


✗ Medium severity vulnerability found on com.fasterxml.jackson.core:jackson-core@2.6.7
- desc: Denial of Service (DoS)
- info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31519
- from: com.amazonaws:aws-java-sdk-core@1.11.227-SNAPSHOT > com.fasterxml.jackson.core:jackson-databind@2.6.7.1 > com.fasterxml.jackson.core:jackson-core@2.6.7


✗ Medium severity vulnerability found on com.fasterxml.jackson.core:jackson-core@2.6.7
- desc: Denial of Service (DoS)
- info: https://snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-31520
- from: com.amazonaws:aws-java-sdk-core@1.11.227-SNAPSHOT > com.fasterxml.jackson.core:jackson-databind@2.6.7.1 > com.fasterxml.jackson.core:jackson-core@2.6.7


Tested 10 dependencies for known vulnerabilities, found 3 vulnerabilities, 3 vulnerable paths.
```

Updating to a later version of [jackson-core](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core) and [jackson-databind](https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-databind) appears to fix the vulnerabilities:

```console
$ snyk test --file=aws-java-sdk-core/pom.xml

✓ Tested 10 dependencies for known vulnerabilities, no vulnerable paths found.
```

This does break CI on Java6 because [since 2.7 jackson's minimum is java 7](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.7#changes-compatibility). Advice welcomed!