### PR TITLE
change AmazonSNSClientBuilder and AmazonSQSClientBuilder return concr…

### DIFF
--- a/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AmazonSNSClientBuilder.java
+++ b/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AmazonSNSClientBuilder.java
@@ -25,7 +25,7 @@ import com.amazonaws.client.AwsSyncClientParams;
  **/
 @NotThreadSafe
 @Generated("com.amazonaws:aws-java-sdk-code-generator")
-public final class AmazonSNSClientBuilder extends AwsSyncClientBuilder<AmazonSNSClientBuilder, AmazonSNS> {
+public final class AmazonSNSClientBuilder extends AwsSyncClientBuilder<AmazonSNSClientBuilder, AmazonSNSClient> {
 
     private static final ClientConfigurationFactory CLIENT_CONFIG_FACTORY = new ClientConfigurationFactory();
 
@@ -40,7 +40,7 @@ public final class AmazonSNSClientBuilder extends AwsSyncClientBuilder<AmazonSNS
      * @return Default client using the {@link com.amazonaws.auth.DefaultAWSCredentialsProviderChain} and
      *         {@link com.amazonaws.regions.DefaultAwsRegionProviderChain} chain
      */
-    public static AmazonSNS defaultClient() {
+    public static AmazonSNSClient defaultClient() {
         return standard().build();
     }
 
@@ -56,7 +56,7 @@ public final class AmazonSNSClientBuilder extends AwsSyncClientBuilder<AmazonSNS
      * @return Fully configured implementation of AmazonSNS.
      */
     @Override
-    protected AmazonSNS build(AwsSyncClientParams params) {
+    protected AmazonSNSClient build(AwsSyncClientParams params) {
         return new AmazonSNSClient(params);
     }
 

--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AmazonSQSClientBuilder.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AmazonSQSClientBuilder.java
@@ -1,11 +1,11 @@
 /*
  * Copyright 2013-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- * 
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not use this file except in compliance with
  * the License. A copy of the License is located at
- * 
+ *
  * http://aws.amazon.com/apache2.0
- * 
+ *
  * or in the "license" file accompanying this file. This file is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions
  * and limitations under the License.
@@ -25,7 +25,7 @@ import com.amazonaws.client.AwsSyncClientParams;
  **/
 @NotThreadSafe
 @Generated("com.amazonaws:aws-java-sdk-code-generator")
-public final class AmazonSQSClientBuilder extends AwsSyncClientBuilder<AmazonSQSClientBuilder, AmazonSQS> {
+public final class AmazonSQSClientBuilder extends AwsSyncClientBuilder<AmazonSQSClientBuilder, AmazonSQSClient> {
 
     private static final ClientConfigurationFactory CLIENT_CONFIG_FACTORY = new com.amazonaws.services.sqs.AmazonSQSClientConfigurationFactory();
 
@@ -40,7 +40,7 @@ public final class AmazonSQSClientBuilder extends AwsSyncClientBuilder<AmazonSQS
      * @return Default client using the {@link com.amazonaws.auth.DefaultAWSCredentialsProviderChain} and
      *         {@link com.amazonaws.regions.DefaultAwsRegionProviderChain} chain
      */
-    public static AmazonSQS defaultClient() {
+    public static AmazonSQSClient defaultClient() {
         return standard().build();
     }
 
@@ -56,7 +56,7 @@ public final class AmazonSQSClientBuilder extends AwsSyncClientBuilder<AmazonSQS
      * @return Fully configured implementation of AmazonSQS.
      */
     @Override
-    protected AmazonSQS build(AwsSyncClientParams params) {
+    protected AmazonSQSClient build(AwsSyncClientParams params) {
         return new AmazonSQSClient(params);
     }
 


### PR DESCRIPTION
…ete classes from build and defaultClient methods, instead of the interface

so callers have access to getClientConfiguration method.

Turns out https://github.com/aws/aws-sdk-java/pull/1641 wasn't enough.  It helps me get the configuration from the result of AmazonSNSClientBuilder.build() without reflection, but I still need a cast from AmazonSNS to AmazonSNSClient before the getClientConfiguration method is available.

This change makes that call possible with no cast.