### PR TITLE
InstanceProfileCredentialsProvider: use daemon thread for refresh.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/InstanceProfileCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/InstanceProfileCredentialsProvider.java
@@ -108,7 +108,13 @@ public class InstanceProfileCredentialsProvider implements AWSCredentialsProvide
 
         if (!SDKGlobalConfiguration.isEc2MetadataDisabled()) {
             if (refreshCredentialsAsync) {
-                executor = Executors.newScheduledThreadPool(1);
+                executor = Executors.newScheduledThreadPool(1, new ThreadFactory() {
+                    public Thread newThread(Runnable r) {
+                        Thread t = Executors.defaultThreadFactory().newThread(r);
+                        t.setDaemon(true);
+                        return t;
+                    }
+                });
                 executor.scheduleWithFixedDelay(new Runnable() {
                     @Override
                     public void run() {

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/InstanceProfileCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/InstanceProfileCredentialsProvider.java
@@ -27,6 +27,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ThreadFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 


### PR DESCRIPTION
When refreshCredentialsAsync is specified, a scheduled executor
is used to refresh credentials, however that executor is not configured
to use daemon threads. As result, that non-daemon thread blocks JVM
exit. This change explicit make the thread into daemon.