### PR TITLE
Enable clearing of SDK ThreadLocals

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SdkThreadLocals.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SdkThreadLocals.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws;
+
+import com.amazonaws.annotation.SdkProtectedApi;
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
+
+/**
+ * Utility class to manage {@link ThreadLocal} storage within the AWS SDK.
+ * 
+ * <p>
+ * {@code ThreadLocal} removal is especially relevant when the AWS SDK is used
+ * in an application server that manages a pool of threads across many
+ * applications (for example Tomcat or Glassfish). If a {@code ThreadLocal} is
+ * not cleared on application shutdown and the {@code ThreadLocal} value is a
+ * class from the application classloader then the application classloader
+ * cannot be garbage collected until the {@code ThreadLocal} is set again or the thread
+ * is disposed of (Glassfish attempts thread renewal on occasion to help with
+ * this).
+ */
+public final class SdkThreadLocals {
+
+    private SdkThreadLocals() {
+        // prevent instantiation
+    }
+
+    /**
+     * Removes the current thread's values for all {@link ThreadLocal}s used by the
+     * AWS SDK.
+     */
+    public static void remove() {
+        SdkThreadLocalsRegistry.remove();
+    }
+
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
@@ -34,6 +34,7 @@ import com.amazonaws.ReadLimitInfo;
 import com.amazonaws.SDKGlobalTime;
 import com.amazonaws.SignableRequest;
 import com.amazonaws.internal.SdkDigestInputStream;
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
 import com.amazonaws.util.Base64;
 import com.amazonaws.util.BinaryUtils;
 import com.amazonaws.util.SdkHttpUtils;
@@ -52,18 +53,18 @@ public abstract class AbstractAWSSigner implements Signer {
     private static final ThreadLocal<MessageDigest> SHA256_MESSAGE_DIGEST;
 
     static {
-        SHA256_MESSAGE_DIGEST = new ThreadLocal<MessageDigest>() {
-            @Override
-            protected MessageDigest initialValue() {
-                try {
-                    return MessageDigest.getInstance("SHA-256");
-                } catch (NoSuchAlgorithmException e) {
-                    throw new SdkClientException(
-                            "Unable to get SHA256 Function"
-                                    + e.getMessage(), e);
-                }
-            }
-        };
+        SHA256_MESSAGE_DIGEST = SdkThreadLocalsRegistry.register(
+                new ThreadLocal<MessageDigest>() {
+                    @Override
+                    protected MessageDigest initialValue() {
+                        try {
+                            return MessageDigest.getInstance("SHA-256");
+                        } catch (NoSuchAlgorithmException e) {
+                            throw new SdkClientException(
+                                    "Unable to get SHA256 Function" + e.getMessage(), e);
+                        }
+                    }
+                });
         EMPTY_STRING_SHA256_HEX = BinaryUtils.toHex(doHash(""));
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SigningAlgorithm.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/SigningAlgorithm.java
@@ -19,6 +19,8 @@ import com.amazonaws.SdkClientException;
 import javax.crypto.Mac;
 import java.security.NoSuchAlgorithmException;
 
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
+
 public enum SigningAlgorithm {
 
     HmacSHA1,
@@ -28,18 +30,17 @@ public enum SigningAlgorithm {
 
     private SigningAlgorithm() {
         final String algorithmName = this.toString();
-        macReference = new ThreadLocal<Mac>() {
+        macReference = SdkThreadLocalsRegistry.register(new ThreadLocal<Mac>() {
             @Override
             protected Mac initialValue() {
                 try {
                     return Mac.getInstance(algorithmName);
                 } catch (NoSuchAlgorithmException e) {
-                    throw new SdkClientException("Unable to fetch Mac instance for Algorithm "
-                            + algorithmName + e.getMessage(),e);
-
+                    throw new SdkClientException(
+                            "Unable to fetch Mac instance for Algorithm " + algorithmName + e.getMessage(), e);
                 }
             }
-        };
+        });
     }
 
     /**

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkThreadLocalsRegistry.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkThreadLocalsRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.internal;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.amazonaws.annotation.SdkProtectedApi;
+
+@SdkProtectedApi
+public final class SdkThreadLocalsRegistry {
+    
+    private static final List<ThreadLocal<?>> threadLocals = new ArrayList<ThreadLocal<?>>();
+
+    private SdkThreadLocalsRegistry() {
+        // prevent instantiation
+    }
+    
+    /**
+     * Registers {@link ThreadLocal} objects in use by the AWS SDK so that their values can 
+     * be removed via the {@link #remove()} method.
+     * 
+     * <p>To avoid memory leaks and reduce contention this method should only be called when 
+     * setting static final locations (for example finals in enums or static final fields).
+     * 
+     * @param threadLocal ThreadLocal to register
+     * @return the input ThreadLocal
+     */
+    public static synchronized <T> ThreadLocal<T> register(ThreadLocal<T> threadLocal) {
+        threadLocals.add(threadLocal);
+        return threadLocal;
+    }
+
+    public synchronized static void remove() {
+        for (ThreadLocal<?> t: threadLocals) {
+            t.remove();
+        }        
+    }
+    
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/XmlUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/XmlUtils.java
@@ -24,17 +24,20 @@ import org.xml.sax.SAXException;
 import org.xml.sax.XMLReader;
 import org.xml.sax.helpers.XMLReaderFactory;
 
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
+
 public class XmlUtils {
 
     /**
      * Shared factory for creating XML event readers
      */
-    private static final ThreadLocal<XMLInputFactory> xmlInputFactory = new ThreadLocal<XMLInputFactory>() {
-        @Override
-        protected XMLInputFactory initialValue() {
-            return createXmlInputFactory();
-        }
-    };
+    private static final ThreadLocal<XMLInputFactory> xmlInputFactory = SdkThreadLocalsRegistry
+            .register(new ThreadLocal<XMLInputFactory>() {
+                @Override
+                protected XMLInputFactory initialValue() {
+                    return createXmlInputFactory();
+                }
+            });
 
     public static XMLReader parse(InputStream in, ContentHandler handler)
         throws SAXException, IOException {

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/XpathUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/XpathUtils.java
@@ -38,6 +38,8 @@ import org.xml.sax.ErrorHandler;
 import org.xml.sax.SAXException;
 import org.xml.sax.SAXParseException;
 
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
+
 /**
  * Utility methods for extracting data from XML documents using Xpath
  * expressions.
@@ -86,12 +88,13 @@ public class XpathUtils {
     /**
      * Shared factory for creating XML Factory
      */
-    private static final ThreadLocal<XPathFactory> X_PATH_FACTORY = new ThreadLocal<XPathFactory>() {
-        @Override
-        protected XPathFactory initialValue() {
-            return XPathFactory.newInstance();
-        }
-    };
+    private static final ThreadLocal<XPathFactory> X_PATH_FACTORY = SdkThreadLocalsRegistry
+            .register(new ThreadLocal<XPathFactory>() {
+                @Override
+                protected XPathFactory initialValue() {
+                    return XPathFactory.newInstance();
+                }
+            });
 
     /**
      * Used to optimize performance by avoiding expensive file access every time

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/SdkThreadLocalsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/SdkThreadLocalsTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2015-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
+
+public class SdkThreadLocalsTest {
+
+    @Test
+    public void testOneThreadLocalRemoved() {
+        ThreadLocal<Integer> t = new ThreadLocal<Integer>();
+        t.set(1);
+        SdkThreadLocalsRegistry.register(t);
+        assertEquals(1, (int) t.get());
+        SdkThreadLocals.remove();
+        assertNull(t.get());
+    }
+    
+    @Test
+    public void testMultipleThreadLocalsRemoved() {
+        ThreadLocal<Integer> t1 = new ThreadLocal<Integer>();
+        t1.set(1);
+        ThreadLocal<Integer> t2 = new ThreadLocal<Integer>();
+        t2.set(1);
+        SdkThreadLocalsRegistry.register(t1);
+        SdkThreadLocalsRegistry.register(t2);
+        assertEquals(1, (int) t1.get());
+        assertEquals(1, (int) t2.get());
+        SdkThreadLocals.remove();
+        assertNull(t1.get());
+        assertNull(t2.get());
+    }
+
+}

--- a/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/util/SignatureChecker.java
+++ b/aws-java-sdk-sns/src/main/java/com/amazonaws/services/sns/util/SignatureChecker.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.sns.util;
 
 import com.amazonaws.SdkClientException;
 import com.amazonaws.annotation.ThreadSafe;
+import com.amazonaws.internal.SdkThreadLocalsRegistry;
 import com.amazonaws.services.sns.message.SnsMessageManager;
 import com.amazonaws.util.Base64;
 import com.fasterxml.jackson.core.JsonFactory;
@@ -45,7 +46,8 @@ import java.util.TreeMap;
 @ThreadSafe
 public class SignatureChecker {
 
-    private static final ThreadLocal<Signature> SIG_CHECKER = new ThreadLocal<Signature>() {
+    private static final ThreadLocal<Signature> SIG_CHECKER = SdkThreadLocalsRegistry.register(
+            new ThreadLocal<Signature>() {
         @Override
         protected Signature initialValue() {
             try {
@@ -54,7 +56,7 @@ public class SignatureChecker {
                 throw new SdkClientException("Could not create RSA Signature", e);
             }
         }
-    };
+    });
 
     private final String NOTIFICATION_TYPE = "Notification";
     private final String SUBSCRIBE_TYPE = "SubscriptionConfirmation";


### PR DESCRIPTION
Discussed in #1704 

There are 5 uses of `ThreadLocal` in the SDK at the moment. 4 are in *aws-java-sdk-core* and 1 in *aws-java-sdk-sns*. Each instantiation has been wrapped with `SdkThreadLocalsRegistry.register()` (declared in an internal package).

When a user wants to clear `ThreadLocal` values specific to the SDK for the current thread he/she calls 

```java
SdkThreadLocals.remove();
```

cc @SuperEvenSteven @philipgroom
