### PR TITLE
add getClientConfiguration method to AmazonSNS, AmazonSQS

### DIFF
--- a/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AbstractAmazonSNS.java
+++ b/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AbstractAmazonSNS.java
@@ -304,4 +304,8 @@ public class AbstractAmazonSNS implements AmazonSNS {
         throw new java.lang.UnsupportedOperationException();
     }
 
+    @Override
+    public ClientConfiguration getClientConfiguration() {
+        throw new java.lang.UnsupportedOperationException();
+    }
 }

--- a/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AmazonSNS.java
+++ b/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/AmazonSNS.java
@@ -1095,4 +1095,8 @@ public interface AmazonSNS {
      */
     ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request);
 
+    /**
+     * Accessor for the configuration for this client
+     */
+    ClientConfiguration getClientConfiguration();
 }

--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AbstractAmazonSQS.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AbstractAmazonSQS.java
@@ -243,4 +243,8 @@ public class AbstractAmazonSQS implements AmazonSQS {
         throw new java.lang.UnsupportedOperationException();
     }
 
+    @Override
+    public ClientConfiguration getClientConfiguration() {
+        throw new java.lang.UnsupportedOperationException();
+    }
 }

--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AmazonSQS.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/AmazonSQS.java
@@ -1148,4 +1148,8 @@ public interface AmazonSQS {
      */
     ResponseMetadata getCachedResponseMetadata(AmazonWebServiceRequest request);
 
+    /**
+     * Accessor for the configuration for this client
+     */
+    ClientConfiguration getClientConfiguration();
 }

--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/AmazonSQSBufferedAsyncClient.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/AmazonSQSBufferedAsyncClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.Future;
 import com.amazonaws.AmazonClientException;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonWebServiceRequest;
+import com.amazonaws.ClientConfiguration;
 import com.amazonaws.ResponseMetadata;
 import com.amazonaws.handlers.AsyncHandler;
 import com.amazonaws.regions.Region;
@@ -900,5 +901,10 @@ public class AmazonSQSBufferedAsyncClient implements AmazonSQSAsync {
     @Override
     public Future<ListQueueTagsResult> listQueueTagsAsync(String queueUrl, AsyncHandler<ListQueueTagsRequest, ListQueueTagsResult> asyncHandler) {
         return listQueueTagsAsync(new ListQueueTagsRequest(queueUrl), asyncHandler);
+    }
+
+    @Override
+    public ClientConfiguration getClientConfiguration() {
+        return realSQS.getClientConfiguration();
     }
 }


### PR DESCRIPTION
Turns out #1641 wasn't enough. It helps me get the configuration from the result of AmazonSNSClientBuilder.build() without reflection, but I still need a cast from AmazonSNS to AmazonSNSClient before the getClientConfiguration method is available.

This change makes that call possible directly on AmazonSNS.