### PR TITLE
Update jackson to use the latest stable version (2.9.4) and branch (2.9)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -175,8 +175,8 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.1</jackson.databind.version>
+      <jackson.version>2.9.4</jackson.version>
+      <jackson.databind.version>2.9.4</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
The 2.6 version of jackson is receiving limited continued maintenance.  Security fixes
are not actively being backported.  As this is the case, use the latest stable branch
(2.9) and grab the latest stable release.