### PR TITLE
Deprecate AWS_REGION

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -256,7 +256,7 @@ public class SDKGlobalConfiguration {
 
     /**
      * Environment variable to set an alternate path to the shared config file
-     * (default path is * ~/.aws/config).
+     * (default path is ~/.aws/config).
      */
     public static final String AWS_CONFIG_FILE_ENV_VAR = "AWS_CONFIG_FILE";
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/SDKGlobalConfiguration.java
@@ -240,22 +240,23 @@ public class SDKGlobalConfiguration {
     public static final String ALTERNATE_ACCESS_KEY_ENV_VAR = "AWS_ACCESS_KEY";
 
     /** Environment variable name for the AWS secret key */
-    public static final String SECRET_KEY_ENV_VAR = "AWS_SECRET_KEY";
+    public static final String SECRET_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY";
 
     /** Alternate environment variable name for the AWS secret key */
-    public static final String ALTERNATE_SECRET_KEY_ENV_VAR = "AWS_SECRET_ACCESS_KEY";
+    public static final String ALTERNATE_SECRET_KEY_ENV_VAR = "AWS_SECRET_KEY";
 
     /** Environment variable name for the AWS session token */
     public static final String AWS_SESSION_TOKEN_ENV_VAR = "AWS_SESSION_TOKEN";
 
-    /**
-     * Environment variable containing region used to configure clients.
-     */
-    public static final String AWS_REGION_ENV_VAR = "AWS_REGION";
+    /** * Environment variable containing region used to configure clients */
+    public static final String AWS_REGION_ENV_VAR = "AWS_DEFAULT_REGION";
+
+    /** * Alternate environment variable name for the AWS region */
+    public static final String ALTERNATE_AWS_REGION_ENV_VAR = "AWS_REGION";
 
     /**
-     * Environment variable to set an alternate path to the shared config file (default path is
-     * ~/.aws/config).
+     * Environment variable to set an alternate path to the shared config file
+     * (default path is * ~/.aws/config).
      */
     public static final String AWS_CONFIG_FILE_ENV_VAR = "AWS_CONFIG_FILE";
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
@@ -33,7 +33,7 @@ public class AwsEnvVarOverrideRegionProvider extends AwsRegionProvider {
         }
         region = StringUtils.trim(region);
 
-        if (StringUtils.isNullOrEmpty(region) {
+        if (StringUtils.isNullOrEmpty(region)) {
             throw new SdkClientException(
                     "Unable to load region from environment variables " +
                     "(" + AWS_REGION_ENV_VAR + " (or " + ALTERNATE_AWS_REGION_ENV_VAR + "))");

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
@@ -15,6 +15,7 @@
 package com.amazonaws.regions;
 
 import com.amazonaws.SdkClientException;
+import com.amazonaws.util.StringUtils;
 
 import static com.amazonaws.SDKGlobalConfiguration.AWS_REGION_ENV_VAR;
 import static com.amazonaws.SDKGlobalConfiguration.ALTERNATE_AWS_REGION_ENV_VAR;

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/regions/AwsEnvVarOverrideRegionProvider.java
@@ -17,15 +17,27 @@ package com.amazonaws.regions;
 import com.amazonaws.SdkClientException;
 
 import static com.amazonaws.SDKGlobalConfiguration.AWS_REGION_ENV_VAR;
+import static com.amazonaws.SDKGlobalConfiguration.ALTERNATE_AWS_REGION_ENV_VAR;
 
 /**
  * Loads region information from the '{@value com.amazonaws.SDKGlobalConfiguration#AWS_REGION_ENV_VAR}'
- * environment variable.
+ * environment variable or it's legacy alternative.
  */
 public class AwsEnvVarOverrideRegionProvider extends AwsRegionProvider {
 
     @Override
     public String getRegion() throws SdkClientException {
-        return System.getenv(AWS_REGION_ENV_VAR);
+        String region = System.getenv(AWS_REGION_ENV_VAR);
+        if (region == null) {
+            region = System.getenv(ALTERNATE_AWS_REGION_ENV_VAR);
+        }
+        region = StringUtils.trim(region);
+
+        if (StringUtils.isNullOrEmpty(region) {
+            throw new SdkClientException(
+                    "Unable to load region from environment variables " +
+                    "(" + AWS_REGION_ENV_VAR + " (or " + ALTERNATE_AWS_REGION_ENV_VAR + "))");
+        }
+        return region;
     }
 }


### PR DESCRIPTION
No wonder there is so much confusion - apparently nobody has cross-checked the various APIs or against  the documentation. AWS_REGION hasn't been valid (per public docs) for a very long time.