### PR TITLE
Bump Jackson to 2.9.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,8 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.1</jackson.databind.version>
+      <jackson.version>2.9.4</jackson.version>
+      <jackson.databind.version>2.9.4</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
Jackson needs to be upgraded because a current version which is used in aws-sdk-java has serious vulnerabilities.

- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-15095 - fixed in 2.8.10, 2.9.1
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-17485 - fixed in 2.8.10, 2.9.3
- https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2017-7525 - fixed in 2.6.7.1, 2.7.9.1 and 2.8.9

See also: https://github.com/akka/alpakka/issues/793