### PR TITLE
Make AWSCredentialsProviderChain exceptions easier to troubleshoot

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AWSCredentialsProviderChain.java
@@ -111,7 +111,7 @@ public class AWSCredentialsProviderChain implements AWSCredentialsProvider {
             return lastUsedProvider.getCredentials();
         }
 
-        List<String> exceptionMessages = new LinkedList<String>();
+        List<String> exceptionMessages = null;
         for (AWSCredentialsProvider provider : credentialsProviders) {
             try {
                 AWSCredentials credentials = provider.getCredentials();
@@ -127,6 +127,9 @@ public class AWSCredentialsProviderChain implements AWSCredentialsProvider {
                 // Ignore any exceptions and move onto the next provider
                 String message = provider + ": " + e.getMessage();
                 log.debug("Unable to load credentials from " + message);
+                if (exceptionMessages == null) {
+                    exceptionMessages = new LinkedList<String>();
+                }
                 exceptionMessages.add(message);
             }
         }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWSCredentialsProviderChainTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWSCredentialsProviderChainTest.java
@@ -22,11 +22,17 @@ import static org.junit.Assert.assertEquals;
 
 import java.util.Arrays;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
+import com.amazonaws.SdkClientException;
 import com.amazonaws.internal.StaticCredentialsProvider;
 
 public class AWSCredentialsProviderChainTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
 
     /**
      * Tests that, by default, the chain remembers which provider was able to
@@ -81,20 +87,43 @@ public class AWSCredentialsProviderChainTest {
         assertEquals(2, provider2.getCredentialsCallCount);
     }
 
+    /**
+     * Tests that getCredentials throws an thrown if all providers in the
+     * chain fail to provide credentials.
+     */
+    @Test
+    public void testGetCredentialsException() {
+        MockCredentialsProvider provider1 = new MockCredentialsProvider("Failed!");
+        MockCredentialsProvider provider2 = new MockCredentialsProvider("Bad!");
+        AWSCredentialsProviderChain chain = new AWSCredentialsProviderChain(provider1, provider2);
+
+        thrown.expect(SdkClientException.class);
+        thrown.expectMessage(provider1.exceptionMessage);
+        thrown.expectMessage(provider2.exceptionMessage);
+
+        chain.getCredentials();
+    }
 
     private static final class MockCredentialsProvider extends StaticCredentialsProvider {
         public int getCredentialsCallCount = 0;
         public boolean throwException = false;
+        public String exceptionMessage = "No credentials";
 
         public MockCredentialsProvider() {
             super(new BasicAWSCredentials("accessKey", "secretKey"));
+        }
+
+        public MockCredentialsProvider(String exceptionMessage) {
+            this();
+            this.exceptionMessage = exceptionMessage;
+            this.throwException = true;
         }
 
         @Override
         public AWSCredentials getCredentials() {
             getCredentialsCallCount++;
 
-            if (throwException) throw new RuntimeException("No credentials");
+            if (throwException) throw new RuntimeException(exceptionMessage);
             else return super.getCredentials();
         }
     }


### PR DESCRIPTION
When all providers in an AWSCredentialsProviderChain fail to provide credentials, the exception gives no hint of the underlying exceptions. This makes troubleshooting difficult (unless your log level is already set to DEBUG, which is rarely the case in production).

To improve the situation, this PR includes the root causes in the exception message.
