### PR TITLE
POM: Fix SCM meta-data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,9 @@
     <module>aws-java-sdk-bundle</module>
 </modules>
   <scm>
-    <url>https://github.com/aws/aws-sdk-java.git</url>
+    <connection>scm:git:https://github.com/aws/aws-sdk-java.git</connection>
+    <developerConnection>scm:git:git@github.com:aws/aws-sdk-java.git</developerConnection>
+    <url>https://github.com/aws/aws-sdk-java</url>
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>


### PR DESCRIPTION
The URL should be browsable and not end in ".git". Add missing (anonymous)
connection and (authenticated) developerConnection tags.