### PR TITLE
aws-java-sdk-core: EC2MetadataClient.java - Fix sending of a User-Agent

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/EC2CredentialsUtils.java
@@ -79,12 +79,7 @@ public final class EC2CredentialsUtils {
      *             If the requested service is not found.
      */
     public String readResource(URI endpoint) throws IOException {
-        Map<String, String> headers = new HashMap<String, String>();
-        headers.put("User-Agent", USER_AGENT);
-        headers.put("Accept", "*/*");
-        headers.put("Connection", "keep-alive");
-
-        return readResource(endpoint, CredentialsEndpointRetryPolicy.NO_RETRY, headers);
+        return readResource(endpoint, CredentialsEndpointRetryPolicy.NO_RETRY, null);
     }
 
     /**
@@ -110,6 +105,8 @@ public final class EC2CredentialsUtils {
     public String readResource(URI endpoint, CredentialsEndpointRetryPolicy retryPolicy, Map<String, String> headers) throws IOException {
         int retriesAttempted = 0;
         InputStream inputStream = null;
+
+        headers = addDefaultHeaders(headers);
 
         while (true) {
             try {
@@ -139,6 +136,24 @@ public final class EC2CredentialsUtils {
             }
         }
 
+    }
+
+    private Map<String,String> addDefaultHeaders(Map<String,String> headers) {
+        HashMap<String, String> map = new HashMap<String, String>();
+        if (headers != null) {
+            map.putAll(headers);
+        }
+
+        putIfAbsent(map,"User-Agent", USER_AGENT);
+        putIfAbsent(map,"Accept", "*/*");
+        putIfAbsent(map,"Connection", "keep-alive");
+        return map;
+    }
+
+    private <K,V> void putIfAbsent(Map<K,V> map, K key, V value) {
+        if (map.get(key) == null) {
+            map.put(key, value);
+        }
     }
 
     private void handleErrorResponse(InputStream errorStream, int statusCode, String responseMessage) throws IOException {

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/internal/EC2CredentialsUtilsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/internal/EC2CredentialsUtilsTest.java
@@ -14,15 +14,19 @@
  */
 package com.amazonaws.internal;
 
+import com.amazonaws.util.VersionInfoUtils;
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Matchers.eq;
 
 import java.io.IOException;
@@ -31,6 +35,7 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.hamcrest.Matcher;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -49,6 +54,8 @@ import utils.http.SocketUtils;
 
 @RunWith(MockitoJUnitRunner.class)
 public class EC2CredentialsUtilsTest {
+
+    private static final String USER_AGENT = String.format("aws-sdk-java/%s", VersionInfoUtils.getVersion());
 
     @ClassRule
     public static WireMockRule mockServer = new WireMockRule(0);
@@ -202,6 +209,66 @@ public class EC2CredentialsUtilsTest {
             fail("Expected an AmazonServiceException");
         } catch (AmazonServiceException ase) {
             Mockito.verify(mockConnection, Mockito.times(1)).connectToEndpoint(eq(endpoint), any(Map.class));
+        }
+    }
+
+    /**
+     * When readResource is called,
+     * the SDK User-Agent should be added.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void readResouce_AddsSDKUserAgent() throws IOException {
+        Mockito.when(mockConnection.connectToEndpoint(eq(endpoint), any(Map.class))).thenThrow(new IOException());
+
+        try {
+            new EC2CredentialsUtils(mockConnection).readResource(endpoint);
+            fail("Expected an IOexception");
+        } catch (IOException exception) {
+            Matcher<Map<? extends String, ? extends String>> expectedHeaders = hasEntry("User-Agent", USER_AGENT);
+            Mockito.verify(mockConnection, Mockito.times(1)).connectToEndpoint(eq(endpoint), (Map<String, String>) argThat(expectedHeaders));
+        }
+    }
+
+    /**
+     * When readResource is called with custom retry policy,
+     * the SDK User-Agent should be added.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void readResouceWithCustomRetryPolicy_AddsSDKUserAgent() throws IOException {
+        Mockito.when(mockConnection.connectToEndpoint(eq(endpoint), any(Map.class))).thenThrow(new IOException());
+
+        try {
+            new EC2CredentialsUtils(mockConnection).readResource(endpoint, customRetryPolicy, null);
+            fail("Expected an IOexception");
+        } catch (IOException exception) {
+            Matcher<Map<? extends String, ? extends String>> expectedHeaders = hasEntry("User-Agent", USER_AGENT);
+            Mockito.verify(mockConnection, Mockito.times(CustomRetryPolicy.MAX_RETRIES + 1)).connectToEndpoint(eq(endpoint), (Map<String, String>) argThat(expectedHeaders));
+        }
+    }
+
+    /**
+     * When readResource is called with custom retry policy
+     * and additional headers, the SDK User-Agent should be
+     * added.
+     */
+    @Test
+    @SuppressWarnings("unchecked")
+    public void readResouceWithCustomRetryPolicyAndHeaders_AddsSDKUserAgent() throws IOException {
+        Mockito.when(mockConnection.connectToEndpoint(eq(endpoint), any(Map.class))).thenThrow(new IOException());
+
+        try {
+            Map<String, String> headers = new HashMap<String, String>();
+            headers.put("Foo","Bar");
+            new EC2CredentialsUtils(mockConnection).readResource(endpoint, customRetryPolicy, headers);
+            fail("Expected an IOexception");
+        } catch (IOException exception) {
+            Matcher<Map<? extends String, ? extends String>> expectedHeaders = allOf(
+                hasEntry("User-Agent", USER_AGENT),
+                hasEntry("Foo", "Bar")
+            );
+            Mockito.verify(mockConnection, Mockito.times(CustomRetryPolicy.MAX_RETRIES + 1)).connectToEndpoint(eq(endpoint), (Map<String, String>) argThat(expectedHeaders));
         }
     }
 


### PR DESCRIPTION
Builds upon #1562 by @willbengtson. 

- [x] Adds Unit Tests to verify the SDK User-Agent is added to metadata requests
- [x] Fix missing SDK User-Agent, when custom retry policy is used.

/cc @varunnvs92