### PR TITLE
aws-java-sdk-core: EC2MetadataClient.java - Adds sending of a User-Ag…

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
@@ -31,6 +31,7 @@ import com.amazonaws.retry.internal.CredentialsEndpointRetryParameters;
 import com.amazonaws.retry.internal.CredentialsEndpointRetryPolicy;
 import com.amazonaws.util.IOUtils;
 import com.amazonaws.util.json.Jackson;
+import com.amazonaws.util.VersionInfoUtils;
 import com.fasterxml.jackson.databind.JsonNode;
 
 @SdkInternalApi
@@ -41,6 +42,8 @@ public final class EC2CredentialsUtils {
     private static EC2CredentialsUtils instance;
 
     private final ConnectionUtils connectionUtils;
+
+    private static final String USER_AGENT = String.format("aws-sdk-java/%s", VersionInfoUtils.getVersion());
 
     private EC2CredentialsUtils() {
         this(ConnectionUtils.getInstance());
@@ -76,6 +79,11 @@ public final class EC2CredentialsUtils {
      *             If the requested service is not found.
      */
     public String readResource(URI endpoint) throws IOException {
+        Map<String, String> headers = new HashMap<String, String>();
+        headers.put("User-Agent", USER_AGENT);
+        headers.put("Accept", "*/*");
+        headers.put("Connection", "keep-alive");
+
         return readResource(endpoint, CredentialsEndpointRetryPolicy.NO_RETRY, new HashMap<String, String>());
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
@@ -84,7 +84,7 @@ public final class EC2CredentialsUtils {
         headers.put("Accept", "*/*");
         headers.put("Connection", "keep-alive");
 
-        return readResource(endpoint, CredentialsEndpointRetryPolicy.NO_RETRY, new HashMap<String, String>());
+        return readResource(endpoint, CredentialsEndpointRetryPolicy.NO_RETRY, headers);
     }
 
     /**

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2MetadataClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2MetadataClient.java
@@ -26,6 +26,7 @@ import org.apache.commons.logging.LogFactory;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.util.EC2MetadataUtils;
+import com.amazonaws.util.VersionInfoUtils;
 
 /**
  * Simple client for accessing the Amazon EC2 Instance Metadata Service.
@@ -42,6 +43,9 @@ public class EC2MetadataClient {
     public static final String SECURITY_CREDENTIALS_RESOURCE = "/latest/meta-data/iam/security-credentials/";
 
     private static final Log log = LogFactory.getLog(EC2MetadataClient.class);
+
+    /** User-Agent for requests to the metadata service **/
+    private static final String USER_AGENT = String.format("aws-sdk-java/%s", VersionInfoUtils.getVersion());
 
     /**
      * Connects to the Amazon EC2 Instance Metadata Service to retrieve the
@@ -91,6 +95,7 @@ public class EC2MetadataClient {
         connection.setReadTimeout(1000 * 5);
         connection.setRequestMethod("GET");
         connection.setDoOutput(true);
+        connection.addRequestProperty("User-Agent", USER_AGENT);
         connection.connect();
 
         return readResponse(connection);


### PR DESCRIPTION
Adds the sending of a User-Agent other than default User-Agent in Java when making requests to metadata service

Similar to AWS Golang SDK and now AWS Ruby SDK, send a User-Agent when making requests to metadata for credentials.
Golang uses a structure like aws-sdk-go/1.8.19 and now Ruby uses aws-sdk-ruby3/ as of PR #1762.  PR #1445 adds this for python as well.

This will enable protection of AWS credentials from Server Side Request Foregery (SSRF) vectors by use of a metadata proxy and rejecting User-Agents that do not meet a regex.