### PR TITLE
add getClientConfiguration accessor to AmazonWebServiceClient

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/AmazonWebServiceClient.java
@@ -961,4 +961,8 @@ public abstract class AmazonWebServiceClient {
     public String getSignerOverride() {
         return clientConfiguration.getSignerOverride();
     }
+
+    public ClientConfiguration getClientConfiguration() {
+       return new ClientConfiguration(clientConfiguration);
+    }
 }


### PR DESCRIPTION
I'm looking for a way (without reflection) to see what configuration I actually ended up with, so I can log it.