### PR TITLE
feat: make object mapper for lambda configureable

### DIFF
--- a/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactoryConfig.java
+++ b/aws-java-sdk-lambda/src/main/java/com/amazonaws/services/lambda/invoke/LambdaInvokerFactoryConfig.java
@@ -17,6 +17,7 @@ package com.amazonaws.services.lambda.invoke;
 
 import com.amazonaws.annotation.SdkProtectedApi;
 import com.amazonaws.util.ValidationUtils;
+import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * Configuration for {@link LambdaInvokerFactory} to override default behavior.
@@ -29,22 +30,25 @@ public class LambdaInvokerFactoryConfig {
     private LambdaFunctionNameResolver lambdaFunctionNameResolver;
     private final String functionAlias;
     private final String functionVersion;
+    private final ObjectMapper objectMapper;
 
     /**
      * @deprecated Use {@link LambdaInvokerFactory#builder()} to configure invoker factory.
      */
     @Deprecated
     public LambdaInvokerFactoryConfig() {
-        this(new DefaultLambdaFunctionNameResolver(), null, null);
+        this(new DefaultLambdaFunctionNameResolver(), LambdaInvokerFactory.DEFAULT_MAPPER, null, null);
     }
 
     @SdkProtectedApi
     LambdaInvokerFactoryConfig(LambdaFunctionNameResolver lambdaFunctionNameResolver,
+                               ObjectMapper objectMapper,
                                String functionAlias,
                                String functionVersion) {
         this.lambdaFunctionNameResolver = lambdaFunctionNameResolver;
         this.functionAlias = functionAlias;
         this.functionVersion = functionVersion;
+        this.objectMapper = objectMapper;
     }
 
     public LambdaFunctionNameResolver getLambdaFunctionNameResolver() {
@@ -57,6 +61,10 @@ public class LambdaInvokerFactoryConfig {
 
     public String getFunctionVersion() {
         return functionVersion;
+    }
+
+    public ObjectMapper getObjectMapper() {
+        return objectMapper;
     }
 
     /**


### PR DESCRIPTION
1. Making the `ObjectMapper` configureable 
2. Returning result of `.hashCode` to avoid `LambdaSerializationException` as it prevents us from defining a lambda function interface as bean in a spring boot application. See also: https://stackoverflow.com/a/49071474/3703307

I found no unit tests therefore I'm quite unsure how to test the changes or if its even required?!

I hope we can get this merged soon because its very important for us to use our own `ObjectMapper` and not defining additional annotations  

closes https://github.com/aws/aws-sdk-java/issues/1436
