### PR TITLE
Updated ClientConfiguration factories to use PredefinedClientConfigurations.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfigurationFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfigurationFactory.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws;
 
+import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.annotation.SdkProtectedApi;
 
 /**
@@ -43,7 +44,7 @@ public class ClientConfigurationFactory {
      * @return constructed {@link ClientConfiguration} with standard configuration.
      */
     protected ClientConfiguration getDefaultConfig() {
-        return new ClientConfiguration();
+        return PredefinedClientConfigurations.defaultConfig();
     }
 
     /**

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClientConfigurationFactory.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClientConfigurationFactory.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.dynamodbv2;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
+import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.annotation.SdkInternalApi;
 import com.amazonaws.retry.PredefinedRetryPolicies;
 
@@ -28,7 +29,7 @@ class AmazonDynamoDBClientConfigurationFactory extends ClientConfigurationFactor
 
     @Override
     protected ClientConfiguration getDefaultConfig() {
-        return super.getDefaultConfig().withRetryPolicy(PredefinedRetryPolicies.DYNAMODB_DEFAULT);
+        return PredefinedClientConfigurations.dynamoDefault();
     }
 
     @Override

--- a/aws-java-sdk-simpleworkflow/src/main/java/com/amazonaws/services/simpleworkflow/AmazonSimpleWorkflowClientConfigurationFactory.java
+++ b/aws-java-sdk-simpleworkflow/src/main/java/com/amazonaws/services/simpleworkflow/AmazonSimpleWorkflowClientConfigurationFactory.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.simpleworkflow;
 
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ClientConfigurationFactory;
+import com.amazonaws.PredefinedClientConfigurations;
 import com.amazonaws.annotation.SdkInternalApi;
 
 /*
@@ -27,6 +28,6 @@ public class AmazonSimpleWorkflowClientConfigurationFactory extends ClientConfig
 
     @Override
     protected ClientConfiguration getDefaultConfig() {
-        return super.getDefaultConfig().withMaxConnections(1000).withSocketTimeout(90000);
+        return PredefinedClientConfigurations.swfDefault();
     }
 }


### PR DESCRIPTION
In order to preserve the guarantees stated [here](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/PredefinedClientConfigurations.html).