### PR TITLE
Adds toItem function to InternalUtils

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/internal/InternalUtils.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/document/internal/InternalUtils.java
@@ -49,6 +49,16 @@ public enum InternalUtils {
     ;
 
     /**
+     * Returns an <code>Item</code> given the low level item information;
+     * or null if the input is null;
+     */
+    public static Item toItem(Map<String, AttributeValue> item) {
+        if (item == null)
+            return null;
+        return Item.fromMap(toSimpleMapValue(item));
+    }
+
+    /**
      * Returns a non-null list of <code>Item</code>'s given the low level
      * list of item information.
      */


### PR DESCRIPTION
Adds the `toItem` function to convert a map of item information to an `Item`. There was already a `toItemList` function in there, but not one for a single item.