### PR TITLE
Bump Jackson to 2.9.5 to address security vulnerability CVE-2018-7489

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -176,8 +176,8 @@
   </scm>
   <properties>
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
-      <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.1</jackson.databind.version>
+      <jackson.version>2.9.5</jackson.version>
+      <jackson.databind.version>2.9.5</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
Jackson <=2.9.4 is affected by CVE-2018-7489, which allows
unauthenticated remote code execution.

http://cve.circl.lu/cve/CVE-2018-7489