### PR TITLE
Early return in endpointDiscoveryEnabled

### DIFF
--- a/aws-java-sdk-code-generator/src/main/resources/templates/common/SyncClientBuilder.ftl
+++ b/aws-java-sdk-code-generator/src/main/resources/templates/common/SyncClientBuilder.ftl
@@ -62,8 +62,6 @@ public final class ${metadata.syncClientBuilderClassName}
 
     private boolean endpointDiscoveryEnabled() {
 
-        Boolean endpointDiscoveryChainSetting = DEFAULT_ENDPOINT_DISCOVERY_PROVIDER.endpointDiscoveryEnabled();
-
         if (endpointDiscoveryDisabled) {
             return false;
         }
@@ -71,6 +69,8 @@ public final class ${metadata.syncClientBuilderClassName}
         if (endpointDiscoveryEnabled) {
             return true;
         }
+
+        Boolean endpointDiscoveryChainSetting = DEFAULT_ENDPOINT_DISCOVERY_PROVIDER.endpointDiscoveryEnabled();
 
         if (endpointDiscoveryChainSetting != null && endpointDiscoveryChainSetting == false) {
             return false;

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClientBuilder.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/AmazonDynamoDBClientBuilder.java
@@ -69,8 +69,6 @@ public final class AmazonDynamoDBClientBuilder extends AwsSyncClientBuilder<Amaz
 
     private boolean endpointDiscoveryEnabled() {
 
-        Boolean endpointDiscoveryChainSetting = DEFAULT_ENDPOINT_DISCOVERY_PROVIDER.endpointDiscoveryEnabled();
-
         if (endpointDiscoveryDisabled) {
             return false;
         }
@@ -78,6 +76,8 @@ public final class AmazonDynamoDBClientBuilder extends AwsSyncClientBuilder<Amaz
         if (endpointDiscoveryEnabled) {
             return true;
         }
+
+        Boolean endpointDiscoveryChainSetting = DEFAULT_ENDPOINT_DISCOVERY_PROVIDER.endpointDiscoveryEnabled();
 
         if (endpointDiscoveryChainSetting != null && endpointDiscoveryChainSetting == false) {
             return false;


### PR DESCRIPTION
Even when `endpointDiscoveryDisabled` is set to `true`, `DEFAULT_ENDPOINT_DISCOVERY_PROVIDER` still goes through default endpoint discovery providers, loads profiles, etc.

This PR changes `endpointDiscoveryEnabled` behavior to exit early.
In case when endpoint discovery is explicitly enabled or disabled, `endpointDiscoveryChainSetting` would be ignored anyways.

I couldn't find any tests for this functionality.