### PR TITLE
remove ThreadLocal use from AbstractAWSSigner and SigningAlgorithm

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
@@ -48,25 +48,8 @@ import com.amazonaws.util.StringUtils;
  */
 public abstract class AbstractAWSSigner implements Signer {
 
-    public static final String EMPTY_STRING_SHA256_HEX;
-    private static final ThreadLocal<MessageDigest> SHA256_MESSAGE_DIGEST;
-
-    static {
-        SHA256_MESSAGE_DIGEST = new ThreadLocal<MessageDigest>() {
-            @Override
-            protected MessageDigest initialValue() {
-                try {
-                    return MessageDigest.getInstance("SHA-256");
-                } catch (NoSuchAlgorithmException e) {
-                    throw new SdkClientException(
-                            "Unable to get SHA256 Function"
-                                    + e.getMessage(), e);
-                }
-            }
-        };
-        EMPTY_STRING_SHA256_HEX = BinaryUtils.toHex(doHash(""));
-    }
-
+    public static final String EMPTY_STRING_SHA256_HEX = BinaryUtils.toHex(doHash(""));
+    
     /**
      * Computes an RFC 2104-compliant HMAC signature and returns the result as a
      * Base64 encoded string.
@@ -471,13 +454,22 @@ public abstract class AbstractAWSSigner implements Signer {
 
 
     /**
-     * Returns the re-usable thread local version of MessageDigest.
-     * @return
+     * Returns a MessageDigest for the SHA-256 algorithm.
+     * @return a MessageDigest for the SHA-256 algorithm
      */
     private static MessageDigest getMessageDigestInstance() {
-        MessageDigest messageDigest = SHA256_MESSAGE_DIGEST.get();
-        messageDigest.reset();
-        return messageDigest;
+        return getMessageDigestInstance("SHA-256");
+    }
+    
+    // visible for testing
+    static MessageDigest getMessageDigestInstance(String algorithm) {
+        try {
+            return MessageDigest.getInstance(algorithm);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SdkClientException(
+                    "Unable to get " + algorithm + " Function"
+                            + e.getMessage(), e);
+        }
     }
 
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SigningAlgorithm.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SigningAlgorithm.java
@@ -24,28 +24,16 @@ public enum SigningAlgorithm {
     HmacSHA1,
     HmacSHA256;
 
-    private final ThreadLocal<Mac> macReference;
-
-    private SigningAlgorithm() {
-        final String algorithmName = this.toString();
-        macReference = new ThreadLocal<Mac>() {
-            @Override
-            protected Mac initialValue() {
-                try {
-                    return Mac.getInstance(algorithmName);
-                } catch (NoSuchAlgorithmException e) {
-                    throw new SdkClientException("Unable to fetch Mac instance for Algorithm "
-                            + algorithmName + e.getMessage(),e);
-
-                }
-            }
-        };
-    }
-
     /**
-     * Returns the thread local reference for the crypto algorithm
+     * Returns an instance of {@link Mac} for the algorithm name.
      */
     public Mac getMac() {
-        return macReference.get();
+        final String algorithmName = this.toString();
+        try {
+            return Mac.getInstance(algorithmName);
+        } catch (NoSuchAlgorithmException e) {
+            throw new SdkClientException("Unable to fetch Mac instance for Algorithm "
+                    + algorithmName + e.getMessage(),e);
+        }
     }
 }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AbstractAWSSignerTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AbstractAWSSignerTest.java
@@ -19,13 +19,22 @@ import static org.junit.Assert.assertEquals;
 
 import org.junit.Test;
 
+import com.amazonaws.SdkClientException;
+
 public class AbstractAWSSignerTest {
 
+    private static final String EMPTY_STRING_SHA256_HEX = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
     @Test
-    public void test() {
+    public void testDigestOfEmptyString() {
         assertEquals(
-            "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+            EMPTY_STRING_SHA256_HEX,
             AbstractAWSSigner.EMPTY_STRING_SHA256_HEX);
+    }
+    
+    @Test(expected=SdkClientException.class)
+    public void testMessageDigestAlgorithmDoesNotExist() {
+        AbstractAWSSigner.getMessageDigestInstance("doesNotExist");
     }
 
 }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/SigningAlgorithmTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/SigningAlgorithmTest.java
@@ -1,0 +1,19 @@
+package com.amazonaws.auth;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+public class SigningAlgorithmTest {
+    
+    @Test
+    public void testCanCreateSHA1() {
+        assertEquals("HmacSHA1",SigningAlgorithm.HmacSHA1.getMac().getAlgorithm());
+    }
+    
+    @Test
+    public void testCanCreateSHA256() {
+        assertEquals("HmacSHA256",SigningAlgorithm.HmacSHA256.getMac().getAlgorithm());
+    }
+
+}


### PR DESCRIPTION
This PR removes `ThreadLocal` usage from `AbstractAWSSigner` and `SigningAlgorithm` classes in *aws-java-sdk-core* as discussed in #1704.

Also includes a couple of unit tests (`SigningAlgorithm.getMac` had no coverage).