### PR TITLE
Fixed Route53 HostedZone Id on ListHostedZonesByName response

### DIFF
--- a/aws-java-sdk-route53/src/main/java/com/amazonaws/services/route53/internal/Route53IdRequestHandler.java
+++ b/aws-java-sdk-route53/src/main/java/com/amazonaws/services/route53/internal/Route53IdRequestHandler.java
@@ -28,6 +28,7 @@ import com.amazonaws.services.route53.model.GetHostedZoneResult;
 import com.amazonaws.services.route53.model.GetReusableDelegationSetResult;
 import com.amazonaws.services.route53.model.HostedZone;
 import com.amazonaws.services.route53.model.ListHostedZonesResult;
+import com.amazonaws.services.route53.model.ListHostedZonesByNameResult;
 import com.amazonaws.services.route53.model.ListResourceRecordSetsResult;
 import com.amazonaws.services.route53.model.ListReusableDelegationSetsResult;
 import com.amazonaws.services.route53.model.ResourceRecordSet;
@@ -66,6 +67,9 @@ public class Route53IdRequestHandler extends AbstractRequestHandler {
             removePrefix(result.getHostedZone());
         } else if (obj instanceof ListHostedZonesResult) {
             ListHostedZonesResult result = (ListHostedZonesResult)obj;
+            for (HostedZone zone : result.getHostedZones()) removePrefix(zone);
+        } else if (obj instanceof ListHostedZonesByNameResult) {
+            ListHostedZonesByNameResult result = (ListHostedZonesByNameResult)obj;
             for (HostedZone zone : result.getHostedZones()) removePrefix(zone);
         } else if (obj instanceof ListResourceRecordSetsResult) {
             ListResourceRecordSetsResult result = (ListResourceRecordSetsResult)obj;


### PR DESCRIPTION
For the Route53 `ListHostedZonesByName` response, the prefix from HostedZone's Id field wasn't being stripped as it should be. This caused HostedZone objects returned to not work with other requests.

before:
```java
System.out.println(route53.listHostedZones().getHostedZones().get(0).getId());
// output: ABCDEF12345678
System.out.println(route53.listHostedZonesByName().getHostedZones().get(0).getId());
// output: /hostedzone/ABCDEF12345678
```

after:
```java
System.out.println(route53.listHostedZones().getHostedZones().get(0).getId());
// output: ABCDEF12345678
System.out.println(route53.listHostedZonesByName().getHostedZones().get(0).getId());
// output: ABCDEF12345678
```