### PR TITLE
Allow the use of CryptoMode.AuthenticatedEncryption with the FIPS-certified BouncyCastle

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3AbortableInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/S3AbortableInputStream.java
@@ -172,7 +172,7 @@ public final class S3AbortableInputStream extends SdkFilterInputStream {
      */
     @Override
     public void close() throws IOException {
-        if (readAllBytes() || isAborted()) {
+        if (_readAllBytes() || isAborted()) {
             super.close();
         } else {
             LOG.warn(
@@ -218,7 +218,7 @@ public final class S3AbortableInputStream extends SdkFilterInputStream {
         }
     }
 
-    private boolean readAllBytes() {
+    private boolean _readAllBytes() {
         return bytesRead >= contentLength || eofReached;
     }
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/AesGcm.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/AesGcm.java
@@ -40,7 +40,7 @@ class AesGcm extends ContentCryptoScheme {
      * Currently only Bouncy Castle can support the AES/GCM cipher in
      * Java 6 without having to use the AEAD API in Java 7+.
      */
-    @Override String getSpecificCipherProvider() { return "BC"; }
+    @Override String getPreferredCipherProvider() { return "BC"; }
 
     @Override
     CipherLite createAuxillaryCipher(SecretKey cek, byte[] ivOrig,
@@ -49,7 +49,7 @@ class AesGcm extends ContentCryptoScheme {
             NoSuchProviderException, NoSuchPaddingException,
             InvalidAlgorithmParameterException {
         byte[] iv = AES_CTR.adjustIV(ivOrig, startingBytePos);
-        return AES_CTR.createCipherLite(cek, iv, cipherMode, securityProvider);
+        return AES_CTR.createCipherLite(cek, iv, cipherMode, securityProvider, false);
     }
 
     @Override

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CipherLite.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CipherLite.java
@@ -86,7 +86,7 @@ class CipherLite {
      */
     CipherLite recreate() {
         return scheme.createCipherLite(secreteKey, cipher.getIV(),
-                this.cipherMode, cipher.getProvider());
+                this.cipherMode, cipher.getProvider(), true);
     }
 
     /**
@@ -95,7 +95,7 @@ class CipherLite {
      */
     CipherLite createUsingIV(byte[] iv) {
         return scheme.createCipherLite(secreteKey, iv, this.cipherMode,
-                cipher.getProvider());
+                cipher.getProvider(), true);
     }
 
     /**
@@ -128,7 +128,7 @@ class CipherLite {
         else
             throw new UnsupportedOperationException();
         return scheme.createCipherLite(secreteKey, cipher.getIV(),
-                inversedMode, cipher.getProvider());
+                inversedMode, cipher.getProvider(), true);
     }
 
     /**
@@ -162,7 +162,7 @@ class CipherLite {
      *                if this cipher is in decryption mode, and (un)padding has
      *                been requested, but the decrypted data is not bounded by
      *                the appropriate padding bytes
-     * @exception BadTagException
+     * @exception javax.crypto.AEADBadTagException
      *                if this cipher is decrypting in an AEAD mode (such as
      *                GCM/CCM), and the received authentication tag does not
      *                match the calculated value

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/ContentCryptoScheme.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/ContentCryptoScheme.java
@@ -177,10 +177,10 @@ abstract class ContentCryptoScheme {
         String specificProvider = getSpecificCipherProvider();
         Cipher cipher;
         try {
-            if (specificProvider != null) { // use the specific provider if defined
-                    cipher = Cipher.getInstance(getCipherAlgorithm(), specificProvider);
-            } else if (securityProvider != null) { // use the one optionally specified in the input
+            if (securityProvider != null) { // use the one optionally specified in the input
                 cipher = Cipher.getInstance(getCipherAlgorithm(), securityProvider);
+            } else if (specificProvider != null) { // use the specific provider if defined
+                    cipher = Cipher.getInstance(getCipherAlgorithm(), specificProvider);
             } else { // use the default provider
                 cipher = Cipher.getInstance(getCipherAlgorithm());
             }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/S3CryptoModuleAE.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/S3CryptoModuleAE.java
@@ -221,6 +221,7 @@ class S3CryptoModuleAE extends S3CryptoModuleBase<MultipartUploadCryptoContext> 
                     matdesc,
                     kekMaterialsProvider,
                     cryptoConfig.getCryptoProvider(),
+                    cryptoConfig.getAlwaysUseCryptoProvider(),
                     cryptoRange,   // range is sometimes necessary to compute the adjusted IV
                     extraMatDesc,
                     keyWrapExpected,
@@ -249,6 +250,7 @@ class S3CryptoModuleAE extends S3CryptoModuleBase<MultipartUploadCryptoContext> 
             .fromObjectMetadata(retrieved.getObjectMetadata(),
                 kekMaterialsProvider,
                 cryptoConfig.getCryptoProvider(),
+                cryptoConfig.getAlwaysUseCryptoProvider(),
                 // range is sometimes necessary to compute the adjusted IV
                 cryptoRange,
                 extraMatDesc,

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
@@ -233,8 +233,8 @@ public class CryptoConfiguration implements Cloneable,Serializable {
      *             specified crypto mode.
      */
     private void check(CryptoMode cryptoMode) {
-        if (cryptoMode == CryptoMode.AuthenticatedEncryption
-                || cryptoMode == CryptoMode.StrictAuthenticatedEncryption) {
+        if (cryptoProvider == null && (cryptoMode == CryptoMode.AuthenticatedEncryption
+                || cryptoMode == CryptoMode.StrictAuthenticatedEncryption)) {
             if (!CryptoRuntime.isBouncyCastleAvailable()) {
                 CryptoRuntime.enableBouncyCastle();
                 if (!CryptoRuntime.isBouncyCastleAvailable()) {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
@@ -35,6 +35,8 @@ public class CryptoConfiguration implements Cloneable,Serializable {
     private CryptoMode cryptoMode;
     private CryptoStorageMode storageMode;
     private Provider cryptoProvider;
+    private boolean alwaysUseCryptoProvider;
+
     /**
      * True to ignore instruction file that cannot be found during a GET
      * operation; false otherwise. Default is true. This property is ignored if
@@ -146,6 +148,36 @@ public class CryptoConfiguration implements Cloneable,Serializable {
      */
     public Provider getCryptoProvider() {
         return this.cryptoProvider;
+    }
+
+    /**
+     * Sets whether the specified crypto provider should be used in all cases. For
+     * backwards compatibility, it will be ignored if CryptoMode specified authenticated
+     * encryption.
+     */
+    public void setAlwaysUseCryptoProvider(boolean value) {
+        this.alwaysUseCryptoProvider = value;
+    }
+
+    /**
+     * Sets whether the specified crypto provider should be used in all cases. For
+     * backwards compatibility, it will be ignored if CryptoMode specified authenticated
+     * encryption.
+     */
+    public CryptoConfiguration withAlwaysUseCryptoProvider(boolean value) {
+        this.alwaysUseCryptoProvider = value;
+        return this;
+    }
+
+    /**
+     * Returns true if the specified crypto provider should be used in all cases. For
+     * backwards compatibility, it will be ignored if CryptoMode specifies authenticated
+     * encryption.
+     *
+     * @return true if the crypto provider should always be used
+     */
+    public boolean getAlwaysUseCryptoProvider() {
+        return alwaysUseCryptoProvider;
     }
 
     /**
@@ -268,6 +300,12 @@ public class CryptoConfiguration implements Cloneable,Serializable {
         @Override public CryptoConfiguration withCryptoProvider(Provider cryptoProvider) {
             throw new UnsupportedOperationException();
         }
+        @Override public void setAlwaysUseCryptoProvider(boolean value) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public CryptoConfiguration withAlwaysUseCryptoProvider(boolean value) {
+            throw new UnsupportedOperationException();
+        }
         @Override public void setCryptoMode(CryptoMode cryptoMode) {
             throw new UnsupportedOperationException();
         }
@@ -308,6 +346,7 @@ public class CryptoConfiguration implements Cloneable,Serializable {
         that.cryptoMode = this.cryptoMode;
         that.storageMode = this.storageMode;
         that.cryptoProvider = this.cryptoProvider;
+        that.alwaysUseCryptoProvider = this.alwaysUseCryptoProvider;
         that.ignoreMissingInstructionFile = this.ignoreMissingInstructionFile;
         that.awskmsRegion = this.awskmsRegion;
         return that;

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/CryptoConfiguration.java
@@ -265,8 +265,15 @@ public class CryptoConfiguration implements Cloneable,Serializable {
      *             specified crypto mode.
      */
     private void check(CryptoMode cryptoMode) {
-        if (cryptoProvider == null && (cryptoMode == CryptoMode.AuthenticatedEncryption
-                || cryptoMode == CryptoMode.StrictAuthenticatedEncryption)) {
+        // For modes that use AES/GCM, we prefer using the BouncyCastle provider unless the
+        // user has explicitly overridden us (i.e., with the FIPS-compliant BouncyCastle
+        // implementation).
+        boolean preferBC = (cryptoMode == CryptoMode.AuthenticatedEncryption)
+                || (cryptoMode == CryptoMode.StrictAuthenticatedEncryption);
+
+        boolean haveOverride = (cryptoProvider != null && alwaysUseCryptoProvider);
+
+        if (preferBC && !haveOverride) {
             if (!CryptoRuntime.isBouncyCastleAvailable()) {
                 CryptoRuntime.enableBouncyCastle();
                 if (!CryptoRuntime.isBouncyCastleAvailable()) {


### PR DESCRIPTION
Hi friends!

Here's a proposed fix for #1632, as I suspect we're going to run into this at some point as well. This gets things working with the BC-FIPS library in non-approved mode; approved mode also requires some changes to the way CEKs are generated, which I'll take a look at if you're okay merging this.

The most-relevant change is to `ContentCryptoScheme`: prioritizing the user-specified security provider (in this case, `BouncyCastleFipsProvider`) over the default one called for by the chosen CryptoMode. This is, potentially, a breaking change if someone is specifying a provider but relying on the fact that it gets ignored. That _seems_ like an acceptable risk to me, but I could live with having to opt in somehow if you want to be extra extra safe.

The second change, to `CryptoConfiguration`, simply skips the BouncyCastle-related checks if the user has specified a provider to use. `check()` is called directly from `set/withCryptoMode`, so you have to call `set/withSecurityProvider` first if you don't want the checks. That's a bit surprising, but I didn't want to attempt a more serious refactor to address it.

As a bonus: Java 9 added a public `InputStream.readAllBytes()` method, breaking compilation of `S3AbortableInputStream` (which tries to define a private method of the same name). The fix is backwards compatible, so I went ahead and made it. If you would rather not bother, it's in a separate commit so it's easy to drop.

I'll preemptively say that I'm happy to contribute these changes under the terms of the Apache 2.0 license if no CLA paperwork is required. :)