### PR TITLE
Attempt to parse versionID from any valid URI object

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
@@ -77,6 +77,8 @@ public class AmazonS3URI {
         }
         this.uri = uri;
 
+        this.versionId = parseVersionId(uri.getRawQuery());
+
         // s3://*
         if ("s3".equalsIgnoreCase(uri.getScheme())) {
             this.region = null;
@@ -167,8 +169,6 @@ public class AmazonS3URI {
                 this.key = uri.getPath().substring(1);
             }
         }
-
-        this.versionId = parseVersionId(uri.getRawQuery());
 
         if ("amazonaws".equals(matcher.group(2))) {
             // No region specified

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java
@@ -82,7 +82,6 @@ public class AmazonS3URI {
         // s3://*
         if ("s3".equalsIgnoreCase(uri.getScheme())) {
             this.region = null;
-            this.versionId = null;
             this.isPathStyle = false;
             this.bucket = uri.getAuthority();
 


### PR DESCRIPTION
The URI class supports query string parameters, so versionId could potentially be extracted from any valid URI object.

I would like to create S3 URIs with version ID, formatted like `s3://bucket/object?versionId=version`. It is handy for storing object references without having to use the entire URL.