### PR TITLE
Add AmazonApiGateway to Principal.Services

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/policy/Principal.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/policy/Principal.java
@@ -150,6 +150,7 @@ public class Principal {
      */
     static public enum Services {
 
+        AmazonApiGateway("apigateway.amazonaws.com"),
         AWSDataPipeline("datapipeline.amazonaws.com"),
         AmazonElasticTranscoder("elastictranscoder.amazonaws.com"),
         AmazonEC2("ec2.amazonaws.com"),


### PR DESCRIPTION
I need to be able to create an IAM Policy with Api gateway as a Principal Service as specified in the [docs](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html). Right now it is impossible with the Java SDK as it is missing from `Principal.Services`. Fixes #1440


  