### PR TITLE
Add custom header to download transfer request, default value for uploads parameter, content-length for x-amzn-Remapped-Content-Length

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -254,8 +254,6 @@ import com.amazonaws.services.s3.model.SetBucketEncryptionResult;
 import com.amazonaws.services.s3.model.SetBucketInventoryConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketInventoryConfigurationResult;
 import com.amazonaws.services.s3.model.SetBucketLifecycleConfigurationRequest;
-import com.amazonaws.services.s3.model.SetPublicAccessBlockRequest;
-import com.amazonaws.services.s3.model.SetPublicAccessBlockResult;
 import com.amazonaws.services.s3.model.SetBucketLoggingConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketMetricsConfigurationRequest;
 import com.amazonaws.services.s3.model.SetBucketMetricsConfigurationResult;
@@ -274,6 +272,8 @@ import com.amazonaws.services.s3.model.SetObjectRetentionRequest;
 import com.amazonaws.services.s3.model.SetObjectRetentionResult;
 import com.amazonaws.services.s3.model.SetObjectTaggingRequest;
 import com.amazonaws.services.s3.model.SetObjectTaggingResult;
+import com.amazonaws.services.s3.model.SetPublicAccessBlockRequest;
+import com.amazonaws.services.s3.model.SetPublicAccessBlockResult;
 import com.amazonaws.services.s3.model.SetRequestPaymentConfigurationRequest;
 import com.amazonaws.services.s3.model.StorageClass;
 import com.amazonaws.services.s3.model.Tag;
@@ -289,6 +289,7 @@ import com.amazonaws.services.s3.model.transform.BucketConfigurationXmlFactory;
 import com.amazonaws.services.s3.model.transform.BucketNotificationConfigurationStaxUnmarshaller;
 import com.amazonaws.services.s3.model.transform.GetBucketEncryptionStaxUnmarshaller;
 import com.amazonaws.services.s3.model.transform.GetBucketPolicyStatusStaxUnmarshaller;
+import com.amazonaws.services.s3.model.transform.GetPublicAccessBlockStaxUnmarshaller;
 import com.amazonaws.services.s3.model.transform.HeadBucketResultHandler;
 import com.amazonaws.services.s3.model.transform.MultiObjectDeleteXmlFactory;
 import com.amazonaws.services.s3.model.transform.ObjectLockConfigurationXmlFactory;
@@ -297,7 +298,6 @@ import com.amazonaws.services.s3.model.transform.ObjectLockRetentionXmlFactory;
 import com.amazonaws.services.s3.model.transform.ObjectTaggingXmlFactory;
 import com.amazonaws.services.s3.model.transform.RequestPaymentConfigurationXmlFactory;
 import com.amazonaws.services.s3.model.transform.RequestXmlFactory;
-import com.amazonaws.services.s3.model.transform.GetPublicAccessBlockStaxUnmarshaller;
 import com.amazonaws.services.s3.model.transform.Unmarshallers;
 import com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser.CompleteMultipartUploadHandler;
 import com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser.CopyObjectResultHandler;
@@ -341,6 +341,8 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -3449,7 +3451,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
 
         Request<InitiateMultipartUploadRequest> request = createRequest(initiateMultipartUploadRequest.getBucketName(), initiateMultipartUploadRequest.getKey(), initiateMultipartUploadRequest, HttpMethodName.POST);
         request.addHandlerContext(HandlerContextKey.OPERATION_NAME, "CreateMultipartUpload");
-        request.addParameter("uploads", null);
+        request.addParameter("uploads", UUID.randomUUID().toString());
 
         if (initiateMultipartUploadRequest.getStorageClass() != null)
             request.addHeader(Headers.STORAGE_CLASS, initiateMultipartUploadRequest.getStorageClass().toString());
@@ -4592,12 +4594,23 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
             }
         }
 
+
+
         Request<X> request = new DefaultRequest<X>(originalRequest, Constants.S3_SERVICE_DISPLAY_NAME);
         request.setHttpMethod(httpMethod);
         request.addHandlerContext(S3HandlerContextKeys.IS_CHUNKED_ENCODING_DISABLED,
                 Boolean.valueOf(clientOptions.isChunkedEncodingDisabled()));
         request.addHandlerContext(S3HandlerContextKeys.IS_PAYLOAD_SIGNING_ENABLED,
                 Boolean.valueOf(clientOptions.isPayloadSigningEnabled()));
+
+        if ( originalRequest.getCustomRequestHeaders() != null ) {
+        	Set<String> keys = originalRequest.getCustomRequestHeaders().keySet();
+        	for (Iterator<String> iterator = keys.iterator(); iterator.hasNext();) {
+    			String headerKey =  iterator.next();
+    			request.addHeader(headerKey, originalRequest.getCustomRequestHeaders().get(headerKey));
+    		}
+        }
+
         resolveRequestEndpoint(request, bucketName, key, endpoint);
         request.addHandlerContext(HandlerContextKey.SIGNING_REGION, getSigningRegion());
         request.addHandlerContext(HandlerContextKey.SERVICE_ID, SERVICE_ID);

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/Headers.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/Headers.java
@@ -27,6 +27,7 @@ public interface Headers {
     public static final String CONTENT_DISPOSITION = "Content-Disposition";
     public static final String CONTENT_ENCODING = "Content-Encoding";
     public static final String CONTENT_LENGTH = "Content-Length";
+    public static final String X_AMZN_REMAPPED_CONTENT_LENGTH = "x-amzn-Remapped-Content-Length";
     public static final String CONTENT_RANGE = "Content-Range";
     public static final String CONTENT_MD5 = "Content-MD5";
     public static final String CONTENT_TYPE = "Content-Type";

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RequestCopyUtils.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RequestCopyUtils.java
@@ -14,6 +14,9 @@
  */
 package com.amazonaws.services.s3.internal;
 
+import java.util.Iterator;
+import java.util.Set;
+
 import com.amazonaws.annotation.SdkInternalApi;
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.GetObjectRequest;
@@ -21,15 +24,28 @@ import com.amazonaws.services.s3.model.GetObjectRequest;
 @SdkInternalApi
 public class RequestCopyUtils {
 
-    /**
-     * Creates a #GetObjectMetadataRequest by copying values for common members
-     * from the input #GetObjectRequest.
-     */
-    public static GetObjectMetadataRequest createGetObjectMetadataRequestFrom(GetObjectRequest getObjectRequest) {
-        return new GetObjectMetadataRequest(getObjectRequest.getBucketName(), getObjectRequest.getKey())
-                .withVersionId(getObjectRequest.getVersionId())
-                .withRequesterPays(getObjectRequest.isRequesterPays())
-                .withSSECustomerKey(getObjectRequest.getSSECustomerKey())
-                .withPartNumber(getObjectRequest.getPartNumber());
-    }
+	/**
+	 * Creates a #GetObjectMetadataRequest by copying values for common members from
+	 * the input #GetObjectRequest.
+	 */
+	public static GetObjectMetadataRequest createGetObjectMetadataRequestFrom(GetObjectRequest getObjectRequest) {
+		GetObjectMetadataRequest getObjectMetadataRequest = new GetObjectMetadataRequest(
+				getObjectRequest.getBucketName(), getObjectRequest.getKey())
+						.withVersionId(getObjectRequest.getVersionId())
+						.withRequesterPays(getObjectRequest.isRequesterPays())
+						.withSSECustomerKey(getObjectRequest.getSSECustomerKey())
+						.withPartNumber(getObjectRequest.getPartNumber());
+		if (getObjectRequest.getCustomRequestHeaders() != null) {
+			Set<String> keys = getObjectRequest.getCustomRequestHeaders().keySet();
+
+			for (Iterator<String> iterator = keys.iterator(); iterator.hasNext();) {
+				String key = iterator.next();
+				getObjectMetadataRequest.putCustomRequestHeader(key,
+						getObjectRequest.getCustomRequestHeaders().get(key));
+			}
+		}
+
+		return getObjectMetadataRequest;
+	}
+
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
@@ -32,21 +32,23 @@ import com.amazonaws.services.s3.internal.ServerSideEncryptionResult;
 import com.amazonaws.util.DateUtils;
 
 /**
- * Represents the object metadata that is stored with Amazon S3. This includes
- * custom user-supplied metadata, as well as the standard HTTP headers that
- * Amazon S3 sends and receives (Content-Length, ETag, Content-MD5, etc.).
+ * Represents the object metadata that is stored with Amazon S3. This includes custom
+ * user-supplied metadata, as well as the standard HTTP headers that Amazon S3
+ * sends and receives (Content-Length, ETag, Content-MD5, etc.).
  */
-public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterChargedResult, ObjectExpirationResult,
-		ObjectRestoreResult, Cloneable, Serializable {
+public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterChargedResult,
+		ObjectExpirationResult, ObjectRestoreResult, Cloneable, Serializable
+{
 	/*
-	 * TODO: Might be nice to get as many of the internal use only methods out of
-	 * here so users never even see them. Example: we could set the ETag header
-	 * directly through the raw metadata map instead of having a setter for it.
+	 * TODO: Might be nice to get as many of the internal use only methods out
+	 *       of here so users never even see them.
+	 *       Example: we could set the ETag header directly through the raw
+	 *                metadata map instead of having a setter for it.
 	 */
 
 	/**
-	 * Custom user metadata, represented in responses with the x-amz-meta- header
-	 * prefix
+	 * Custom user metadata, represented in responses with the x-amz-meta-
+	 * header prefix
 	 */
 	private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
@@ -56,7 +58,8 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 */
 	private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
 
-	public static final String AES_256_SERVER_SIDE_ENCRYPTION = SSEAlgorithm.AES256.getAlgorithm();
+	public static final String AES_256_SERVER_SIDE_ENCRYPTION =
+			SSEAlgorithm.AES256.getAlgorithm();
 
 	/**
 	 * The date when the object is no longer cacheable.
@@ -64,11 +67,11 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	private Date httpExpiresDate;
 
 	/**
-	 * The time this object will expire and be completely removed from S3, or null
-	 * if this object will never expire.
+	 * The time this object will expire and be completely removed from S3, or
+	 * null if this object will never expire.
 	 * <p>
-	 * This and the expiration time rule aren't stored in the metadata map because
-	 * the header contains both the time and the rule.
+	 * This and the expiration time rule aren't stored in the metadata map
+	 * because the header contains both the time and the rule.
 	 */
 	private Date expirationTime;
 
@@ -78,25 +81,28 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	private String expirationTimeRuleId;
 
 	/**
-	 * Boolean value indicating whether there is an ongoing request to restore an
-	 * archived copy of this object from Amazon Glacier.
+	 * Boolean value indicating whether there is an ongoing request to restore
+	 * an archived copy of this object from Amazon Glacier.
 	 */
 	private Boolean ongoingRestore;
 
 	/**
-	 * The time at which an object that has been temporarily restored from Glacier
-	 * will expire, and will need to be restored again in order to be accessed. Null
-	 * if this object has not been restored from Glacier.
+	 * The time at which an object that has been temporarily restored from
+	 * Glacier will expire, and will need to be restored again in order to be
+	 * accessed. Null if this object has not been restored from Glacier.
 	 */
 	private Date restoreExpirationTime;
 
-	public ObjectMetadata() {
-	}
+	public ObjectMetadata() {}
 
 	private ObjectMetadata(ObjectMetadata from) {
-		this.userMetadata = from.userMetadata == null ? null : new TreeMap<String, String>(from.userMetadata);
+		this.userMetadata = from.userMetadata == null
+				? null
+				: new TreeMap<String,String>(from.userMetadata);
 		// shallow clone the meata data
-		this.metadata = from.metadata == null ? null : new TreeMap<String, Object>(from.metadata);
+		this.metadata = from.metadata == null
+				? null
+				: new TreeMap<String, Object>(from.metadata);
 		this.expirationTime = cloneDate(from.expirationTime);
 		this.expirationTimeRuleId = from.expirationTimeRuleId;
 		this.httpExpiresDate = cloneDate(from.httpExpiresDate);
@@ -109,13 +115,13 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * Gets the custom user-metadata for the associated object.
 	 * </p>
 	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally representing
-	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
-	 * arbitrary metadata alongside their data in Amazon S3. When setting user
-	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
-	 * prefix; this library will handle that for them. Likewise, when callers
-	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
-	 * prefix.
+	 * Amazon S3 can store additional metadata on objects by internally
+	 * representing it as HTTP headers prefixed with "x-amz-meta-". Use
+	 * user-metadata to store arbitrary metadata alongside their data in Amazon
+	 * S3. When setting user metadata, callers <i>should not</i> include the
+	 * internal "x-amz-meta-" prefix; this library will handle that for them.
+	 * Likewise, when callers retrieve custom user-metadata, they will not see
+	 * the "x-amz-meta-" header prefix.
 	 * </p>
 	 * <p>
 	 * User-metadata keys are <b>case insensitive</b> and will be returned as
@@ -123,9 +129,9 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * strings.
 	 * </p>
 	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request header
-	 * limit. All HTTP headers included in a request (including user metadata
-	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * Note that user-metadata for an object is limited by the HTTP request
+	 * header limit. All HTTP headers included in a request (including user
+	 * metadata headers and other standard HTTP headers) must be less than 8KB.
 	 * </p>
 	 *
 	 * @return The custom user metadata for the associated object.
@@ -142,13 +148,13 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * Sets the custom user-metadata for the associated object.
 	 * </p>
 	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally representing
-	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
-	 * arbitrary metadata alongside their data in Amazon S3. When setting user
-	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
-	 * prefix; this library will handle that for them. Likewise, when callers
-	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
-	 * prefix.
+	 * Amazon S3 can store additional metadata on objects by internally
+	 * representing it as HTTP headers prefixed with "x-amz-meta-". Use
+	 * user-metadata to store arbitrary metadata alongside their data in Amazon
+	 * S3. When setting user metadata, callers <i>should not</i> include the
+	 * internal "x-amz-meta-" prefix; this library will handle that for them.
+	 * Likewise, when callers retrieve custom user-metadata, they will not see
+	 * the "x-amz-meta-" header prefix.
 	 * </p>
 	 * <p>
 	 * User-metadata keys are <b>case insensitive</b> and will be returned as
@@ -156,14 +162,14 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * strings.
 	 * </p>
 	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request header
-	 * limit. All HTTP headers included in a request (including user metadata
-	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * Note that user-metadata for an object is limited by the HTTP request
+	 * header limit. All HTTP headers included in a request (including user
+	 * metadata headers and other standard HTTP headers) must be less than 8KB.
 	 * </p>
 	 *
 	 * @param userMetadata
-	 *            The custom user-metadata for the associated object. Note that the
-	 *            key should not include the internal S3 HTTP header prefix.
+	 *            The custom user-metadata for the associated object. Note that
+	 *            the key should not include the internal S3 HTTP header prefix.
 	 * @see ObjectMetadata#getUserMetadata()
 	 * @see ObjectMetadata#addUserMetadata(String, String)
 	 */
@@ -172,8 +178,8 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-	 * For internal use only. Sets a specific metadata header value. Not intended to
-	 * be called by external code.
+	 * For internal use only. Sets a specific metadata header value. Not
+	 * intended to be called by external code.
 	 *
 	 * @param key
 	 *            The name of the header being set.
@@ -186,28 +192,29 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-	 * Adds the key value pair of custom user-metadata for the associated object. If
-	 * the entry in the custom user-metadata map already contains the specified key,
-	 * it will be replaced with these new contents.
+	 * Adds the key value pair of custom user-metadata for the associated
+	 * object. If the entry in the custom user-metadata map already contains the
+	 * specified key, it will be replaced with these new contents.
 	 * </p>
 	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally representing
-	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
-	 * arbitrary metadata alongside their data in Amazon S3. When setting user
-	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
-	 * prefix; this library will handle that for them. Likewise, when callers
-	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
-	 * prefix.
+	 * Amazon S3 can store additional metadata on objects by internally
+	 * representing it as HTTP headers prefixed with "x-amz-meta-".
+	 * Use user-metadata to store arbitrary metadata alongside their data in
+	 * Amazon S3. When setting user metadata, callers <i>should not</i> include
+	 * the internal "x-amz-meta-" prefix; this library will handle that for
+	 * them. Likewise, when callers retrieve custom user-metadata, they will not
+	 * see the "x-amz-meta-" header prefix.
 	 * </p>
 	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request header
-	 * limit. All HTTP headers included in a request (including user metadata
-	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * Note that user-metadata for an object is limited by the HTTP request
+	 * header limit. All HTTP headers included in a request (including user
+	 * metadata headers and other standard HTTP headers) must be less than 8KB.
 	 * </p>
 	 *
 	 * @param key
 	 *            The key for the custom user metadata entry. Note that the key
-	 *            should not include the internal S3 HTTP header prefix.
+	 *            should not include
+	 *            the internal S3 HTTP header prefix.
 	 * @param value
 	 *            The value for the custom user-metadata entry.
 	 *
@@ -224,7 +231,7 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * @return A map of the raw metadata/headers for the associated object.
 	 */
 	public Map<String, Object> getRawMetadata() {
-		Map<String, Object> copy = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
+		Map<String,Object> copy = new TreeMap<String,Object>(String.CASE_INSENSITIVE_ORDER);
 		copy.putAll(metadata);
 		return Collections.unmodifiableMap(copy);
 	}
@@ -237,24 +244,25 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-	 * Gets the value of the Last-Modified header, indicating the date and time at
-	 * which Amazon S3 last recorded a modification to the associated object.
+	 * Gets the value of the Last-Modified header, indicating the date
+	 * and time at which Amazon S3 last recorded a modification to the
+	 * associated object.
 	 *
-	 * @return The date and time at which Amazon S3 last recorded a modification to
-	 *         the associated object.
+	 * @return The date and time at which Amazon S3 last recorded a modification
+	 *         to the associated object.
 	 */
 	public Date getLastModified() {
-		return cloneDate((Date) metadata.get(Headers.LAST_MODIFIED));
+		return cloneDate((Date)metadata.get(Headers.LAST_MODIFIED));
 	}
 
 	/**
-	 * For internal use only. Sets the Last-Modified header value indicating the
-	 * date and time at which Amazon S3 last recorded a modification to the
-	 * associated object.
+	 * For internal use only. Sets the Last-Modified header value
+	 * indicating the date and time at which Amazon S3 last recorded a
+	 * modification to the associated object.
 	 *
 	 * @param lastModified
-	 *            The date and time at which Amazon S3 last recorded a modification
-	 *            to the associated object.
+	 *            The date and time at which Amazon S3 last recorded a
+	 *            modification to the associated object.
 	 */
 	public void setLastModified(Date lastModified) {
 		metadata.put(Headers.LAST_MODIFIED, lastModified);
@@ -262,72 +270,71 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the Content-Length HTTP header indicating the size of the
-     * associated object in bytes.
+	 * Gets the Content-Length HTTP header indicating the size of the
+	 * associated object in bytes.
 	 * </p>
 	 * <p>
 	 * This field is required when uploading objects to S3, but the AWS S3 Java
 	 * client will automatically set it when working directly with files. When
-     * uploading directly from a stream, set this field if
-     * possible. Otherwise the client must buffer the entire stream in
-     * order to calculate the content length before sending the data to
-     * Amazon S3.
+	 * uploading directly from a stream, set this field if
+	 * possible. Otherwise the client must buffer the entire stream in
+	 * order to calculate the content length before sending the data to
+	 * Amazon S3.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Length HTTP header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
+	 * For more information on the Content-Length HTTP header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
 	 * </p>
 	 *
-     * @return The Content-Length HTTP header indicating the size of the
-     *         associated object in bytes. Returns <code>null</code>
-     *         if it hasn't been set yet.
+	 * @return The Content-Length HTTP header indicating the size of the
+	 *         associated object in bytes. Returns <code>null</code>
+	 *         if it hasn't been set yet.
 	 *
 	 * @see ObjectMetadata#setContentLength(long)
 	 */
 	public long getContentLength() {
-		Long contentLength = (Long) metadata.get(Headers.CONTENT_LENGTH);
+		Long contentLength = (Long)metadata.get(Headers.CONTENT_LENGTH);
 		if (metadata.containsKey(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)) {
 			contentLength = Long.valueOf(String.valueOf(metadata.get(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)));
 		}
 
-		if (contentLength == null)
-			return 0;
+		if (contentLength == null) return 0;
 		return contentLength.longValue();
 	}
 
 	/**
-     * Returns the physical length of the entire object stored in S3.
-     * This is useful during, for example, a range get operation.
+	 * Returns the physical length of the entire object stored in S3.
+	 * This is useful during, for example, a range get operation.
 	 */
 	public long getInstanceLength() {
 		// See Content-Range in
 		// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-		String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
+		String contentRange = (String)metadata.get(Headers.CONTENT_RANGE);
 		if (contentRange != null) {
 			int pos = contentRange.lastIndexOf("/");
 			if (pos >= 0)
-				return Long.parseLong(contentRange.substring(pos + 1));
+				return Long.parseLong(contentRange.substring(pos+1));
 		}
 		return getContentLength();
 	}
 
 	/**
 	 * <p>
-     * Sets the Content-Length HTTP header indicating the size of the
-     * associated object in bytes.
+	 * Sets the Content-Length HTTP header indicating the size of the
+	 * associated object in bytes.
 	 * </p>
 	 * <p>
 	 * This field is required when uploading objects to S3, but the AWS S3 Java
 	 * client will automatically set it when working directly with files. When
-     * uploading directly from a stream, set this field if
-     * possible. Otherwise the client must buffer the entire stream in
-     * order to calculate the content length before sending the data to
-     * Amazon S3.
+	 * uploading directly from a stream, set this field if
+	 * possible. Otherwise the client must buffer the entire stream in
+	 * order to calculate the content length before sending the data to
+	 * Amazon S3.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Length HTTP header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
+	 * For more information on the Content-Length HTTP header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
 	 * </p>
 	 *
@@ -343,58 +350,58 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the Content-Type HTTP header, which indicates the type of content
-     * stored in the associated object. The value of this header is a standard
-     * MIME type.
+	 * Gets the Content-Type HTTP header, which indicates the type of content
+	 * stored in the associated object. The value of this header is a standard
+	 * MIME type.
 	 * </p>
 	 * <p>
-     * When uploading files, the AWS S3 Java client will attempt to determine
-     * the correct content type if one hasn't been set yet. Users are
-     * responsible for ensuring a suitable content type is set when uploading
-     * streams. If no content type is provided and cannot be determined by
-     * the filename, the default content type, "application/octet-stream", will
-     * be used.
+	 * When uploading files, the AWS S3 Java client will attempt to determine
+	 * the correct content type if one hasn't been set yet. Users are
+	 * responsible for ensuring a suitable content type is set when uploading
+	 * streams. If no content type is provided and cannot be determined by
+	 * the filename, the default content type, "application/octet-stream", will
+	 * be used.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Type header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+	 * For more information on the Content-Type header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
 	 * </p>
 	 *
-     * @return The HTTP Content-Type header, indicating the type of content
-     *         stored in the associated S3 object. Returns <code>null</code>
-     *         if it hasn't been
-     *         set.
+	 * @return The HTTP Content-Type header, indicating the type of content
+	 *         stored in the associated S3 object. Returns <code>null</code>
+	 *         if it hasn't been
+	 *         set.
 	 *
 	 * @see ObjectMetadata#setContentType(String)
 	 */
 	public String getContentType() {
-		return (String) metadata.get(Headers.CONTENT_TYPE);
+		return (String)metadata.get(Headers.CONTENT_TYPE);
 	}
 
 	/**
 	 * <p>
-     * Sets the Content-Type HTTP header indicating the type of content
-     * stored in the associated object. The value of this header is a standard
-     * MIME type.
+	 * Sets the Content-Type HTTP header indicating the type of content
+	 * stored in the associated object. The value of this header is a standard
+	 * MIME type.
 	 * </p>
 	 * <p>
-     * When uploading files, the AWS S3 Java client will attempt to determine
-     * the correct content type if one hasn't been set yet. Users are
-     * responsible for ensuring a suitable content type is set when uploading
-     * streams. If no content type is provided and cannot be determined by
-     * the filename, the default content type "application/octet-stream" will
-     * be used.
+	 * When uploading files, the AWS S3 Java client will attempt to determine
+	 * the correct content type if one hasn't been set yet. Users are
+	 * responsible for ensuring a suitable content type is set when uploading
+	 * streams. If no content type is provided and cannot be determined by
+	 * the filename, the default content type "application/octet-stream" will
+	 * be used.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Type header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+	 * For more information on the Content-Type header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
 	 * </p>
 	 *
 	 * @param contentType
-     *            The HTTP Content-Type header indicating the type of content
-     *            stored in the associated S3 object.
+	 *            The HTTP Content-Type header indicating the type of content
+	 *            stored in the associated S3 object.
 	 *
 	 * @see ObjectMetadata#getContentType()
 	 */
@@ -404,39 +411,39 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the Content-Language HTTP header, which describes the natural language(s) of the
-     * intended audience for the enclosed entity.
+	 * Gets the Content-Language HTTP header, which describes the natural language(s) of the
+	 * intended audience for the enclosed entity.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Type header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+	 * For more information on the Content-Type header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
 	 * </p>
 	 *
-     * @return The HTTP Content-Language header, which describes the natural language(s) of the
-     * intended audience for the enclosed entity. Returns <code>null</code>
-     *         if it hasn't been set.
+	 * @return The HTTP Content-Language header, which describes the natural language(s) of the
+	 * intended audience for the enclosed entity. Returns <code>null</code>
+	 *         if it hasn't been set.
 	 *
 	 * @see ObjectMetadata#setContentLanguage(String)
 	 */
 	public String getContentLanguage() {
-		return (String) metadata.get(Headers.CONTENT_LANGUAGE);
+		return (String)metadata.get(Headers.CONTENT_LANGUAGE);
 	}
 
 	/**
 	 * <p>
-     * Sets the Content-Language HTTP header which describes the natural language(s) of the
-     * intended audience for the enclosed entity.
+	 * Sets the Content-Language HTTP header which describes the natural language(s) of the
+	 * intended audience for the enclosed entity.
 	 * </p>
 	 * <p>
-     * For more information on the Content-Type header, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+	 * For more information on the Content-Type header, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
 	 * </p>
 	 *
 	 * @param contentLanguage
-     *            The HTTP Content-Language header which describes the natural language(s) of the
-     * intended audience for the enclosed entity.
+	 *            The HTTP Content-Language header which describes the natural language(s) of the
+	 * intended audience for the enclosed entity.
 	 *
 	 * @see ObjectMetadata#getContentLanguage()
 	 */
@@ -446,46 +453,46 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the optional Content-Encoding HTTP header specifying what
-     * content encodings have been applied to the object and what decoding
-     * mechanisms must be applied in order to obtain the media-type referenced
-     * by the Content-Type field.
+	 * Gets the optional Content-Encoding HTTP header specifying what
+	 * content encodings have been applied to the object and what decoding
+	 * mechanisms must be applied in order to obtain the media-type referenced
+	 * by the Content-Type field.
 	 * </p>
 	 * <p>
 	 * For more information on how the Content-Encoding HTTP header works, see
-     * <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
+	 * <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
 	 * </p>
 	 *
-     * @return The HTTP Content-Encoding header.
-     * Returns <code>null</code> if it hasn't been set.
+	 * @return The HTTP Content-Encoding header.
+	 * Returns <code>null</code> if it hasn't been set.
 	 *
 	 * @see ObjectMetadata#setContentEncoding(String)
 	 */
 	public String getContentEncoding() {
-		return (String) metadata.get(Headers.CONTENT_ENCODING);
+		return (String)metadata.get(Headers.CONTENT_ENCODING);
 	}
 
 	/**
 	 * <p>
-     * Sets the optional Content-Encoding HTTP header specifying what
-     * content encodings have been applied to the object and what decoding
-     * mechanisms must be applied in order to obtain the media-type referenced
-     * by the Content-Type field.
+	 * Sets the optional Content-Encoding HTTP header specifying what
+	 * content encodings have been applied to the object and what decoding
+	 * mechanisms must be applied in order to obtain the media-type referenced
+	 * by the Content-Type field.
 	 * </p>
 	 * <p>
 	 * For more information on how the Content-Encoding HTTP header works, see
-     * <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
+	 * <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
 	 * </p>
 	 *
 	 * @param encoding
 	 *            The HTTP Content-Encoding header, as defined in RFC 2616.
 	 *
-     * @see <a
-     *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11"
+	 * @see <a
+	 *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11"
 	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
 	 *
 	 * @see ObjectMetadata#getContentEncoding()
@@ -496,35 +503,35 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the optional Cache-Control HTTP header which allows the user to
-     * specify caching behavior along the HTTP request/reply chain.
+	 * Gets the optional Cache-Control HTTP header which allows the user to
+	 * specify caching behavior along the HTTP request/reply chain.
 	 * </p>
 	 * <p>
 	 * For more information on how the Cache-Control HTTP header affects HTTP
-     * requests and responses, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
+	 * requests and responses, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
 	 * </p>
 	 *
-     * @return The HTTP Cache-Control header as defined in RFC 2616.
-     *         Returns <code>null</code>  if
-     *         it hasn't been set.
+	 * @return The HTTP Cache-Control header as defined in RFC 2616.
+	 *         Returns <code>null</code>  if
+	 *         it hasn't been set.
 	 *
 	 * @see ObjectMetadata#setCacheControl(String)
 	 */
 	public String getCacheControl() {
-		return (String) metadata.get(Headers.CACHE_CONTROL);
+		return (String)metadata.get(Headers.CACHE_CONTROL);
 	}
 
 	/**
 	 * <p>
-     * Sets the optional Cache-Control HTTP header which allows the user to
-     * specify caching behavior along the HTTP request/reply chain.
+	 * Sets the optional Cache-Control HTTP header which allows the user to
+	 * specify caching behavior along the HTTP request/reply chain.
 	 * </p>
 	 * <p>
 	 * For more information on how the Cache-Control HTTP header affects HTTP
-     * requests and responses see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
+	 * requests and responses see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
 	 * </p>
 	 *
@@ -539,17 +546,17 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Sets the base64 encoded 128-bit MD5 digest of the associated object
-     * (content - not including headers) according to RFC 1864. This data is
-     * used as a message integrity check to verify that the data received by
-     * Amazon S3 is the same data that the caller sent. If set to null,then the
-     * MD5 digest is removed from the metadata.
+	 * Sets the base64 encoded 128-bit MD5 digest of the associated object
+	 * (content - not including headers) according to RFC 1864. This data is
+	 * used as a message integrity check to verify that the data received by
+	 * Amazon S3 is the same data that the caller sent. If set to null,then the
+	 * MD5 digest is removed from the metadata.
 	 * </p>
 	 * <p>
 	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
-     * object's content as calculated on the caller's side. The ETag metadata
-     * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
-     * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
+	 * object's content as calculated on the caller's side. The ETag metadata
+	 * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
+	 * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
 	 * </p>
 	 * <p>
 	 * The AWS S3 Java client will attempt to calculate this field automatically
@@ -563,9 +570,9 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * @see ObjectMetadata#getContentMD5()
 	 */
 	public void setContentMD5(String md5Base64) {
-		if (md5Base64 == null) {
+		if(md5Base64 == null){
 			metadata.remove(Headers.CONTENT_MD5);
-		} else {
+		}else{
 			metadata.put(Headers.CONTENT_MD5, md5Base64);
 		}
 
@@ -573,42 +580,42 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Gets the base64 encoded 128-bit MD5 digest of the associated object
-     * (content - not including headers) according to RFC 1864. This data is
-     * used as a message integrity check to verify that the data received by
-     * Amazon S3 is the same data that the caller sent.
+	 * Gets the base64 encoded 128-bit MD5 digest of the associated object
+	 * (content - not including headers) according to RFC 1864. This data is
+	 * used as a message integrity check to verify that the data received by
+	 * Amazon S3 is the same data that the caller sent.
 	 * </p>
 	 * <p>
 	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
-     * object's content as calculated on the caller's side. The ETag metadata
-     * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
-     * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
+	 * object's content as calculated on the caller's side. The ETag metadata
+	 * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
+	 * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
 	 * </p>
 	 * <p>
 	 * The AWS S3 Java client will attempt to calculate this field automatically
 	 * when uploading files to Amazon S3.
 	 * </p>
 	 *
-     * @return The base64 encoded MD5 hash of the content for the associated
-     *         object.  Returns <code>null</code> if the MD5 hash of the content
-     *         hasn't been set.
+	 * @return The base64 encoded MD5 hash of the content for the associated
+	 *         object.  Returns <code>null</code> if the MD5 hash of the content
+	 *         hasn't been set.
 	 *
 	 * @see ObjectMetadata#setContentMD5(String)
 	 */
 	public String getContentMD5() {
-		return (String) metadata.get(Headers.CONTENT_MD5);
+		return (String)metadata.get(Headers.CONTENT_MD5);
 	}
 
 	/**
 	 * <p>
 	 * Sets the optional Content-Disposition HTTP header, which specifies
-     * presentational information such as the recommended filename for the
-     * object to be saved as.
+	 * presentational information such as the recommended filename for the
+	 * object to be saved as.
 	 * </p>
 	 * <p>
 	 * For more information on how the Content-Disposition header affects HTTP
-     * client behavior, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
+	 * client behavior, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
 	 * </p>
 	 *
@@ -624,73 +631,73 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	/**
 	 * <p>
 	 * Gets the optional Content-Disposition HTTP header, which specifies
-     * presentation information for the object such as the recommended filename
-     * for the object to be saved as.
+	 * presentation information for the object such as the recommended filename
+	 * for the object to be saved as.
 	 * </p>
 	 * <p>
 	 * For more information on how the Content-Disposition header affects HTTP
-     * client behavior, see <a
-     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
+	 * client behavior, see <a
+	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
 	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
 	 * </p>
 	 *
-     * @return The value of the Content-Disposition header.
-     *         Returns <code>null</code> if the Content-Disposition header
-     *         hasn't been set.
+	 * @return The value of the Content-Disposition header.
+	 *         Returns <code>null</code> if the Content-Disposition header
+	 *         hasn't been set.
 	 *
-     * @see <a
-     *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1"
+	 * @see <a
+	 *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1"
 	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
 	 *
 	 * @see ObjectMetadata#setCacheControl(String)
 	 */
 	public String getContentDisposition() {
-		return (String) metadata.get(Headers.CONTENT_DISPOSITION);
+		return (String)metadata.get(Headers.CONTENT_DISPOSITION);
 	}
 
 	/**
-     * The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata.
-     * The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created
-     * and how it is encrypted as described below:
+	 * The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata.
+	 * The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created
+	 * and how it is encrypted as described below:
 	 * <ul>
-     * <li>
-     * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
-     * by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object data.
-     * </li>
-     * <li>
-     * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
-     * by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object data.
-     * </li>
-     * <li>
-     * If an object is created by either the Multipart Upload or Part Copy operation, the ETag is not an MD5 digest, regardless of
-     * the method of encryption.
-     * </li>
+	 * <li>
+	 * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
+	 * by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object data.
+	 * </li>
+	 * <li>
+	 * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
+	 * by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object data.
+	 * </li>
+	 * <li>
+	 * If an object is created by either the Multipart Upload or Part Copy operation, the ETag is not an MD5 digest, regardless of
+	 * the method of encryption.
+	 * </li>
 	 * </ul>
 	 *
 	 * @return The ETag of the object or <code>null</code>if it hasn't been set yet.
 	 */
 	public String getETag() {
-		return (String) metadata.get(Headers.ETAG);
+		return (String)metadata.get(Headers.ETAG);
 	}
 
 	/**
-     * Gets the version ID of the associated Amazon S3 object if available.
-     * Version IDs are only assigned to objects when an object is uploaded to an
-     * Amazon S3 bucket that has object versioning enabled.
+	 * Gets the version ID of the associated Amazon S3 object if available.
+	 * Version IDs are only assigned to objects when an object is uploaded to an
+	 * Amazon S3 bucket that has object versioning enabled.
 	 *
 	 * @return The version ID of the associated Amazon S3 object if available.
 	 */
 	public String getVersionId() {
-		return (String) metadata.get(Headers.S3_VERSION_ID);
+		return (String)metadata.get(Headers.S3_VERSION_ID);
 	}
 
 	/**
-     * Returns the server-side encryption algorithm when encrypting the object
-     * using AWS-managed keys .
+	 * Returns the server-side encryption algorithm when encrypting the object
+	 * using AWS-managed keys .
 	 */
 	@Override
 	public String getSSEAlgorithm() {
-		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
 	}
 
 	/**
@@ -698,21 +705,22 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 */
 	@Deprecated
 	public String getServerSideEncryption() {
-		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
 	}
 
 	/**
-     * Sets the server-side encryption algorithm when encrypting the object
-	 *            using AWS-managed keys .
-     *
-     * @param algorithm
-     *            The server-side encryption algorithm when encrypting the
-     *            object using AWS-managed keys .
+	 * Sets the server-side encryption algorithm when encrypting the object
+	 * using AWS-managed keys.
+	 *
+	 * @param algorithm
+	 *            The server-side encryption algorithm when encrypting the
+	 *            object using AWS-managed keys .
 	 */
 	@Override
 	public void setSSEAlgorithm(String algorithm) {
 		metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
 	}
+
 
 	/**
 	 * @deprecated Replaced by {@link #setSSEAlgorithm(String)}
@@ -745,7 +753,7 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 */
 	@Override
 	public String getSSECustomerKeyMd5() {
-		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
+		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
 	}
 
 	/**
@@ -758,17 +766,17 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * Returns the time this object will expire and be completely removed from
-     * S3. Returns null if this object will never expire.
+	 * Returns the time this object will expire and be completely removed from
+	 * S3. Returns null if this object will never expire.
 	 */
 	public Date getExpirationTime() {
 		return cloneDate(expirationTime);
 	}
 
 	/**
-     * For internal use only. This will *not* set the object's expiration time,
-     * and is only used to set the value in the object after receiving the value
-     * in a response from S3.
+	 * For internal use only. This will *not* set the object's expiration time,
+	 * and is only used to set the value in the object after receiving the value
+	 * in a response from S3.
 	 *
 	 * @param expirationTime
 	 *            The expiration time for the object.
@@ -778,36 +786,37 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * Returns the {@link BucketLifecycleConfiguration} rule ID for this
-     * object's expiration, or null if it doesn't expire.
+	 * Returns the {@link BucketLifecycleConfiguration} rule ID for this
+	 * object's expiration, or null if it doesn't expire.
 	 */
 	public String getExpirationTimeRuleId() {
 		return expirationTimeRuleId;
 	}
 
 	/**
-     * For internal use only. This will *not* set the object's expiration time
-     * rule id, and is only used to set the value in the object after receiving
-     * the value in a response from S3.
+	 * For internal use only. This will *not* set the object's expiration time
+	 * rule id, and is only used to set the value in the object after receiving
+	 * the value in a response from S3.
 	 */
 	public void setExpirationTimeRuleId(String expirationTimeRuleId) {
 		this.expirationTimeRuleId = expirationTimeRuleId;
 	}
 
+
 	/**
-     * Returns the time at which an object that has been temporarily restored
-     * from Amazon Glacier will expire, and will need to be restored again in
-     * order to be accessed. Returns null if this is not a temporary copy of an
-     * object restored from Glacier.
+	 * Returns the time at which an object that has been temporarily restored
+	 * from Amazon Glacier will expire, and will need to be restored again in
+	 * order to be accessed. Returns null if this is not a temporary copy of an
+	 * object restored from Glacier.
 	 */
 	public Date getRestoreExpirationTime() {
 		return cloneDate(restoreExpirationTime);
 	}
 
 	/**
-     * For internal use only. This will *not* set the object's restore
-     * expiration time, and is only used to set the value in the object after
-     * receiving the value in a response from S3.
+	 * For internal use only. This will *not* set the object's restore
+	 * expiration time, and is only used to set the value in the object after
+	 * receiving the value in a response from S3.
 	 *
 	 * @param restoreExpirationTime
 	 *            The new restore expiration time for the object.
@@ -817,23 +826,24 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * For internal use only. Sets the boolean value which indicates whether
-     * there is ongoing restore request. Not intended to be called by external
-     * code.
+	 * For internal use only. Sets the boolean value which indicates whether
+	 * there is ongoing restore request. Not intended to be called by external
+	 * code.
 	 */
 	public void setOngoingRestore(boolean ongoingRestore) {
 		this.ongoingRestore = Boolean.valueOf(ongoingRestore);
 	}
 
+
 	/**
-     *  Returns the boolean value which indicates whether there is ongoing restore request.
+	 *  Returns the boolean value which indicates whether there is ongoing restore request.
 	 */
 	public Boolean getOngoingRestore() {
 		return this.ongoingRestore;
 	}
 
 	/**
-	 * Set the date when the object is no longer cacheable.
+	 *  Set the date when the object is no longer cacheable.
 	 */
 	public void setHttpExpiresDate(Date httpExpiresDate) {
 		this.httpExpiresDate = httpExpiresDate;
@@ -847,8 +857,8 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * @return The storage class of the object. Returns null if the object is in STANDARD storage.
-     *         See {@link StorageClass} for possible values
+	 * @return The storage class of the object. Returns null if the object is in STANDARD storage.
+	 *         See {@link StorageClass} for possible values
 	 */
 	public String getStorageClass() {
 		final Object storageClass = metadata.get(Headers.STORAGE_CLASS);
@@ -866,21 +876,22 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * Returns a clone of this <code>ObjectMetadata</code>. Note the clone of
-     * the internal {@link #metadata} is limited to a shallow copy due to the
-     * unlimited type of value in the map. Other fields can be regarded as deep
-     * clone.
+	 * Returns a clone of this <code>ObjectMetadata</code>. Note the clone of
+	 * the internal {@link #metadata} is limited to a shallow copy due to the
+	 * unlimited type of value in the map. Other fields can be regarded as deep
+	 * clone.
 	 */
 	public ObjectMetadata clone() {
 		return new ObjectMetadata(this);
 	}
 
 	/**
-     * Returns the AWS Key Management System key id used for Server Side
-     * Encryption of the Amazon S3 object.
+	 * Returns the AWS Key Management System key id used for Server Side
+	 * Encryption of the Amazon S3 object.
 	 */
 	public String getSSEAwsKmsKeyId() {
-		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
+		return (String) metadata
+				.get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
 	}
 
 	@Override
@@ -900,13 +911,13 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	 * Returns the value of x-amz-mp-parts-count header.
 	 * </p>
 	 * <p>
-     * The x-amz-mp-parts-count header is returned in the response only when
-     * a valid partNumber is specified in the request and the object has more than 1 part.
+	 * The x-amz-mp-parts-count header is returned in the response only when
+	 * a valid partNumber is specified in the request and the object has more than 1 part.
 	 * </p>
 	 * <p>
-     * To find the part count of an object, set the partNumber to 1 in GetObjectRequest.
-     * If the object has more than 1 part then part count will be returned,
-     * otherwise null is returned.
+	 * To find the part count of an object, set the partNumber to 1 in GetObjectRequest.
+	 * If the object has more than 1 part then part count will be returned,
+	 * otherwise null is returned.
 	 * </p>
 	 */
 	public Integer getPartCount() {
@@ -915,15 +926,15 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 
 	/**
 	 * <p>
-     * Returns the content range of the object if response contains the Content-Range header.
+	 * Returns the content range of the object if response contains the Content-Range header.
 	 * </p>
 	 * <p>
-     * If the request specifies a range or part number, then response returns the Content-Range range header.
-     * Otherwise, the response does not return Content-Range header.
+	 * If the request specifies a range or part number, then response returns the Content-Range range header.
+	 * Otherwise, the response does not return Content-Range header.
 	 * </p>
-     * @return
-     * 		Returns content range if the object is requested with specific range or part number,
-     * 		null otherwise.
+	 * @return
+	 * 		Returns content range if the object is requested with specific range or part number,
+	 * 		null otherwise.
 	 */
 	public Long[] getContentRange() {
 		String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
@@ -942,35 +953,35 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
 	}
 
 	/**
-     * @return The replication status of the object if it is from a bucket that
-     * is the source or destination in a cross-region replication.
+	 * @return The replication status of the object if it is from a bucket that
+	 * is the source or destination in a cross-region replication.
 	 */
 	public String getReplicationStatus() {
 		return (String) metadata.get(Headers.OBJECT_REPLICATION_STATUS);
 	}
 
-    /**
-     * The Object Lock mode applied to this object.
-     */
-    public String getObjectLockMode() {
-        return (String) metadata.get(Headers.OBJECT_LOCK_MODE);
-    }
+	/**
+	 * The Object Lock mode applied to this object.
+	 */
+	public String getObjectLockMode() {
+		return (String) metadata.get(Headers.OBJECT_LOCK_MODE);
+	}
 
-    /**
-     * The date and time this object's Object Lock will expire.
-     */
-    public Date getObjectLockRetainUntilDate() {
-        String dateStr = (String) metadata.get(Headers.OBJECT_LOCK_RETAIN_UNTIL_DATE);
-        if (dateStr != null) {
-            return DateUtils.parseISO8601Date(dateStr);
-        }
-        return null;
-    }
+	/**
+	 * The date and time this object's Object Lock will expire.
+	 */
+	public Date getObjectLockRetainUntilDate() {
+		String dateStr = (String) metadata.get(Headers.OBJECT_LOCK_RETAIN_UNTIL_DATE);
+		if (dateStr != null) {
+			return DateUtils.parseISO8601Date(dateStr);
+		}
+		return null;
+	}
 
-    /**
-     * The Legal Hold status of the specified object.
-     */
-    public String getObjectLockLegalHoldStatus() {
-        return (String) metadata.get(Headers.OBJECT_LOCK_LEGAL_HOLD_STATUS);
-    }
+	/**
+	 * The Legal Hold status of the specified object.
+	 */
+	public String getObjectLockLegalHoldStatus() {
+		return (String) metadata.get(Headers.OBJECT_LOCK_LEGAL_HOLD_STATUS);
+	}
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
@@ -37,951 +37,950 @@ import com.amazonaws.util.DateUtils;
  * sends and receives (Content-Length, ETag, Content-MD5, etc.).
  */
 public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterChargedResult,
-		ObjectExpirationResult, ObjectRestoreResult, Cloneable, Serializable
+        ObjectExpirationResult, ObjectRestoreResult, Cloneable, Serializable
 {
-	/*
-	 * TODO: Might be nice to get as many of the internal use only methods out
-	 *       of here so users never even see them.
-	 *       Example: we could set the ETag header directly through the raw
-	 *                metadata map instead of having a setter for it.
-	 */
-
-	/**
-	 * Custom user metadata, represented in responses with the x-amz-meta-
-	 * header prefix
-	 */
-	private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
-
-	/**
-	 * All other (non user custom) headers such as Content-Length, Content-Type,
-	 * etc.
-	 */
-	private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
-
-	public static final String AES_256_SERVER_SIDE_ENCRYPTION =
-			SSEAlgorithm.AES256.getAlgorithm();
-
-	/**
-	 * The date when the object is no longer cacheable.
-	 */
-	private Date httpExpiresDate;
-
-	/**
-	 * The time this object will expire and be completely removed from S3, or
-	 * null if this object will never expire.
-	 * <p>
-	 * This and the expiration time rule aren't stored in the metadata map
-	 * because the header contains both the time and the rule.
-	 */
-	private Date expirationTime;
-
-	/**
-	 * The expiration rule id for this object.
-	 */
-	private String expirationTimeRuleId;
-
-	/**
-	 * Boolean value indicating whether there is an ongoing request to restore
-	 * an archived copy of this object from Amazon Glacier.
-	 */
-	private Boolean ongoingRestore;
-
-	/**
-	 * The time at which an object that has been temporarily restored from
-	 * Glacier will expire, and will need to be restored again in order to be
-	 * accessed. Null if this object has not been restored from Glacier.
-	 */
-	private Date restoreExpirationTime;
-
-	public ObjectMetadata() {}
-
-	private ObjectMetadata(ObjectMetadata from) {
-		this.userMetadata = from.userMetadata == null
-				? null
-				: new TreeMap<String,String>(from.userMetadata);
-		// shallow clone the meata data
-		this.metadata = from.metadata == null
-				? null
-				: new TreeMap<String, Object>(from.metadata);
-		this.expirationTime = cloneDate(from.expirationTime);
-		this.expirationTimeRuleId = from.expirationTimeRuleId;
-		this.httpExpiresDate = cloneDate(from.httpExpiresDate);
-		this.ongoingRestore = from.ongoingRestore;
-		this.restoreExpirationTime = cloneDate(from.restoreExpirationTime);
-	}
-
-	/**
-	 * <p>
-	 * Gets the custom user-metadata for the associated object.
-	 * </p>
-	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally
-	 * representing it as HTTP headers prefixed with "x-amz-meta-". Use
-	 * user-metadata to store arbitrary metadata alongside their data in Amazon
-	 * S3. When setting user metadata, callers <i>should not</i> include the
-	 * internal "x-amz-meta-" prefix; this library will handle that for them.
-	 * Likewise, when callers retrieve custom user-metadata, they will not see
-	 * the "x-amz-meta-" header prefix.
-	 * </p>
-	 * <p>
-	 * User-metadata keys are <b>case insensitive</b> and will be returned as
-	 * lowercase strings, even if they were originally specified with uppercase
-	 * strings.
-	 * </p>
-	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request
-	 * header limit. All HTTP headers included in a request (including user
-	 * metadata headers and other standard HTTP headers) must be less than 8KB.
-	 * </p>
-	 *
-	 * @return The custom user metadata for the associated object.
-	 *
-	 * @see ObjectMetadata#setUserMetadata(Map)
-	 * @see ObjectMetadata#addUserMetadata(String, String)
-	 */
-	public Map<String, String> getUserMetadata() {
-		return userMetadata;
-	}
-
-	/**
-	 * <p>
-	 * Sets the custom user-metadata for the associated object.
-	 * </p>
-	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally
-	 * representing it as HTTP headers prefixed with "x-amz-meta-". Use
-	 * user-metadata to store arbitrary metadata alongside their data in Amazon
-	 * S3. When setting user metadata, callers <i>should not</i> include the
-	 * internal "x-amz-meta-" prefix; this library will handle that for them.
-	 * Likewise, when callers retrieve custom user-metadata, they will not see
-	 * the "x-amz-meta-" header prefix.
-	 * </p>
-	 * <p>
-	 * User-metadata keys are <b>case insensitive</b> and will be returned as
-	 * lowercase strings, even if they were originally specified with uppercase
-	 * strings.
-	 * </p>
-	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request
-	 * header limit. All HTTP headers included in a request (including user
-	 * metadata headers and other standard HTTP headers) must be less than 8KB.
-	 * </p>
-	 *
-	 * @param userMetadata
-	 *            The custom user-metadata for the associated object. Note that
-	 *            the key should not include the internal S3 HTTP header prefix.
-	 * @see ObjectMetadata#getUserMetadata()
-	 * @see ObjectMetadata#addUserMetadata(String, String)
-	 */
-	public void setUserMetadata(Map<String, String> userMetadata) {
-		this.userMetadata = userMetadata;
-	}
-
-	/**
-	 * For internal use only. Sets a specific metadata header value. Not
-	 * intended to be called by external code.
-	 *
-	 * @param key
-	 *            The name of the header being set.
-	 * @param value
-	 *            The value for the header.
-	 */
-	public void setHeader(String key, Object value) {
-		metadata.put(key, value);
-	}
-
-	/**
-	 * <p>
-	 * Adds the key value pair of custom user-metadata for the associated
-	 * object. If the entry in the custom user-metadata map already contains the
-	 * specified key, it will be replaced with these new contents.
-	 * </p>
-	 * <p>
-	 * Amazon S3 can store additional metadata on objects by internally
-	 * representing it as HTTP headers prefixed with "x-amz-meta-".
-	 * Use user-metadata to store arbitrary metadata alongside their data in
-	 * Amazon S3. When setting user metadata, callers <i>should not</i> include
-	 * the internal "x-amz-meta-" prefix; this library will handle that for
-	 * them. Likewise, when callers retrieve custom user-metadata, they will not
-	 * see the "x-amz-meta-" header prefix.
-	 * </p>
-	 * <p>
-	 * Note that user-metadata for an object is limited by the HTTP request
-	 * header limit. All HTTP headers included in a request (including user
-	 * metadata headers and other standard HTTP headers) must be less than 8KB.
-	 * </p>
-	 *
-	 * @param key
-	 *            The key for the custom user metadata entry. Note that the key
-	 *            should not include
-	 *            the internal S3 HTTP header prefix.
-	 * @param value
-	 *            The value for the custom user-metadata entry.
-	 *
-	 * @see ObjectMetadata#setUserMetadata(Map)
-	 * @see ObjectMetadata#getUserMetadata()
-	 */
-	public void addUserMetadata(String key, String value) {
-		this.userMetadata.put(key, value);
-	}
-
-	/**
-	 * Gets a map of the raw metadata/headers for the associated object.
-	 *
-	 * @return A map of the raw metadata/headers for the associated object.
-	 */
-	public Map<String, Object> getRawMetadata() {
-		Map<String,Object> copy = new TreeMap<String,Object>(String.CASE_INSENSITIVE_ORDER);
-		copy.putAll(metadata);
-		return Collections.unmodifiableMap(copy);
-	}
-
-	/**
-	 * Returns the raw value of the metadata/headers for the specified key.
-	 */
-	public Object getRawMetadataValue(String key) {
-		return metadata.get(key);
-	}
-
-	/**
-	 * Gets the value of the Last-Modified header, indicating the date
-	 * and time at which Amazon S3 last recorded a modification to the
-	 * associated object.
-	 *
-	 * @return The date and time at which Amazon S3 last recorded a modification
-	 *         to the associated object.
-	 */
-	public Date getLastModified() {
-		return cloneDate((Date)metadata.get(Headers.LAST_MODIFIED));
-	}
-
-	/**
-	 * For internal use only. Sets the Last-Modified header value
-	 * indicating the date and time at which Amazon S3 last recorded a
-	 * modification to the associated object.
-	 *
-	 * @param lastModified
-	 *            The date and time at which Amazon S3 last recorded a
-	 *            modification to the associated object.
-	 */
-	public void setLastModified(Date lastModified) {
-		metadata.put(Headers.LAST_MODIFIED, lastModified);
-	}
-
-	/**
-	 * <p>
-	 * Gets the Content-Length HTTP header indicating the size of the
-	 * associated object in bytes.
-	 * </p>
-	 * <p>
-	 * This field is required when uploading objects to S3, but the AWS S3 Java
-	 * client will automatically set it when working directly with files. When
-	 * uploading directly from a stream, set this field if
-	 * possible. Otherwise the client must buffer the entire stream in
-	 * order to calculate the content length before sending the data to
-	 * Amazon S3.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Length HTTP header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
-	 * </p>
-	 *
-	 * @return The Content-Length HTTP header indicating the size of the
-	 *         associated object in bytes. Returns <code>null</code>
-	 *         if it hasn't been set yet.
-	 *
-	 * @see ObjectMetadata#setContentLength(long)
-	 */
-	public long getContentLength() {
-		Long contentLength = (Long)metadata.get(Headers.CONTENT_LENGTH);
-		if (metadata.containsKey(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)) {
-			contentLength = Long.valueOf(String.valueOf(metadata.get(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)));
-		}
-
-		if (contentLength == null) return 0;
-		return contentLength.longValue();
-	}
-
-	/**
-	 * Returns the physical length of the entire object stored in S3.
-	 * This is useful during, for example, a range get operation.
-	 */
-	public long getInstanceLength() {
-		// See Content-Range in
-		// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-		String contentRange = (String)metadata.get(Headers.CONTENT_RANGE);
-		if (contentRange != null) {
-			int pos = contentRange.lastIndexOf("/");
-			if (pos >= 0)
-				return Long.parseLong(contentRange.substring(pos+1));
-		}
-		return getContentLength();
-	}
-
-	/**
-	 * <p>
-	 * Sets the Content-Length HTTP header indicating the size of the
-	 * associated object in bytes.
-	 * </p>
-	 * <p>
-	 * This field is required when uploading objects to S3, but the AWS S3 Java
-	 * client will automatically set it when working directly with files. When
-	 * uploading directly from a stream, set this field if
-	 * possible. Otherwise the client must buffer the entire stream in
-	 * order to calculate the content length before sending the data to
-	 * Amazon S3.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Length HTTP header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
-	 * </p>
-	 *
-	 * @param contentLength
-	 *            The Content-Length HTTP header indicating the size of the
-	 *            associated object in bytes.
-	 *
-	 * @see ObjectMetadata#getContentLength()
-	 */
-	public void setContentLength(long contentLength) {
-		metadata.put(Headers.CONTENT_LENGTH, contentLength);
-	}
-
-	/**
-	 * <p>
-	 * Gets the Content-Type HTTP header, which indicates the type of content
-	 * stored in the associated object. The value of this header is a standard
-	 * MIME type.
-	 * </p>
-	 * <p>
-	 * When uploading files, the AWS S3 Java client will attempt to determine
-	 * the correct content type if one hasn't been set yet. Users are
-	 * responsible for ensuring a suitable content type is set when uploading
-	 * streams. If no content type is provided and cannot be determined by
-	 * the filename, the default content type, "application/octet-stream", will
-	 * be used.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Type header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-	 * </p>
-	 *
-	 * @return The HTTP Content-Type header, indicating the type of content
-	 *         stored in the associated S3 object. Returns <code>null</code>
-	 *         if it hasn't been
-	 *         set.
-	 *
-	 * @see ObjectMetadata#setContentType(String)
-	 */
-	public String getContentType() {
-		return (String)metadata.get(Headers.CONTENT_TYPE);
-	}
-
-	/**
-	 * <p>
-	 * Sets the Content-Type HTTP header indicating the type of content
-	 * stored in the associated object. The value of this header is a standard
-	 * MIME type.
-	 * </p>
-	 * <p>
-	 * When uploading files, the AWS S3 Java client will attempt to determine
-	 * the correct content type if one hasn't been set yet. Users are
-	 * responsible for ensuring a suitable content type is set when uploading
-	 * streams. If no content type is provided and cannot be determined by
-	 * the filename, the default content type "application/octet-stream" will
-	 * be used.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Type header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-	 * </p>
-	 *
-	 * @param contentType
-	 *            The HTTP Content-Type header indicating the type of content
-	 *            stored in the associated S3 object.
-	 *
-	 * @see ObjectMetadata#getContentType()
-	 */
-	public void setContentType(String contentType) {
-		metadata.put(Headers.CONTENT_TYPE, contentType);
-	}
-
-	/**
-	 * <p>
-	 * Gets the Content-Language HTTP header, which describes the natural language(s) of the
-	 * intended audience for the enclosed entity.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Type header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-	 * </p>
-	 *
-	 * @return The HTTP Content-Language header, which describes the natural language(s) of the
-	 * intended audience for the enclosed entity. Returns <code>null</code>
-	 *         if it hasn't been set.
-	 *
-	 * @see ObjectMetadata#setContentLanguage(String)
-	 */
-	public String getContentLanguage() {
-		return (String)metadata.get(Headers.CONTENT_LANGUAGE);
-	}
-
-	/**
-	 * <p>
-	 * Sets the Content-Language HTTP header which describes the natural language(s) of the
-	 * intended audience for the enclosed entity.
-	 * </p>
-	 * <p>
-	 * For more information on the Content-Type header, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-	 * </p>
-	 *
-	 * @param contentLanguage
-	 *            The HTTP Content-Language header which describes the natural language(s) of the
-	 * intended audience for the enclosed entity.
-	 *
-	 * @see ObjectMetadata#getContentLanguage()
-	 */
-	public void setContentLanguage(String contentLanguage) {
-		metadata.put(Headers.CONTENT_LANGUAGE, contentLanguage);
-	}
-
-	/**
-	 * <p>
-	 * Gets the optional Content-Encoding HTTP header specifying what
-	 * content encodings have been applied to the object and what decoding
-	 * mechanisms must be applied in order to obtain the media-type referenced
-	 * by the Content-Type field.
-	 * </p>
-	 * <p>
-	 * For more information on how the Content-Encoding HTTP header works, see
-	 * <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-	 * </p>
-	 *
-	 * @return The HTTP Content-Encoding header.
-	 * Returns <code>null</code> if it hasn't been set.
-	 *
-	 * @see ObjectMetadata#setContentEncoding(String)
-	 */
-	public String getContentEncoding() {
-		return (String)metadata.get(Headers.CONTENT_ENCODING);
-	}
-
-	/**
-	 * <p>
-	 * Sets the optional Content-Encoding HTTP header specifying what
-	 * content encodings have been applied to the object and what decoding
-	 * mechanisms must be applied in order to obtain the media-type referenced
-	 * by the Content-Type field.
-	 * </p>
-	 * <p>
-	 * For more information on how the Content-Encoding HTTP header works, see
-	 * <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-	 * </p>
-	 *
-	 * @param encoding
-	 *            The HTTP Content-Encoding header, as defined in RFC 2616.
-	 *
-	 * @see <a
-	 *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11"
-	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-	 *
-	 * @see ObjectMetadata#getContentEncoding()
-	 */
-	public void setContentEncoding(String encoding) {
-		metadata.put(Headers.CONTENT_ENCODING, encoding);
-	}
-
-	/**
-	 * <p>
-	 * Gets the optional Cache-Control HTTP header which allows the user to
-	 * specify caching behavior along the HTTP request/reply chain.
-	 * </p>
-	 * <p>
-	 * For more information on how the Cache-Control HTTP header affects HTTP
-	 * requests and responses, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
-	 * </p>
-	 *
-	 * @return The HTTP Cache-Control header as defined in RFC 2616.
-	 *         Returns <code>null</code>  if
-	 *         it hasn't been set.
-	 *
-	 * @see ObjectMetadata#setCacheControl(String)
-	 */
-	public String getCacheControl() {
-		return (String)metadata.get(Headers.CACHE_CONTROL);
-	}
-
-	/**
-	 * <p>
-	 * Sets the optional Cache-Control HTTP header which allows the user to
-	 * specify caching behavior along the HTTP request/reply chain.
-	 * </p>
-	 * <p>
-	 * For more information on how the Cache-Control HTTP header affects HTTP
-	 * requests and responses see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
-	 * </p>
-	 *
-	 * @param cacheControl
-	 *            The HTTP Cache-Control header as defined in RFC 2616.
-	 *
-	 * @see ObjectMetadata#getCacheControl()
-	 */
-	public void setCacheControl(String cacheControl) {
-		metadata.put(Headers.CACHE_CONTROL, cacheControl);
-	}
-
-	/**
-	 * <p>
-	 * Sets the base64 encoded 128-bit MD5 digest of the associated object
-	 * (content - not including headers) according to RFC 1864. This data is
-	 * used as a message integrity check to verify that the data received by
-	 * Amazon S3 is the same data that the caller sent. If set to null,then the
-	 * MD5 digest is removed from the metadata.
-	 * </p>
-	 * <p>
-	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
-	 * object's content as calculated on the caller's side. The ETag metadata
-	 * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
-	 * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
-	 * </p>
-	 * <p>
-	 * The AWS S3 Java client will attempt to calculate this field automatically
-	 * when uploading files to Amazon S3.
-	 * </p>
-	 *
-	 * @param md5Base64
-	 *            The base64 encoded MD5 hash of the content for the object
-	 *            associated with this metadata.
-	 *
-	 * @see ObjectMetadata#getContentMD5()
-	 */
-	public void setContentMD5(String md5Base64) {
-		if(md5Base64 == null){
-			metadata.remove(Headers.CONTENT_MD5);
-		}else{
-			metadata.put(Headers.CONTENT_MD5, md5Base64);
-		}
-
-	}
-
-	/**
-	 * <p>
-	 * Gets the base64 encoded 128-bit MD5 digest of the associated object
-	 * (content - not including headers) according to RFC 1864. This data is
-	 * used as a message integrity check to verify that the data received by
-	 * Amazon S3 is the same data that the caller sent.
-	 * </p>
-	 * <p>
-	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
-	 * object's content as calculated on the caller's side. The ETag metadata
-	 * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
-	 * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
-	 * </p>
-	 * <p>
-	 * The AWS S3 Java client will attempt to calculate this field automatically
-	 * when uploading files to Amazon S3.
-	 * </p>
-	 *
-	 * @return The base64 encoded MD5 hash of the content for the associated
-	 *         object.  Returns <code>null</code> if the MD5 hash of the content
-	 *         hasn't been set.
-	 *
-	 * @see ObjectMetadata#setContentMD5(String)
-	 */
-	public String getContentMD5() {
-		return (String)metadata.get(Headers.CONTENT_MD5);
-	}
-
-	/**
-	 * <p>
-	 * Sets the optional Content-Disposition HTTP header, which specifies
-	 * presentational information such as the recommended filename for the
-	 * object to be saved as.
-	 * </p>
-	 * <p>
-	 * For more information on how the Content-Disposition header affects HTTP
-	 * client behavior, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-	 * </p>
-	 *
-	 * @param disposition
-	 *            The value for the Content-Disposition header.
-	 *
-	 * @see ObjectMetadata#getContentDisposition()
-	 */
-	public void setContentDisposition(String disposition) {
-		metadata.put(Headers.CONTENT_DISPOSITION, disposition);
-	}
-
-	/**
-	 * <p>
-	 * Gets the optional Content-Disposition HTTP header, which specifies
-	 * presentation information for the object such as the recommended filename
-	 * for the object to be saved as.
-	 * </p>
-	 * <p>
-	 * For more information on how the Content-Disposition header affects HTTP
-	 * client behavior, see <a
-	 * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
-	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-	 * </p>
-	 *
-	 * @return The value of the Content-Disposition header.
-	 *         Returns <code>null</code> if the Content-Disposition header
-	 *         hasn't been set.
-	 *
-	 * @see <a
-	 *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1"
-	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-	 *
-	 * @see ObjectMetadata#setCacheControl(String)
-	 */
-	public String getContentDisposition() {
-		return (String)metadata.get(Headers.CONTENT_DISPOSITION);
-	}
-
-	/**
-	 * The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata.
-	 * The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created
-	 * and how it is encrypted as described below:
-	 * <ul>
-	 * <li>
-	 * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
-	 * by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object data.
-	 * </li>
-	 * <li>
-	 * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
-	 * by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object data.
-	 * </li>
-	 * <li>
-	 * If an object is created by either the Multipart Upload or Part Copy operation, the ETag is not an MD5 digest, regardless of
-	 * the method of encryption.
-	 * </li>
-	 * </ul>
-	 *
-	 * @return The ETag of the object or <code>null</code>if it hasn't been set yet.
-	 */
-	public String getETag() {
-		return (String)metadata.get(Headers.ETAG);
-	}
-
-	/**
-	 * Gets the version ID of the associated Amazon S3 object if available.
-	 * Version IDs are only assigned to objects when an object is uploaded to an
-	 * Amazon S3 bucket that has object versioning enabled.
-	 *
-	 * @return The version ID of the associated Amazon S3 object if available.
-	 */
-	public String getVersionId() {
-		return (String)metadata.get(Headers.S3_VERSION_ID);
-	}
-
-	/**
-	 * Returns the server-side encryption algorithm when encrypting the object
-	 * using AWS-managed keys .
-	 */
-	@Override
-	public String getSSEAlgorithm() {
-		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
-	}
-
-	/**
-	 * @deprecated Replaced by {@link #getSSEAlgorithm()}
-	 */
-	@Deprecated
-	public String getServerSideEncryption() {
-		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
-	}
-
-	/**
-	 * Sets the server-side encryption algorithm when encrypting the object
-	 * using AWS-managed keys.
-	 *
-	 * @param algorithm
-	 *            The server-side encryption algorithm when encrypting the
-	 *            object using AWS-managed keys .
-	 */
-	@Override
-	public void setSSEAlgorithm(String algorithm) {
-		metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
-	}
-
-
-	/**
-	 * @deprecated Replaced by {@link #setSSEAlgorithm(String)}
-	 */
-	@Deprecated
-	public void setServerSideEncryption(String algorithm) {
-		metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String getSSECustomerAlgorithm() {
-		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
-	}
-
-	/**
-	 * For internal use only. This method is only used to set the value in the
-	 * object after receiving the value in a response from S3. When sending
-	 * requests, use {@link SSECustomerKey} members in request objects.
-	 */
-	@Override
-	public void setSSECustomerAlgorithm(String algorithm) {
-		metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, algorithm);
-	}
-
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public String getSSECustomerKeyMd5() {
-		return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
-	}
-
-	/**
-	 * For internal use only. This method is only used to set the value in the
-	 * object after receiving the value in a response from S3. When sending
-	 * requests, use {@link SSECustomerKey} members in request objects.
-	 */
-	public void setSSECustomerKeyMd5(String md5Digest) {
-		metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, md5Digest);
-	}
-
-	/**
-	 * Returns the time this object will expire and be completely removed from
-	 * S3. Returns null if this object will never expire.
-	 */
-	public Date getExpirationTime() {
-		return cloneDate(expirationTime);
-	}
-
-	/**
-	 * For internal use only. This will *not* set the object's expiration time,
-	 * and is only used to set the value in the object after receiving the value
-	 * in a response from S3.
-	 *
-	 * @param expirationTime
-	 *            The expiration time for the object.
-	 */
-	public void setExpirationTime(Date expirationTime) {
-		this.expirationTime = expirationTime;
-	}
-
-	/**
-	 * Returns the {@link BucketLifecycleConfiguration} rule ID for this
-	 * object's expiration, or null if it doesn't expire.
-	 */
-	public String getExpirationTimeRuleId() {
-		return expirationTimeRuleId;
-	}
-
-	/**
-	 * For internal use only. This will *not* set the object's expiration time
-	 * rule id, and is only used to set the value in the object after receiving
-	 * the value in a response from S3.
-	 */
-	public void setExpirationTimeRuleId(String expirationTimeRuleId) {
-		this.expirationTimeRuleId = expirationTimeRuleId;
-	}
-
-
-	/**
-	 * Returns the time at which an object that has been temporarily restored
-	 * from Amazon Glacier will expire, and will need to be restored again in
-	 * order to be accessed. Returns null if this is not a temporary copy of an
-	 * object restored from Glacier.
-	 */
-	public Date getRestoreExpirationTime() {
-		return cloneDate(restoreExpirationTime);
-	}
-
-	/**
-	 * For internal use only. This will *not* set the object's restore
-	 * expiration time, and is only used to set the value in the object after
-	 * receiving the value in a response from S3.
-	 *
-	 * @param restoreExpirationTime
-	 *            The new restore expiration time for the object.
-	 */
-	public void setRestoreExpirationTime(Date restoreExpirationTime) {
-		this.restoreExpirationTime = restoreExpirationTime;
-	}
-
-	/**
-	 * For internal use only. Sets the boolean value which indicates whether
-	 * there is ongoing restore request. Not intended to be called by external
-	 * code.
-	 */
-	public void setOngoingRestore(boolean ongoingRestore) {
-		this.ongoingRestore = Boolean.valueOf(ongoingRestore);
-	}
-
-
-	/**
-	 *  Returns the boolean value which indicates whether there is ongoing restore request.
-	 */
-	public Boolean getOngoingRestore() {
-		return this.ongoingRestore;
-	}
-
-	/**
-	 *  Set the date when the object is no longer cacheable.
-	 */
-	public void setHttpExpiresDate(Date httpExpiresDate) {
-		this.httpExpiresDate = httpExpiresDate;
-	}
-
-	/**
-	 * Returns the date when the object is no longer cacheable.
-	 */
-	public Date getHttpExpiresDate() {
-		return cloneDate(httpExpiresDate);
-	}
-
-	/**
-	 * @return The storage class of the object. Returns null if the object is in STANDARD storage.
-	 *         See {@link StorageClass} for possible values
-	 */
-	public String getStorageClass() {
-		final Object storageClass = metadata.get(Headers.STORAGE_CLASS);
-		if (storageClass == null) {
-			return null;
-		}
-		return storageClass.toString();
-	}
-
-	/**
-	 * Returns the value of the specified user meta datum.
-	 */
-	public String getUserMetaDataOf(String key) {
-		return userMetadata == null ? null : userMetadata.get(key);
-	}
-
-	/**
-	 * Returns a clone of this <code>ObjectMetadata</code>. Note the clone of
-	 * the internal {@link #metadata} is limited to a shallow copy due to the
-	 * unlimited type of value in the map. Other fields can be regarded as deep
-	 * clone.
-	 */
-	public ObjectMetadata clone() {
-		return new ObjectMetadata(this);
-	}
-
-	/**
-	 * Returns the AWS Key Management System key id used for Server Side
-	 * Encryption of the Amazon S3 object.
-	 */
-	public String getSSEAwsKmsKeyId() {
-		return (String) metadata
-				.get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
-	}
-
-	@Override
-	public boolean isRequesterCharged() {
-		return metadata.get(Headers.REQUESTER_CHARGED_HEADER) != null;
-	}
-
-	@Override
-	public void setRequesterCharged(boolean isRequesterCharged) {
-		if (isRequesterCharged) {
-			metadata.put(Headers.REQUESTER_CHARGED_HEADER, Constants.REQUESTER_PAYS);
-		}
-	}
-
-	/**
-	 * <p>
-	 * Returns the value of x-amz-mp-parts-count header.
-	 * </p>
-	 * <p>
-	 * The x-amz-mp-parts-count header is returned in the response only when
-	 * a valid partNumber is specified in the request and the object has more than 1 part.
-	 * </p>
-	 * <p>
-	 * To find the part count of an object, set the partNumber to 1 in GetObjectRequest.
-	 * If the object has more than 1 part then part count will be returned,
-	 * otherwise null is returned.
-	 * </p>
-	 */
-	public Integer getPartCount() {
-		return (Integer) metadata.get(Headers.S3_PARTS_COUNT);
-	}
-
-	/**
-	 * <p>
-	 * Returns the content range of the object if response contains the Content-Range header.
-	 * </p>
-	 * <p>
-	 * If the request specifies a range or part number, then response returns the Content-Range range header.
-	 * Otherwise, the response does not return Content-Range header.
-	 * </p>
-	 * @return
-	 * 		Returns content range if the object is requested with specific range or part number,
-	 * 		null otherwise.
-	 */
-	public Long[] getContentRange() {
-		String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
-		Long[] range = null;
-		if (contentRange != null) {
-			String[] tokens = contentRange.split("[ -/]+");
-			try {
-				range = new Long[] { Long.parseLong(tokens[1]), Long.parseLong(tokens[2]) };
-			} catch (NumberFormatException nfe) {
-				throw new SdkClientException(
-						"Unable to parse content range. Header 'Content-Range' has corrupted data" + nfe.getMessage(),
-						nfe);
-			}
-		}
-		return range;
-	}
-
-	/**
-	 * @return The replication status of the object if it is from a bucket that
-	 * is the source or destination in a cross-region replication.
-	 */
-	public String getReplicationStatus() {
-		return (String) metadata.get(Headers.OBJECT_REPLICATION_STATUS);
-	}
-
-	/**
-	 * The Object Lock mode applied to this object.
-	 */
-	public String getObjectLockMode() {
-		return (String) metadata.get(Headers.OBJECT_LOCK_MODE);
-	}
-
-	/**
-	 * The date and time this object's Object Lock will expire.
-	 */
-	public Date getObjectLockRetainUntilDate() {
-		String dateStr = (String) metadata.get(Headers.OBJECT_LOCK_RETAIN_UNTIL_DATE);
-		if (dateStr != null) {
-			return DateUtils.parseISO8601Date(dateStr);
-		}
-		return null;
-	}
-
-	/**
-	 * The Legal Hold status of the specified object.
-	 */
-	public String getObjectLockLegalHoldStatus() {
-		return (String) metadata.get(Headers.OBJECT_LOCK_LEGAL_HOLD_STATUS);
-	}
+    /*
+     * TODO: Might be nice to get as many of the internal use only methods out
+     *       of here so users never even see them.
+     *       Example: we could set the ETag header directly through the raw
+     *                metadata map instead of having a setter for it.
+     */
+
+    /**
+     * Custom user metadata, represented in responses with the x-amz-meta-
+     * header prefix
+     */
+    private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+
+    /**
+     * All other (non user custom) headers such as Content-Length, Content-Type,
+     * etc.
+     */
+    private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
+
+    public static final String AES_256_SERVER_SIDE_ENCRYPTION =
+            SSEAlgorithm.AES256.getAlgorithm();
+
+    /**
+     * The date when the object is no longer cacheable.
+     */
+    private Date httpExpiresDate;
+
+    /**
+     * The time this object will expire and be completely removed from S3, or
+     * null if this object will never expire.
+     * <p>
+     * This and the expiration time rule aren't stored in the metadata map
+     * because the header contains both the time and the rule.
+     */
+    private Date expirationTime;
+
+    /**
+     * The expiration rule id for this object.
+     */
+    private String expirationTimeRuleId;
+
+    /**
+     * Boolean value indicating whether there is an ongoing request to restore
+     * an archived copy of this object from Amazon Glacier.
+     */
+    private Boolean ongoingRestore;
+
+    /**
+     * The time at which an object that has been temporarily restored from
+     * Glacier will expire, and will need to be restored again in order to be
+     * accessed. Null if this object has not been restored from Glacier.
+     */
+    private Date restoreExpirationTime;
+
+    public ObjectMetadata() {}
+
+    private ObjectMetadata(ObjectMetadata from) {
+        this.userMetadata = from.userMetadata == null
+            ? null
+            : new TreeMap<String,String>(from.userMetadata);
+        // shallow clone the meata data
+        this.metadata = from.metadata == null
+            ? null
+            : new TreeMap<String, Object>(from.metadata);
+        this.expirationTime = cloneDate(from.expirationTime);
+        this.expirationTimeRuleId = from.expirationTimeRuleId;
+        this.httpExpiresDate = cloneDate(from.httpExpiresDate);
+        this.ongoingRestore = from.ongoingRestore;
+        this.restoreExpirationTime = cloneDate(from.restoreExpirationTime);
+    }
+
+    /**
+     * <p>
+     * Gets the custom user-metadata for the associated object.
+     * </p>
+     * <p>
+     * Amazon S3 can store additional metadata on objects by internally
+     * representing it as HTTP headers prefixed with "x-amz-meta-". Use
+     * user-metadata to store arbitrary metadata alongside their data in Amazon
+     * S3. When setting user metadata, callers <i>should not</i> include the
+     * internal "x-amz-meta-" prefix; this library will handle that for them.
+     * Likewise, when callers retrieve custom user-metadata, they will not see
+     * the "x-amz-meta-" header prefix.
+     * </p>
+     * <p>
+     * User-metadata keys are <b>case insensitive</b> and will be returned as
+     * lowercase strings, even if they were originally specified with uppercase
+     * strings.
+     * </p>
+     * <p>
+     * Note that user-metadata for an object is limited by the HTTP request
+     * header limit. All HTTP headers included in a request (including user
+     * metadata headers and other standard HTTP headers) must be less than 8KB.
+     * </p>
+     *
+     * @return The custom user metadata for the associated object.
+     *
+     * @see ObjectMetadata#setUserMetadata(Map)
+     * @see ObjectMetadata#addUserMetadata(String, String)
+     */
+    public Map<String, String> getUserMetadata() {
+        return userMetadata;
+    }
+
+    /**
+     * <p>
+     * Sets the custom user-metadata for the associated object.
+     * </p>
+     * <p>
+     * Amazon S3 can store additional metadata on objects by internally
+     * representing it as HTTP headers prefixed with "x-amz-meta-". Use
+     * user-metadata to store arbitrary metadata alongside their data in Amazon
+     * S3. When setting user metadata, callers <i>should not</i> include the
+     * internal "x-amz-meta-" prefix; this library will handle that for them.
+     * Likewise, when callers retrieve custom user-metadata, they will not see
+     * the "x-amz-meta-" header prefix.
+     * </p>
+     * <p>
+     * User-metadata keys are <b>case insensitive</b> and will be returned as
+     * lowercase strings, even if they were originally specified with uppercase
+     * strings.
+     * </p>
+     * <p>
+     * Note that user-metadata for an object is limited by the HTTP request
+     * header limit. All HTTP headers included in a request (including user
+     * metadata headers and other standard HTTP headers) must be less than 8KB.
+     * </p>
+     *
+     * @param userMetadata
+     *            The custom user-metadata for the associated object. Note that
+     *            the key should not include the internal S3 HTTP header prefix.
+     * @see ObjectMetadata#getUserMetadata()
+     * @see ObjectMetadata#addUserMetadata(String, String)
+     */
+    public void setUserMetadata(Map<String, String> userMetadata) {
+        this.userMetadata = userMetadata;
+    }
+
+    /**
+     * For internal use only. Sets a specific metadata header value. Not
+     * intended to be called by external code.
+     *
+     * @param key
+     *            The name of the header being set.
+     * @param value
+     *            The value for the header.
+     */
+    public void setHeader(String key, Object value) {
+        metadata.put(key, value);
+    }
+
+    /**
+     * <p>
+     * Adds the key value pair of custom user-metadata for the associated
+     * object. If the entry in the custom user-metadata map already contains the
+     * specified key, it will be replaced with these new contents.
+     * </p>
+     * <p>
+     * Amazon S3 can store additional metadata on objects by internally
+     * representing it as HTTP headers prefixed with "x-amz-meta-".
+     * Use user-metadata to store arbitrary metadata alongside their data in
+     * Amazon S3. When setting user metadata, callers <i>should not</i> include
+     * the internal "x-amz-meta-" prefix; this library will handle that for
+     * them. Likewise, when callers retrieve custom user-metadata, they will not
+     * see the "x-amz-meta-" header prefix.
+     * </p>
+     * <p>
+     * Note that user-metadata for an object is limited by the HTTP request
+     * header limit. All HTTP headers included in a request (including user
+     * metadata headers and other standard HTTP headers) must be less than 8KB.
+     * </p>
+     *
+     * @param key
+     *            The key for the custom user metadata entry. Note that the key
+     *            should not include
+     *            the internal S3 HTTP header prefix.
+     * @param value
+     *            The value for the custom user-metadata entry.
+     *
+     * @see ObjectMetadata#setUserMetadata(Map)
+     * @see ObjectMetadata#getUserMetadata()
+     */
+    public void addUserMetadata(String key, String value) {
+        this.userMetadata.put(key, value);
+    }
+
+    /**
+     * Gets a map of the raw metadata/headers for the associated object.
+     *
+     * @return A map of the raw metadata/headers for the associated object.
+     */
+    public Map<String, Object> getRawMetadata() {
+        Map<String,Object> copy = new TreeMap<String,Object>(String.CASE_INSENSITIVE_ORDER);
+        copy.putAll(metadata);
+        return Collections.unmodifiableMap(copy);
+    }
+
+    /**
+     * Returns the raw value of the metadata/headers for the specified key.
+     */
+    public Object getRawMetadataValue(String key) {
+        return metadata.get(key);
+    }
+
+    /**
+     * Gets the value of the Last-Modified header, indicating the date
+     * and time at which Amazon S3 last recorded a modification to the
+     * associated object.
+     *
+     * @return The date and time at which Amazon S3 last recorded a modification
+     *         to the associated object.
+     */
+    public Date getLastModified() {
+        return cloneDate((Date)metadata.get(Headers.LAST_MODIFIED));
+    }
+
+    /**
+     * For internal use only. Sets the Last-Modified header value
+     * indicating the date and time at which Amazon S3 last recorded a
+     * modification to the associated object.
+     *
+     * @param lastModified
+     *            The date and time at which Amazon S3 last recorded a
+     *            modification to the associated object.
+     */
+    public void setLastModified(Date lastModified) {
+        metadata.put(Headers.LAST_MODIFIED, lastModified);
+    }
+
+    /**
+     * <p>
+     * Gets the Content-Length HTTP header indicating the size of the
+     * associated object in bytes.
+     * </p>
+     * <p>
+     * This field is required when uploading objects to S3, but the AWS S3 Java
+     * client will automatically set it when working directly with files. When
+     * uploading directly from a stream, set this field if
+     * possible. Otherwise the client must buffer the entire stream in
+     * order to calculate the content length before sending the data to
+     * Amazon S3.
+     * </p>
+     * <p>
+     * For more information on the Content-Length HTTP header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
+     * </p>
+     *
+     * @return The Content-Length HTTP header indicating the size of the
+     *         associated object in bytes. Returns <code>null</code>
+     *         if it hasn't been set yet.
+     *
+     * @see ObjectMetadata#setContentLength(long)
+     */
+    public long getContentLength() {
+        Long contentLength = (Long)metadata.get(Headers.CONTENT_LENGTH);
+				if (metadata.containsKey(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)) {
+						contentLength = Long.valueOf(String.valueOf(metadata.get(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)));
+				}
+        if (contentLength == null) return 0;
+        return contentLength.longValue();
+    }
+
+    /**
+     * Returns the physical length of the entire object stored in S3.
+     * This is useful during, for example, a range get operation.
+     */
+    public long getInstanceLength() {
+        // See Content-Range in
+        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+        String contentRange = (String)metadata.get(Headers.CONTENT_RANGE);
+        if (contentRange != null) {
+            int pos = contentRange.lastIndexOf("/");
+            if (pos >= 0)
+                return Long.parseLong(contentRange.substring(pos+1));
+        }
+        return getContentLength();
+    }
+
+    /**
+     * <p>
+     * Sets the Content-Length HTTP header indicating the size of the
+     * associated object in bytes.
+     * </p>
+     * <p>
+     * This field is required when uploading objects to S3, but the AWS S3 Java
+     * client will automatically set it when working directly with files. When
+     * uploading directly from a stream, set this field if
+     * possible. Otherwise the client must buffer the entire stream in
+     * order to calculate the content length before sending the data to
+     * Amazon S3.
+     * </p>
+     * <p>
+     * For more information on the Content-Length HTTP header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
+     * </p>
+     *
+     * @param contentLength
+     *            The Content-Length HTTP header indicating the size of the
+     *            associated object in bytes.
+     *
+     * @see ObjectMetadata#getContentLength()
+     */
+    public void setContentLength(long contentLength) {
+        metadata.put(Headers.CONTENT_LENGTH, contentLength);
+    }
+
+    /**
+     * <p>
+     * Gets the Content-Type HTTP header, which indicates the type of content
+     * stored in the associated object. The value of this header is a standard
+     * MIME type.
+     * </p>
+     * <p>
+     * When uploading files, the AWS S3 Java client will attempt to determine
+     * the correct content type if one hasn't been set yet. Users are
+     * responsible for ensuring a suitable content type is set when uploading
+     * streams. If no content type is provided and cannot be determined by
+     * the filename, the default content type, "application/octet-stream", will
+     * be used.
+     * </p>
+     * <p>
+     * For more information on the Content-Type header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+     * </p>
+     *
+     * @return The HTTP Content-Type header, indicating the type of content
+     *         stored in the associated S3 object. Returns <code>null</code>
+     *         if it hasn't been
+     *         set.
+     *
+     * @see ObjectMetadata#setContentType(String)
+     */
+    public String getContentType() {
+        return (String)metadata.get(Headers.CONTENT_TYPE);
+    }
+
+    /**
+     * <p>
+     * Sets the Content-Type HTTP header indicating the type of content
+     * stored in the associated object. The value of this header is a standard
+     * MIME type.
+     * </p>
+     * <p>
+     * When uploading files, the AWS S3 Java client will attempt to determine
+     * the correct content type if one hasn't been set yet. Users are
+     * responsible for ensuring a suitable content type is set when uploading
+     * streams. If no content type is provided and cannot be determined by
+     * the filename, the default content type "application/octet-stream" will
+     * be used.
+     * </p>
+     * <p>
+     * For more information on the Content-Type header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+     * </p>
+     *
+     * @param contentType
+     *            The HTTP Content-Type header indicating the type of content
+     *            stored in the associated S3 object.
+     *
+     * @see ObjectMetadata#getContentType()
+     */
+    public void setContentType(String contentType) {
+        metadata.put(Headers.CONTENT_TYPE, contentType);
+    }
+
+    /**
+     * <p>
+     * Gets the Content-Language HTTP header, which describes the natural language(s) of the
+     * intended audience for the enclosed entity.
+     * </p>
+     * <p>
+     * For more information on the Content-Type header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+     * </p>
+     *
+     * @return The HTTP Content-Language header, which describes the natural language(s) of the
+     * intended audience for the enclosed entity. Returns <code>null</code>
+     *         if it hasn't been set.
+     *
+     * @see ObjectMetadata#setContentLanguage(String)
+     */
+    public String getContentLanguage() {
+        return (String)metadata.get(Headers.CONTENT_LANGUAGE);
+    }
+
+    /**
+     * <p>
+     * Sets the Content-Language HTTP header which describes the natural language(s) of the
+     * intended audience for the enclosed entity.
+     * </p>
+     * <p>
+     * For more information on the Content-Type header, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+     * </p>
+     *
+     * @param contentLanguage
+     *            The HTTP Content-Language header which describes the natural language(s) of the
+     * intended audience for the enclosed entity.
+     *
+     * @see ObjectMetadata#getContentLanguage()
+     */
+    public void setContentLanguage(String contentLanguage) {
+        metadata.put(Headers.CONTENT_LANGUAGE, contentLanguage);
+    }
+
+    /**
+     * <p>
+     * Gets the optional Content-Encoding HTTP header specifying what
+     * content encodings have been applied to the object and what decoding
+     * mechanisms must be applied in order to obtain the media-type referenced
+     * by the Content-Type field.
+     * </p>
+     * <p>
+     * For more information on how the Content-Encoding HTTP header works, see
+     * <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+     * </p>
+     *
+     * @return The HTTP Content-Encoding header.
+     * Returns <code>null</code> if it hasn't been set.
+     *
+     * @see ObjectMetadata#setContentEncoding(String)
+     */
+    public String getContentEncoding() {
+        return (String)metadata.get(Headers.CONTENT_ENCODING);
+    }
+
+    /**
+     * <p>
+     * Sets the optional Content-Encoding HTTP header specifying what
+     * content encodings have been applied to the object and what decoding
+     * mechanisms must be applied in order to obtain the media-type referenced
+     * by the Content-Type field.
+     * </p>
+     * <p>
+     * For more information on how the Content-Encoding HTTP header works, see
+     * <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+     * </p>
+     *
+     * @param encoding
+     *            The HTTP Content-Encoding header, as defined in RFC 2616.
+     *
+     * @see <a
+     *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11"
+     *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+     *
+     * @see ObjectMetadata#getContentEncoding()
+     */
+    public void setContentEncoding(String encoding) {
+        metadata.put(Headers.CONTENT_ENCODING, encoding);
+    }
+
+    /**
+     * <p>
+     * Gets the optional Cache-Control HTTP header which allows the user to
+     * specify caching behavior along the HTTP request/reply chain.
+     * </p>
+     * <p>
+     * For more information on how the Cache-Control HTTP header affects HTTP
+     * requests and responses, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
+     * </p>
+     *
+     * @return The HTTP Cache-Control header as defined in RFC 2616.
+     *         Returns <code>null</code>  if
+     *         it hasn't been set.
+     *
+     * @see ObjectMetadata#setCacheControl(String)
+     */
+    public String getCacheControl() {
+        return (String)metadata.get(Headers.CACHE_CONTROL);
+    }
+
+    /**
+     * <p>
+     * Sets the optional Cache-Control HTTP header which allows the user to
+     * specify caching behavior along the HTTP request/reply chain.
+     * </p>
+     * <p>
+     * For more information on how the Cache-Control HTTP header affects HTTP
+     * requests and responses see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
+     * </p>
+     *
+     * @param cacheControl
+     *            The HTTP Cache-Control header as defined in RFC 2616.
+     *
+     * @see ObjectMetadata#getCacheControl()
+     */
+    public void setCacheControl(String cacheControl) {
+        metadata.put(Headers.CACHE_CONTROL, cacheControl);
+    }
+
+    /**
+     * <p>
+     * Sets the base64 encoded 128-bit MD5 digest of the associated object
+     * (content - not including headers) according to RFC 1864. This data is
+     * used as a message integrity check to verify that the data received by
+     * Amazon S3 is the same data that the caller sent. If set to null,then the
+     * MD5 digest is removed from the metadata.
+     * </p>
+     * <p>
+     * This field represents the base64 encoded 128-bit MD5 digest digest of an
+     * object's content as calculated on the caller's side. The ETag metadata
+     * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
+     * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
+     * </p>
+     * <p>
+     * The AWS S3 Java client will attempt to calculate this field automatically
+     * when uploading files to Amazon S3.
+     * </p>
+     *
+     * @param md5Base64
+     *            The base64 encoded MD5 hash of the content for the object
+     *            associated with this metadata.
+     *
+     * @see ObjectMetadata#getContentMD5()
+     */
+    public void setContentMD5(String md5Base64) {
+        if(md5Base64 == null){
+            metadata.remove(Headers.CONTENT_MD5);
+        }else{
+            metadata.put(Headers.CONTENT_MD5, md5Base64);
+        }
+
+    }
+
+    /**
+     * <p>
+     * Gets the base64 encoded 128-bit MD5 digest of the associated object
+     * (content - not including headers) according to RFC 1864. This data is
+     * used as a message integrity check to verify that the data received by
+     * Amazon S3 is the same data that the caller sent.
+     * </p>
+     * <p>
+     * This field represents the base64 encoded 128-bit MD5 digest digest of an
+     * object's content as calculated on the caller's side. The ETag metadata
+     * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
+     * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
+     * </p>
+     * <p>
+     * The AWS S3 Java client will attempt to calculate this field automatically
+     * when uploading files to Amazon S3.
+     * </p>
+     *
+     * @return The base64 encoded MD5 hash of the content for the associated
+     *         object.  Returns <code>null</code> if the MD5 hash of the content
+     *         hasn't been set.
+     *
+     * @see ObjectMetadata#setContentMD5(String)
+     */
+    public String getContentMD5() {
+        return (String)metadata.get(Headers.CONTENT_MD5);
+    }
+
+    /**
+     * <p>
+     * Sets the optional Content-Disposition HTTP header, which specifies
+     * presentational information such as the recommended filename for the
+     * object to be saved as.
+     * </p>
+     * <p>
+     * For more information on how the Content-Disposition header affects HTTP
+     * client behavior, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+     * </p>
+     *
+     * @param disposition
+     *            The value for the Content-Disposition header.
+     *
+     * @see ObjectMetadata#getContentDisposition()
+     */
+    public void setContentDisposition(String disposition) {
+        metadata.put(Headers.CONTENT_DISPOSITION, disposition);
+    }
+
+    /**
+     * <p>
+     * Gets the optional Content-Disposition HTTP header, which specifies
+     * presentation information for the object such as the recommended filename
+     * for the object to be saved as.
+     * </p>
+     * <p>
+     * For more information on how the Content-Disposition header affects HTTP
+     * client behavior, see <a
+     * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
+     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+     * </p>
+     *
+     * @return The value of the Content-Disposition header.
+     *         Returns <code>null</code> if the Content-Disposition header
+     *         hasn't been set.
+     *
+     * @see <a
+     *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1"
+     *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+     *
+     * @see ObjectMetadata#setCacheControl(String)
+     */
+    public String getContentDisposition() {
+        return (String)metadata.get(Headers.CONTENT_DISPOSITION);
+    }
+
+    /**
+     * The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata.
+     * The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created
+     * and how it is encrypted as described below:
+     * <ul>
+     * <li>
+     * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
+     * by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object data.
+     * </li>
+     * <li>
+     * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
+     * by SSE-C or SSE-KMS, have ETags that are not an MD5 digest of their object data.
+     * </li>
+     * <li>
+     * If an object is created by either the Multipart Upload or Part Copy operation, the ETag is not an MD5 digest, regardless of
+     * the method of encryption.
+     * </li>
+     * </ul>
+     *
+     * @return The ETag of the object or <code>null</code>if it hasn't been set yet.
+     */
+    public String getETag() {
+        return (String)metadata.get(Headers.ETAG);
+    }
+
+    /**
+     * Gets the version ID of the associated Amazon S3 object if available.
+     * Version IDs are only assigned to objects when an object is uploaded to an
+     * Amazon S3 bucket that has object versioning enabled.
+     *
+     * @return The version ID of the associated Amazon S3 object if available.
+     */
+    public String getVersionId() {
+        return (String)metadata.get(Headers.S3_VERSION_ID);
+    }
+
+    /**
+     * Returns the server-side encryption algorithm when encrypting the object
+     * using AWS-managed keys .
+     */
+    @Override
+    public String getSSEAlgorithm() {
+        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getSSEAlgorithm()}
+     */
+    @Deprecated
+    public String getServerSideEncryption() {
+        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+    }
+
+    /**
+     * Sets the server-side encryption algorithm when encrypting the object
+     * using AWS-managed keys.
+     *
+     * @param algorithm
+     *            The server-side encryption algorithm when encrypting the
+     *            object using AWS-managed keys .
+     */
+    @Override
+    public void setSSEAlgorithm(String algorithm) {
+        metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
+    }
+
+
+    /**
+     * @deprecated Replaced by {@link #setSSEAlgorithm(String)}
+     */
+    @Deprecated
+    public void setServerSideEncryption(String algorithm) {
+        metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSSECustomerAlgorithm() {
+        return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
+    }
+
+    /**
+     * For internal use only. This method is only used to set the value in the
+     * object after receiving the value in a response from S3. When sending
+     * requests, use {@link SSECustomerKey} members in request objects.
+     */
+    @Override
+    public void setSSECustomerAlgorithm(String algorithm) {
+        metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, algorithm);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getSSECustomerKeyMd5() {
+        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
+    }
+
+    /**
+     * For internal use only. This method is only used to set the value in the
+     * object after receiving the value in a response from S3. When sending
+     * requests, use {@link SSECustomerKey} members in request objects.
+     */
+    public void setSSECustomerKeyMd5(String md5Digest) {
+        metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, md5Digest);
+    }
+
+    /**
+     * Returns the time this object will expire and be completely removed from
+     * S3. Returns null if this object will never expire.
+     */
+    public Date getExpirationTime() {
+        return cloneDate(expirationTime);
+    }
+
+    /**
+     * For internal use only. This will *not* set the object's expiration time,
+     * and is only used to set the value in the object after receiving the value
+     * in a response from S3.
+     *
+     * @param expirationTime
+     *            The expiration time for the object.
+     */
+    public void setExpirationTime(Date expirationTime) {
+        this.expirationTime = expirationTime;
+    }
+
+    /**
+     * Returns the {@link BucketLifecycleConfiguration} rule ID for this
+     * object's expiration, or null if it doesn't expire.
+     */
+    public String getExpirationTimeRuleId() {
+        return expirationTimeRuleId;
+    }
+
+    /**
+     * For internal use only. This will *not* set the object's expiration time
+     * rule id, and is only used to set the value in the object after receiving
+     * the value in a response from S3.
+     */
+    public void setExpirationTimeRuleId(String expirationTimeRuleId) {
+        this.expirationTimeRuleId = expirationTimeRuleId;
+    }
+
+
+    /**
+     * Returns the time at which an object that has been temporarily restored
+     * from Amazon Glacier will expire, and will need to be restored again in
+     * order to be accessed. Returns null if this is not a temporary copy of an
+     * object restored from Glacier.
+     */
+    public Date getRestoreExpirationTime() {
+        return cloneDate(restoreExpirationTime);
+    }
+
+    /**
+     * For internal use only. This will *not* set the object's restore
+     * expiration time, and is only used to set the value in the object after
+     * receiving the value in a response from S3.
+     *
+     * @param restoreExpirationTime
+     *            The new restore expiration time for the object.
+     */
+    public void setRestoreExpirationTime(Date restoreExpirationTime) {
+        this.restoreExpirationTime = restoreExpirationTime;
+    }
+
+    /**
+     * For internal use only. Sets the boolean value which indicates whether
+     * there is ongoing restore request. Not intended to be called by external
+     * code.
+     */
+    public void setOngoingRestore(boolean ongoingRestore) {
+        this.ongoingRestore = Boolean.valueOf(ongoingRestore);
+    }
+
+
+    /**
+     *  Returns the boolean value which indicates whether there is ongoing restore request.
+     */
+    public Boolean getOngoingRestore() {
+        return this.ongoingRestore;
+    }
+
+    /**
+     *  Set the date when the object is no longer cacheable.
+     */
+    public void setHttpExpiresDate(Date httpExpiresDate) {
+        this.httpExpiresDate = httpExpiresDate;
+    }
+
+    /**
+     * Returns the date when the object is no longer cacheable.
+     */
+    public Date getHttpExpiresDate() {
+        return cloneDate(httpExpiresDate);
+    }
+
+    /**
+     * @return The storage class of the object. Returns null if the object is in STANDARD storage.
+     *         See {@link StorageClass} for possible values
+     */
+    public String getStorageClass() {
+        final Object storageClass = metadata.get(Headers.STORAGE_CLASS);
+        if (storageClass == null) {
+            return null;
+        }
+        return storageClass.toString();
+    }
+
+    /**
+     * Returns the value of the specified user meta datum.
+     */
+    public String getUserMetaDataOf(String key) {
+        return userMetadata == null ? null : userMetadata.get(key);
+    }
+
+    /**
+     * Returns a clone of this <code>ObjectMetadata</code>. Note the clone of
+     * the internal {@link #metadata} is limited to a shallow copy due to the
+     * unlimited type of value in the map. Other fields can be regarded as deep
+     * clone.
+     */
+    public ObjectMetadata clone() {
+        return new ObjectMetadata(this);
+    }
+
+    /**
+     * Returns the AWS Key Management System key id used for Server Side
+     * Encryption of the Amazon S3 object.
+     */
+    public String getSSEAwsKmsKeyId() {
+        return (String) metadata
+                .get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
+    }
+
+    @Override
+    public boolean isRequesterCharged() {
+        return metadata.get(Headers.REQUESTER_CHARGED_HEADER) != null;
+    }
+
+    @Override
+    public void setRequesterCharged(boolean isRequesterCharged) {
+        if (isRequesterCharged) {
+            metadata.put(Headers.REQUESTER_CHARGED_HEADER, Constants.REQUESTER_PAYS);
+        }
+    }
+
+    /**
+     * <p>
+     * Returns the value of x-amz-mp-parts-count header.
+     * </p>
+     * <p>
+     * The x-amz-mp-parts-count header is returned in the response only when
+     * a valid partNumber is specified in the request and the object has more than 1 part.
+     * </p>
+     * <p>
+     * To find the part count of an object, set the partNumber to 1 in GetObjectRequest.
+     * If the object has more than 1 part then part count will be returned,
+     * otherwise null is returned.
+     * </p>
+     */
+    public Integer getPartCount() {
+        return (Integer) metadata.get(Headers.S3_PARTS_COUNT);
+    }
+
+    /**
+     * <p>
+     * Returns the content range of the object if response contains the Content-Range header.
+     * </p>
+     * <p>
+     * If the request specifies a range or part number, then response returns the Content-Range range header.
+     * Otherwise, the response does not return Content-Range header.
+     * </p>
+     * @return
+     * 		Returns content range if the object is requested with specific range or part number,
+     * 		null otherwise.
+     */
+    public Long[] getContentRange() {
+        String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
+        Long[] range = null;
+        if (contentRange != null) {
+            String[] tokens = contentRange.split("[ -/]+");
+            try {
+                range = new Long[] { Long.parseLong(tokens[1]), Long.parseLong(tokens[2]) };
+            } catch (NumberFormatException nfe) {
+                throw new SdkClientException(
+                        "Unable to parse content range. Header 'Content-Range' has corrupted data" + nfe.getMessage(),
+                        nfe);
+            }
+        }
+        return range;
+    }
+
+    /**
+     * @return The replication status of the object if it is from a bucket that
+     * is the source or destination in a cross-region replication.
+     */
+    public String getReplicationStatus() {
+        return (String) metadata.get(Headers.OBJECT_REPLICATION_STATUS);
+    }
+
+    /**
+     * The Object Lock mode applied to this object.
+     */
+    public String getObjectLockMode() {
+        return (String) metadata.get(Headers.OBJECT_LOCK_MODE);
+    }
+
+    /**
+     * The date and time this object's Object Lock will expire.
+     */
+    public Date getObjectLockRetainUntilDate() {
+        String dateStr = (String) metadata.get(Headers.OBJECT_LOCK_RETAIN_UNTIL_DATE);
+        if (dateStr != null) {
+            return DateUtils.parseISO8601Date(dateStr);
+        }
+        return null;
+    }
+
+    /**
+     * The Legal Hold status of the specified object.
+     */
+    public String getObjectLockLegalHoldStatus() {
+        return (String) metadata.get(Headers.OBJECT_LOCK_LEGAL_HOLD_STATUS);
+    }
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
@@ -32,631 +32,627 @@ import com.amazonaws.services.s3.internal.ServerSideEncryptionResult;
 import com.amazonaws.util.DateUtils;
 
 /**
- * Represents the object metadata that is stored with Amazon S3. This includes custom
- * user-supplied metadata, as well as the standard HTTP headers that Amazon S3
- * sends and receives (Content-Length, ETag, Content-MD5, etc.).
+ * Represents the object metadata that is stored with Amazon S3. This includes
+ * custom user-supplied metadata, as well as the standard HTTP headers that
+ * Amazon S3 sends and receives (Content-Length, ETag, Content-MD5, etc.).
  */
-public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterChargedResult,
-        ObjectExpirationResult, ObjectRestoreResult, Cloneable, Serializable
-{
-    /*
-     * TODO: Might be nice to get as many of the internal use only methods out
-     *       of here so users never even see them.
-     *       Example: we could set the ETag header directly through the raw
-     *                metadata map instead of having a setter for it.
-     */
+public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterChargedResult, ObjectExpirationResult,
+		ObjectRestoreResult, Cloneable, Serializable {
+	/*
+	 * TODO: Might be nice to get as many of the internal use only methods out of
+	 * here so users never even see them. Example: we could set the ETag header
+	 * directly through the raw metadata map instead of having a setter for it.
+	 */
 
-    /**
-     * Custom user metadata, represented in responses with the x-amz-meta-
-     * header prefix
-     */
-    private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
+	/**
+	 * Custom user metadata, represented in responses with the x-amz-meta- header
+	 * prefix
+	 */
+	private Map<String, String> userMetadata = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
-    /**
-     * All other (non user custom) headers such as Content-Length, Content-Type,
-     * etc.
-     */
-    private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
+	/**
+	 * All other (non user custom) headers such as Content-Length, Content-Type,
+	 * etc.
+	 */
+	private Map<String, Object> metadata = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
 
-    public static final String AES_256_SERVER_SIDE_ENCRYPTION =
-            SSEAlgorithm.AES256.getAlgorithm();
+	public static final String AES_256_SERVER_SIDE_ENCRYPTION = SSEAlgorithm.AES256.getAlgorithm();
 
-    /**
-     * The date when the object is no longer cacheable.
-     */
-    private Date httpExpiresDate;
+	/**
+	 * The date when the object is no longer cacheable.
+	 */
+	private Date httpExpiresDate;
 
-    /**
-     * The time this object will expire and be completely removed from S3, or
-     * null if this object will never expire.
-     * <p>
-     * This and the expiration time rule aren't stored in the metadata map
-     * because the header contains both the time and the rule.
-     */
-    private Date expirationTime;
+	/**
+	 * The time this object will expire and be completely removed from S3, or null
+	 * if this object will never expire.
+	 * <p>
+	 * This and the expiration time rule aren't stored in the metadata map because
+	 * the header contains both the time and the rule.
+	 */
+	private Date expirationTime;
 
-    /**
-     * The expiration rule id for this object.
-     */
-    private String expirationTimeRuleId;
+	/**
+	 * The expiration rule id for this object.
+	 */
+	private String expirationTimeRuleId;
 
-    /**
-     * Boolean value indicating whether there is an ongoing request to restore
-     * an archived copy of this object from Amazon Glacier.
-     */
-    private Boolean ongoingRestore;
+	/**
+	 * Boolean value indicating whether there is an ongoing request to restore an
+	 * archived copy of this object from Amazon Glacier.
+	 */
+	private Boolean ongoingRestore;
 
-    /**
-     * The time at which an object that has been temporarily restored from
-     * Glacier will expire, and will need to be restored again in order to be
-     * accessed. Null if this object has not been restored from Glacier.
-     */
-    private Date restoreExpirationTime;
+	/**
+	 * The time at which an object that has been temporarily restored from Glacier
+	 * will expire, and will need to be restored again in order to be accessed. Null
+	 * if this object has not been restored from Glacier.
+	 */
+	private Date restoreExpirationTime;
 
-    public ObjectMetadata() {}
+	public ObjectMetadata() {
+	}
 
-    private ObjectMetadata(ObjectMetadata from) {
-        this.userMetadata = from.userMetadata == null
-            ? null
-            : new TreeMap<String,String>(from.userMetadata);
-        // shallow clone the meata data
-        this.metadata = from.metadata == null
-            ? null
-            : new TreeMap<String, Object>(from.metadata);
-        this.expirationTime = cloneDate(from.expirationTime);
-        this.expirationTimeRuleId = from.expirationTimeRuleId;
-        this.httpExpiresDate = cloneDate(from.httpExpiresDate);
-        this.ongoingRestore = from.ongoingRestore;
-        this.restoreExpirationTime = cloneDate(from.restoreExpirationTime);
-    }
+	private ObjectMetadata(ObjectMetadata from) {
+		this.userMetadata = from.userMetadata == null ? null : new TreeMap<String, String>(from.userMetadata);
+		// shallow clone the meata data
+		this.metadata = from.metadata == null ? null : new TreeMap<String, Object>(from.metadata);
+		this.expirationTime = cloneDate(from.expirationTime);
+		this.expirationTimeRuleId = from.expirationTimeRuleId;
+		this.httpExpiresDate = cloneDate(from.httpExpiresDate);
+		this.ongoingRestore = from.ongoingRestore;
+		this.restoreExpirationTime = cloneDate(from.restoreExpirationTime);
+	}
 
-    /**
-     * <p>
-     * Gets the custom user-metadata for the associated object.
-     * </p>
-     * <p>
-     * Amazon S3 can store additional metadata on objects by internally
-     * representing it as HTTP headers prefixed with "x-amz-meta-". Use
-     * user-metadata to store arbitrary metadata alongside their data in Amazon
-     * S3. When setting user metadata, callers <i>should not</i> include the
-     * internal "x-amz-meta-" prefix; this library will handle that for them.
-     * Likewise, when callers retrieve custom user-metadata, they will not see
-     * the "x-amz-meta-" header prefix.
-     * </p>
-     * <p>
-     * User-metadata keys are <b>case insensitive</b> and will be returned as
-     * lowercase strings, even if they were originally specified with uppercase
-     * strings.
-     * </p>
-     * <p>
-     * Note that user-metadata for an object is limited by the HTTP request
-     * header limit. All HTTP headers included in a request (including user
-     * metadata headers and other standard HTTP headers) must be less than 8KB.
-     * </p>
-     *
-     * @return The custom user metadata for the associated object.
-     *
-     * @see ObjectMetadata#setUserMetadata(Map)
-     * @see ObjectMetadata#addUserMetadata(String, String)
-     */
-    public Map<String, String> getUserMetadata() {
-        return userMetadata;
-    }
+	/**
+	 * <p>
+	 * Gets the custom user-metadata for the associated object.
+	 * </p>
+	 * <p>
+	 * Amazon S3 can store additional metadata on objects by internally representing
+	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
+	 * arbitrary metadata alongside their data in Amazon S3. When setting user
+	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
+	 * prefix; this library will handle that for them. Likewise, when callers
+	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
+	 * prefix.
+	 * </p>
+	 * <p>
+	 * User-metadata keys are <b>case insensitive</b> and will be returned as
+	 * lowercase strings, even if they were originally specified with uppercase
+	 * strings.
+	 * </p>
+	 * <p>
+	 * Note that user-metadata for an object is limited by the HTTP request header
+	 * limit. All HTTP headers included in a request (including user metadata
+	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * </p>
+	 *
+	 * @return The custom user metadata for the associated object.
+	 *
+	 * @see ObjectMetadata#setUserMetadata(Map)
+	 * @see ObjectMetadata#addUserMetadata(String, String)
+	 */
+	public Map<String, String> getUserMetadata() {
+		return userMetadata;
+	}
 
-    /**
-     * <p>
-     * Sets the custom user-metadata for the associated object.
-     * </p>
-     * <p>
-     * Amazon S3 can store additional metadata on objects by internally
-     * representing it as HTTP headers prefixed with "x-amz-meta-". Use
-     * user-metadata to store arbitrary metadata alongside their data in Amazon
-     * S3. When setting user metadata, callers <i>should not</i> include the
-     * internal "x-amz-meta-" prefix; this library will handle that for them.
-     * Likewise, when callers retrieve custom user-metadata, they will not see
-     * the "x-amz-meta-" header prefix.
-     * </p>
-     * <p>
-     * User-metadata keys are <b>case insensitive</b> and will be returned as
-     * lowercase strings, even if they were originally specified with uppercase
-     * strings.
-     * </p>
-     * <p>
-     * Note that user-metadata for an object is limited by the HTTP request
-     * header limit. All HTTP headers included in a request (including user
-     * metadata headers and other standard HTTP headers) must be less than 8KB.
-     * </p>
-     *
-     * @param userMetadata
-     *            The custom user-metadata for the associated object. Note that
-     *            the key should not include the internal S3 HTTP header prefix.
-     * @see ObjectMetadata#getUserMetadata()
-     * @see ObjectMetadata#addUserMetadata(String, String)
-     */
-    public void setUserMetadata(Map<String, String> userMetadata) {
-        this.userMetadata = userMetadata;
-    }
+	/**
+	 * <p>
+	 * Sets the custom user-metadata for the associated object.
+	 * </p>
+	 * <p>
+	 * Amazon S3 can store additional metadata on objects by internally representing
+	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
+	 * arbitrary metadata alongside their data in Amazon S3. When setting user
+	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
+	 * prefix; this library will handle that for them. Likewise, when callers
+	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
+	 * prefix.
+	 * </p>
+	 * <p>
+	 * User-metadata keys are <b>case insensitive</b> and will be returned as
+	 * lowercase strings, even if they were originally specified with uppercase
+	 * strings.
+	 * </p>
+	 * <p>
+	 * Note that user-metadata for an object is limited by the HTTP request header
+	 * limit. All HTTP headers included in a request (including user metadata
+	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * </p>
+	 *
+	 * @param userMetadata
+	 *            The custom user-metadata for the associated object. Note that the
+	 *            key should not include the internal S3 HTTP header prefix.
+	 * @see ObjectMetadata#getUserMetadata()
+	 * @see ObjectMetadata#addUserMetadata(String, String)
+	 */
+	public void setUserMetadata(Map<String, String> userMetadata) {
+		this.userMetadata = userMetadata;
+	}
 
-    /**
-     * For internal use only. Sets a specific metadata header value. Not
-     * intended to be called by external code.
-     *
-     * @param key
-     *            The name of the header being set.
-     * @param value
-     *            The value for the header.
-     */
-    public void setHeader(String key, Object value) {
-        metadata.put(key, value);
-    }
+	/**
+	 * For internal use only. Sets a specific metadata header value. Not intended to
+	 * be called by external code.
+	 *
+	 * @param key
+	 *            The name of the header being set.
+	 * @param value
+	 *            The value for the header.
+	 */
+	public void setHeader(String key, Object value) {
+		metadata.put(key, value);
+	}
 
-    /**
-     * <p>
-     * Adds the key value pair of custom user-metadata for the associated
-     * object. If the entry in the custom user-metadata map already contains the
-     * specified key, it will be replaced with these new contents.
-     * </p>
-     * <p>
-     * Amazon S3 can store additional metadata on objects by internally
-     * representing it as HTTP headers prefixed with "x-amz-meta-".
-     * Use user-metadata to store arbitrary metadata alongside their data in
-     * Amazon S3. When setting user metadata, callers <i>should not</i> include
-     * the internal "x-amz-meta-" prefix; this library will handle that for
-     * them. Likewise, when callers retrieve custom user-metadata, they will not
-     * see the "x-amz-meta-" header prefix.
-     * </p>
-     * <p>
-     * Note that user-metadata for an object is limited by the HTTP request
-     * header limit. All HTTP headers included in a request (including user
-     * metadata headers and other standard HTTP headers) must be less than 8KB.
-     * </p>
-     *
-     * @param key
-     *            The key for the custom user metadata entry. Note that the key
-     *            should not include
-     *            the internal S3 HTTP header prefix.
-     * @param value
-     *            The value for the custom user-metadata entry.
-     *
-     * @see ObjectMetadata#setUserMetadata(Map)
-     * @see ObjectMetadata#getUserMetadata()
-     */
-    public void addUserMetadata(String key, String value) {
-        this.userMetadata.put(key, value);
-    }
+	/**
+	 * <p>
+	 * Adds the key value pair of custom user-metadata for the associated object. If
+	 * the entry in the custom user-metadata map already contains the specified key,
+	 * it will be replaced with these new contents.
+	 * </p>
+	 * <p>
+	 * Amazon S3 can store additional metadata on objects by internally representing
+	 * it as HTTP headers prefixed with "x-amz-meta-". Use user-metadata to store
+	 * arbitrary metadata alongside their data in Amazon S3. When setting user
+	 * metadata, callers <i>should not</i> include the internal "x-amz-meta-"
+	 * prefix; this library will handle that for them. Likewise, when callers
+	 * retrieve custom user-metadata, they will not see the "x-amz-meta-" header
+	 * prefix.
+	 * </p>
+	 * <p>
+	 * Note that user-metadata for an object is limited by the HTTP request header
+	 * limit. All HTTP headers included in a request (including user metadata
+	 * headers and other standard HTTP headers) must be less than 8KB.
+	 * </p>
+	 *
+	 * @param key
+	 *            The key for the custom user metadata entry. Note that the key
+	 *            should not include the internal S3 HTTP header prefix.
+	 * @param value
+	 *            The value for the custom user-metadata entry.
+	 *
+	 * @see ObjectMetadata#setUserMetadata(Map)
+	 * @see ObjectMetadata#getUserMetadata()
+	 */
+	public void addUserMetadata(String key, String value) {
+		this.userMetadata.put(key, value);
+	}
 
-    /**
-     * Gets a map of the raw metadata/headers for the associated object.
-     *
-     * @return A map of the raw metadata/headers for the associated object.
-     */
-    public Map<String, Object> getRawMetadata() {
-        Map<String,Object> copy = new TreeMap<String,Object>(String.CASE_INSENSITIVE_ORDER);
-        copy.putAll(metadata);
-        return Collections.unmodifiableMap(copy);
-    }
+	/**
+	 * Gets a map of the raw metadata/headers for the associated object.
+	 *
+	 * @return A map of the raw metadata/headers for the associated object.
+	 */
+	public Map<String, Object> getRawMetadata() {
+		Map<String, Object> copy = new TreeMap<String, Object>(String.CASE_INSENSITIVE_ORDER);
+		copy.putAll(metadata);
+		return Collections.unmodifiableMap(copy);
+	}
 
-    /**
-     * Returns the raw value of the metadata/headers for the specified key.
-     */
-    public Object getRawMetadataValue(String key) {
-        return metadata.get(key);
-    }
+	/**
+	 * Returns the raw value of the metadata/headers for the specified key.
+	 */
+	public Object getRawMetadataValue(String key) {
+		return metadata.get(key);
+	}
 
-    /**
-     * Gets the value of the Last-Modified header, indicating the date
-     * and time at which Amazon S3 last recorded a modification to the
-     * associated object.
-     *
-     * @return The date and time at which Amazon S3 last recorded a modification
-     *         to the associated object.
-     */
-    public Date getLastModified() {
-        return cloneDate((Date)metadata.get(Headers.LAST_MODIFIED));
-    }
+	/**
+	 * Gets the value of the Last-Modified header, indicating the date and time at
+	 * which Amazon S3 last recorded a modification to the associated object.
+	 *
+	 * @return The date and time at which Amazon S3 last recorded a modification to
+	 *         the associated object.
+	 */
+	public Date getLastModified() {
+		return cloneDate((Date) metadata.get(Headers.LAST_MODIFIED));
+	}
 
-    /**
-     * For internal use only. Sets the Last-Modified header value
-     * indicating the date and time at which Amazon S3 last recorded a
-     * modification to the associated object.
-     *
-     * @param lastModified
-     *            The date and time at which Amazon S3 last recorded a
-     *            modification to the associated object.
-     */
-    public void setLastModified(Date lastModified) {
-        metadata.put(Headers.LAST_MODIFIED, lastModified);
-    }
+	/**
+	 * For internal use only. Sets the Last-Modified header value indicating the
+	 * date and time at which Amazon S3 last recorded a modification to the
+	 * associated object.
+	 *
+	 * @param lastModified
+	 *            The date and time at which Amazon S3 last recorded a modification
+	 *            to the associated object.
+	 */
+	public void setLastModified(Date lastModified) {
+		metadata.put(Headers.LAST_MODIFIED, lastModified);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the Content-Length HTTP header indicating the size of the
      * associated object in bytes.
-     * </p>
-     * <p>
-     * This field is required when uploading objects to S3, but the AWS S3 Java
-     * client will automatically set it when working directly with files. When
+	 * </p>
+	 * <p>
+	 * This field is required when uploading objects to S3, but the AWS S3 Java
+	 * client will automatically set it when working directly with files. When
      * uploading directly from a stream, set this field if
      * possible. Otherwise the client must buffer the entire stream in
      * order to calculate the content length before sending the data to
      * Amazon S3.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Length HTTP header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
+	 * </p>
+	 *
      * @return The Content-Length HTTP header indicating the size of the
      *         associated object in bytes. Returns <code>null</code>
      *         if it hasn't been set yet.
-     *
-     * @see ObjectMetadata#setContentLength(long)
-     */
-    public long getContentLength() {
-        Long contentLength = (Long)metadata.get(Headers.CONTENT_LENGTH);
+	 *
+	 * @see ObjectMetadata#setContentLength(long)
+	 */
+	public long getContentLength() {
+		Long contentLength = (Long) metadata.get(Headers.CONTENT_LENGTH);
+		if (metadata.containsKey(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)) {
+			contentLength = Long.valueOf(String.valueOf(metadata.get(Headers.X_AMZN_REMAPPED_CONTENT_LENGTH)));
+		}
 
-        if (contentLength == null) return 0;
-        return contentLength.longValue();
-    }
+		if (contentLength == null)
+			return 0;
+		return contentLength.longValue();
+	}
 
-    /**
+	/**
      * Returns the physical length of the entire object stored in S3.
      * This is useful during, for example, a range get operation.
-     */
-    public long getInstanceLength() {
-        // See Content-Range in
-        // http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
-        String contentRange = (String)metadata.get(Headers.CONTENT_RANGE);
-        if (contentRange != null) {
-            int pos = contentRange.lastIndexOf("/");
-            if (pos >= 0)
-                return Long.parseLong(contentRange.substring(pos+1));
-        }
-        return getContentLength();
-    }
+	 */
+	public long getInstanceLength() {
+		// See Content-Range in
+		// http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html
+		String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
+		if (contentRange != null) {
+			int pos = contentRange.lastIndexOf("/");
+			if (pos >= 0)
+				return Long.parseLong(contentRange.substring(pos + 1));
+		}
+		return getContentLength();
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the Content-Length HTTP header indicating the size of the
      * associated object in bytes.
-     * </p>
-     * <p>
-     * This field is required when uploading objects to S3, but the AWS S3 Java
-     * client will automatically set it when working directly with files. When
+	 * </p>
+	 * <p>
+	 * This field is required when uploading objects to S3, but the AWS S3 Java
+	 * client will automatically set it when working directly with files. When
      * uploading directly from a stream, set this field if
      * possible. Otherwise the client must buffer the entire stream in
      * order to calculate the content length before sending the data to
      * Amazon S3.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Length HTTP header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
-     * </p>
-     *
-     * @param contentLength
-     *            The Content-Length HTTP header indicating the size of the
-     *            associated object in bytes.
-     *
-     * @see ObjectMetadata#getContentLength()
-     */
-    public void setContentLength(long contentLength) {
-        metadata.put(Headers.CONTENT_LENGTH, contentLength);
-    }
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.13</a>
+	 * </p>
+	 *
+	 * @param contentLength
+	 *            The Content-Length HTTP header indicating the size of the
+	 *            associated object in bytes.
+	 *
+	 * @see ObjectMetadata#getContentLength()
+	 */
+	public void setContentLength(long contentLength) {
+		metadata.put(Headers.CONTENT_LENGTH, contentLength);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the Content-Type HTTP header, which indicates the type of content
      * stored in the associated object. The value of this header is a standard
      * MIME type.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * When uploading files, the AWS S3 Java client will attempt to determine
      * the correct content type if one hasn't been set yet. Users are
      * responsible for ensuring a suitable content type is set when uploading
      * streams. If no content type is provided and cannot be determined by
      * the filename, the default content type, "application/octet-stream", will
      * be used.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Type header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+	 * </p>
+	 *
      * @return The HTTP Content-Type header, indicating the type of content
      *         stored in the associated S3 object. Returns <code>null</code>
      *         if it hasn't been
      *         set.
-     *
-     * @see ObjectMetadata#setContentType(String)
-     */
-    public String getContentType() {
-        return (String)metadata.get(Headers.CONTENT_TYPE);
-    }
+	 *
+	 * @see ObjectMetadata#setContentType(String)
+	 */
+	public String getContentType() {
+		return (String) metadata.get(Headers.CONTENT_TYPE);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the Content-Type HTTP header indicating the type of content
      * stored in the associated object. The value of this header is a standard
      * MIME type.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * When uploading files, the AWS S3 Java client will attempt to determine
      * the correct content type if one hasn't been set yet. Users are
      * responsible for ensuring a suitable content type is set when uploading
      * streams. If no content type is provided and cannot be determined by
      * the filename, the default content type "application/octet-stream" will
      * be used.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Type header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-     * </p>
-     *
-     * @param contentType
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+	 * </p>
+	 *
+	 * @param contentType
      *            The HTTP Content-Type header indicating the type of content
      *            stored in the associated S3 object.
-     *
-     * @see ObjectMetadata#getContentType()
-     */
-    public void setContentType(String contentType) {
-        metadata.put(Headers.CONTENT_TYPE, contentType);
-    }
+	 *
+	 * @see ObjectMetadata#getContentType()
+	 */
+	public void setContentType(String contentType) {
+		metadata.put(Headers.CONTENT_TYPE, contentType);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the Content-Language HTTP header, which describes the natural language(s) of the
      * intended audience for the enclosed entity.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Type header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+	 * </p>
+	 *
      * @return The HTTP Content-Language header, which describes the natural language(s) of the
      * intended audience for the enclosed entity. Returns <code>null</code>
      *         if it hasn't been set.
-     *
-     * @see ObjectMetadata#setContentLanguage(String)
-     */
-    public String getContentLanguage() {
-        return (String)metadata.get(Headers.CONTENT_LANGUAGE);
-    }
+	 *
+	 * @see ObjectMetadata#setContentLanguage(String)
+	 */
+	public String getContentLanguage() {
+		return (String) metadata.get(Headers.CONTENT_LANGUAGE);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the Content-Language HTTP header which describes the natural language(s) of the
      * intended audience for the enclosed entity.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * For more information on the Content-Type header, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
-     * </p>
-     *
-     * @param contentLanguage
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.17</a>
+	 * </p>
+	 *
+	 * @param contentLanguage
      *            The HTTP Content-Language header which describes the natural language(s) of the
      * intended audience for the enclosed entity.
-     *
-     * @see ObjectMetadata#getContentLanguage()
-     */
-    public void setContentLanguage(String contentLanguage) {
-        metadata.put(Headers.CONTENT_LANGUAGE, contentLanguage);
-    }
+	 *
+	 * @see ObjectMetadata#getContentLanguage()
+	 */
+	public void setContentLanguage(String contentLanguage) {
+		metadata.put(Headers.CONTENT_LANGUAGE, contentLanguage);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the optional Content-Encoding HTTP header specifying what
      * content encodings have been applied to the object and what decoding
      * mechanisms must be applied in order to obtain the media-type referenced
      * by the Content-Type field.
-     * </p>
-     * <p>
-     * For more information on how the Content-Encoding HTTP header works, see
+	 * </p>
+	 * <p>
+	 * For more information on how the Content-Encoding HTTP header works, see
      * <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+	 * </p>
+	 *
      * @return The HTTP Content-Encoding header.
      * Returns <code>null</code> if it hasn't been set.
-     *
-     * @see ObjectMetadata#setContentEncoding(String)
-     */
-    public String getContentEncoding() {
-        return (String)metadata.get(Headers.CONTENT_ENCODING);
-    }
+	 *
+	 * @see ObjectMetadata#setContentEncoding(String)
+	 */
+	public String getContentEncoding() {
+		return (String) metadata.get(Headers.CONTENT_ENCODING);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the optional Content-Encoding HTTP header specifying what
      * content encodings have been applied to the object and what decoding
      * mechanisms must be applied in order to obtain the media-type referenced
      * by the Content-Type field.
-     * </p>
-     * <p>
-     * For more information on how the Content-Encoding HTTP header works, see
+	 * </p>
+	 * <p>
+	 * For more information on how the Content-Encoding HTTP header works, see
      * <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-     * </p>
-     *
-     * @param encoding
-     *            The HTTP Content-Encoding header, as defined in RFC 2616.
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+	 * </p>
+	 *
+	 * @param encoding
+	 *            The HTTP Content-Encoding header, as defined in RFC 2616.
+	 *
      * @see <a
      *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11"
-     *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
-     *
-     * @see ObjectMetadata#getContentEncoding()
-     */
-    public void setContentEncoding(String encoding) {
-        metadata.put(Headers.CONTENT_ENCODING, encoding);
-    }
+	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.11</a>
+	 *
+	 * @see ObjectMetadata#getContentEncoding()
+	 */
+	public void setContentEncoding(String encoding) {
+		metadata.put(Headers.CONTENT_ENCODING, encoding);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the optional Cache-Control HTTP header which allows the user to
      * specify caching behavior along the HTTP request/reply chain.
-     * </p>
-     * <p>
-     * For more information on how the Cache-Control HTTP header affects HTTP
+	 * </p>
+	 * <p>
+	 * For more information on how the Cache-Control HTTP header affects HTTP
      * requests and responses, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
+	 * </p>
+	 *
      * @return The HTTP Cache-Control header as defined in RFC 2616.
      *         Returns <code>null</code>  if
      *         it hasn't been set.
-     *
-     * @see ObjectMetadata#setCacheControl(String)
-     */
-    public String getCacheControl() {
-        return (String)metadata.get(Headers.CACHE_CONTROL);
-    }
+	 *
+	 * @see ObjectMetadata#setCacheControl(String)
+	 */
+	public String getCacheControl() {
+		return (String) metadata.get(Headers.CACHE_CONTROL);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the optional Cache-Control HTTP header which allows the user to
      * specify caching behavior along the HTTP request/reply chain.
-     * </p>
-     * <p>
-     * For more information on how the Cache-Control HTTP header affects HTTP
+	 * </p>
+	 * <p>
+	 * For more information on how the Cache-Control HTTP header affects HTTP
      * requests and responses see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
-     * </p>
-     *
-     * @param cacheControl
-     *            The HTTP Cache-Control header as defined in RFC 2616.
-     *
-     * @see ObjectMetadata#getCacheControl()
-     */
-    public void setCacheControl(String cacheControl) {
-        metadata.put(Headers.CACHE_CONTROL, cacheControl);
-    }
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html#sec14.9</a>
+	 * </p>
+	 *
+	 * @param cacheControl
+	 *            The HTTP Cache-Control header as defined in RFC 2616.
+	 *
+	 * @see ObjectMetadata#getCacheControl()
+	 */
+	public void setCacheControl(String cacheControl) {
+		metadata.put(Headers.CACHE_CONTROL, cacheControl);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Sets the base64 encoded 128-bit MD5 digest of the associated object
      * (content - not including headers) according to RFC 1864. This data is
      * used as a message integrity check to verify that the data received by
      * Amazon S3 is the same data that the caller sent. If set to null,then the
      * MD5 digest is removed from the metadata.
-     * </p>
-     * <p>
-     * This field represents the base64 encoded 128-bit MD5 digest digest of an
+	 * </p>
+	 * <p>
+	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
      * object's content as calculated on the caller's side. The ETag metadata
      * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
      * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
-     * </p>
-     * <p>
-     * The AWS S3 Java client will attempt to calculate this field automatically
-     * when uploading files to Amazon S3.
-     * </p>
-     *
-     * @param md5Base64
-     *            The base64 encoded MD5 hash of the content for the object
-     *            associated with this metadata.
-     *
-     * @see ObjectMetadata#getContentMD5()
-     */
-    public void setContentMD5(String md5Base64) {
-        if(md5Base64 == null){
-            metadata.remove(Headers.CONTENT_MD5);
-        }else{
-            metadata.put(Headers.CONTENT_MD5, md5Base64);
-        }
+	 * </p>
+	 * <p>
+	 * The AWS S3 Java client will attempt to calculate this field automatically
+	 * when uploading files to Amazon S3.
+	 * </p>
+	 *
+	 * @param md5Base64
+	 *            The base64 encoded MD5 hash of the content for the object
+	 *            associated with this metadata.
+	 *
+	 * @see ObjectMetadata#getContentMD5()
+	 */
+	public void setContentMD5(String md5Base64) {
+		if (md5Base64 == null) {
+			metadata.remove(Headers.CONTENT_MD5);
+		} else {
+			metadata.put(Headers.CONTENT_MD5, md5Base64);
+		}
 
-    }
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Gets the base64 encoded 128-bit MD5 digest of the associated object
      * (content - not including headers) according to RFC 1864. This data is
      * used as a message integrity check to verify that the data received by
      * Amazon S3 is the same data that the caller sent.
-     * </p>
-     * <p>
-     * This field represents the base64 encoded 128-bit MD5 digest digest of an
+	 * </p>
+	 * <p>
+	 * This field represents the base64 encoded 128-bit MD5 digest digest of an
      * object's content as calculated on the caller's side. The ETag metadata
      * field sometimes (but not always) represents the hex encoded 128-bit MD5 digest as computed by Amazon
      * S3. See the documentation at {@link #getETag()} for more information on what the ETag field represents.
-     * </p>
-     * <p>
-     * The AWS S3 Java client will attempt to calculate this field automatically
-     * when uploading files to Amazon S3.
-     * </p>
-     *
+	 * </p>
+	 * <p>
+	 * The AWS S3 Java client will attempt to calculate this field automatically
+	 * when uploading files to Amazon S3.
+	 * </p>
+	 *
      * @return The base64 encoded MD5 hash of the content for the associated
      *         object.  Returns <code>null</code> if the MD5 hash of the content
      *         hasn't been set.
-     *
-     * @see ObjectMetadata#setContentMD5(String)
-     */
-    public String getContentMD5() {
-        return (String)metadata.get(Headers.CONTENT_MD5);
-    }
+	 *
+	 * @see ObjectMetadata#setContentMD5(String)
+	 */
+	public String getContentMD5() {
+		return (String) metadata.get(Headers.CONTENT_MD5);
+	}
 
-    /**
-     * <p>
-     * Sets the optional Content-Disposition HTTP header, which specifies
+	/**
+	 * <p>
+	 * Sets the optional Content-Disposition HTTP header, which specifies
      * presentational information such as the recommended filename for the
      * object to be saved as.
-     * </p>
-     * <p>
-     * For more information on how the Content-Disposition header affects HTTP
+	 * </p>
+	 * <p>
+	 * For more information on how the Content-Disposition header affects HTTP
      * client behavior, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-     * </p>
-     *
-     * @param disposition
-     *            The value for the Content-Disposition header.
-     *
-     * @see ObjectMetadata#getContentDisposition()
-     */
-    public void setContentDisposition(String disposition) {
-        metadata.put(Headers.CONTENT_DISPOSITION, disposition);
-    }
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+	 * </p>
+	 *
+	 * @param disposition
+	 *            The value for the Content-Disposition header.
+	 *
+	 * @see ObjectMetadata#getContentDisposition()
+	 */
+	public void setContentDisposition(String disposition) {
+		metadata.put(Headers.CONTENT_DISPOSITION, disposition);
+	}
 
-    /**
-     * <p>
-     * Gets the optional Content-Disposition HTTP header, which specifies
+	/**
+	 * <p>
+	 * Gets the optional Content-Disposition HTTP header, which specifies
      * presentation information for the object such as the recommended filename
      * for the object to be saved as.
-     * </p>
-     * <p>
-     * For more information on how the Content-Disposition header affects HTTP
+	 * </p>
+	 * <p>
+	 * For more information on how the Content-Disposition header affects HTTP
      * client behavior, see <a
      * href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1">
-     * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-     * </p>
-     *
+	 * http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+	 * </p>
+	 *
      * @return The value of the Content-Disposition header.
      *         Returns <code>null</code> if the Content-Disposition header
      *         hasn't been set.
-     *
+	 *
      * @see <a
      *      href="http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1"
-     *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
-     *
-     * @see ObjectMetadata#setCacheControl(String)
-     */
-    public String getContentDisposition() {
-        return (String)metadata.get(Headers.CONTENT_DISPOSITION);
-    }
+	 *      >http://www.w3.org/Protocols/rfc2616/rfc2616-sec19.html#sec19.5.1</a>
+	 *
+	 * @see ObjectMetadata#setCacheControl(String)
+	 */
+	public String getContentDisposition() {
+		return (String) metadata.get(Headers.CONTENT_DISPOSITION);
+	}
 
-    /**
+	/**
      * The entity tag is a hash of the object. The ETag reflects changes only to the contents of an object, not its metadata.
      * The ETag may or may not be an MD5 digest of the object data. Whether or not it is depends on how the object was created
      * and how it is encrypted as described below:
-     * <ul>
+	 * <ul>
      * <li>
      * Objects created by the PUT Object, POST Object, or Copy operation, or through the AWS Management Console, and are encrypted
      * by SSE-S3 or plaintext, have ETags that are an MD5 digest of their object data.
@@ -669,293 +665,289 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
      * If an object is created by either the Multipart Upload or Part Copy operation, the ETag is not an MD5 digest, regardless of
      * the method of encryption.
      * </li>
-     * </ul>
-     *
-     * @return The ETag of the object or <code>null</code>if it hasn't been set yet.
-     */
-    public String getETag() {
-        return (String)metadata.get(Headers.ETAG);
-    }
+	 * </ul>
+	 *
+	 * @return The ETag of the object or <code>null</code>if it hasn't been set yet.
+	 */
+	public String getETag() {
+		return (String) metadata.get(Headers.ETAG);
+	}
 
-    /**
+	/**
      * Gets the version ID of the associated Amazon S3 object if available.
      * Version IDs are only assigned to objects when an object is uploaded to an
      * Amazon S3 bucket that has object versioning enabled.
-     *
-     * @return The version ID of the associated Amazon S3 object if available.
-     */
-    public String getVersionId() {
-        return (String)metadata.get(Headers.S3_VERSION_ID);
-    }
+	 *
+	 * @return The version ID of the associated Amazon S3 object if available.
+	 */
+	public String getVersionId() {
+		return (String) metadata.get(Headers.S3_VERSION_ID);
+	}
 
-    /**
+	/**
      * Returns the server-side encryption algorithm when encrypting the object
      * using AWS-managed keys .
-     */
-    @Override
-    public String getSSEAlgorithm() {
-        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
-    }
+	 */
+	@Override
+	public String getSSEAlgorithm() {
+		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+	}
 
-    /**
-     * @deprecated Replaced by {@link #getSSEAlgorithm()}
-     */
-    @Deprecated
-    public String getServerSideEncryption() {
-        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
-    }
+	/**
+	 * @deprecated Replaced by {@link #getSSEAlgorithm()}
+	 */
+	@Deprecated
+	public String getServerSideEncryption() {
+		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION);
+	}
 
-    /**
+	/**
      * Sets the server-side encryption algorithm when encrypting the object
-     * using AWS-managed keys.
+	 *            using AWS-managed keys .
      *
      * @param algorithm
      *            The server-side encryption algorithm when encrypting the
      *            object using AWS-managed keys .
-     */
-    @Override
-    public void setSSEAlgorithm(String algorithm) {
-        metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
-    }
+	 */
+	@Override
+	public void setSSEAlgorithm(String algorithm) {
+		metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
+	}
 
+	/**
+	 * @deprecated Replaced by {@link #setSSEAlgorithm(String)}
+	 */
+	@Deprecated
+	public void setServerSideEncryption(String algorithm) {
+		metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
+	}
 
-    /**
-     * @deprecated Replaced by {@link #setSSEAlgorithm(String)}
-     */
-    @Deprecated
-    public void setServerSideEncryption(String algorithm) {
-        metadata.put(Headers.SERVER_SIDE_ENCRYPTION, algorithm);
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getSSECustomerAlgorithm() {
+		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getSSECustomerAlgorithm() {
-        return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM);
-    }
+	/**
+	 * For internal use only. This method is only used to set the value in the
+	 * object after receiving the value in a response from S3. When sending
+	 * requests, use {@link SSECustomerKey} members in request objects.
+	 */
+	@Override
+	public void setSSECustomerAlgorithm(String algorithm) {
+		metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, algorithm);
+	}
 
-    /**
-     * For internal use only. This method is only used to set the value in the
-     * object after receiving the value in a response from S3. When sending
-     * requests, use {@link SSECustomerKey} members in request objects.
-     */
-    @Override
-    public void setSSECustomerAlgorithm(String algorithm) {
-        metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_ALGORITHM, algorithm);
-    }
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public String getSSECustomerKeyMd5() {
+		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
+	}
 
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String getSSECustomerKeyMd5() {
-        return (String)metadata.get(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5);
-    }
+	/**
+	 * For internal use only. This method is only used to set the value in the
+	 * object after receiving the value in a response from S3. When sending
+	 * requests, use {@link SSECustomerKey} members in request objects.
+	 */
+	public void setSSECustomerKeyMd5(String md5Digest) {
+		metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, md5Digest);
+	}
 
-    /**
-     * For internal use only. This method is only used to set the value in the
-     * object after receiving the value in a response from S3. When sending
-     * requests, use {@link SSECustomerKey} members in request objects.
-     */
-    public void setSSECustomerKeyMd5(String md5Digest) {
-        metadata.put(Headers.SERVER_SIDE_ENCRYPTION_CUSTOMER_KEY_MD5, md5Digest);
-    }
-
-    /**
+	/**
      * Returns the time this object will expire and be completely removed from
      * S3. Returns null if this object will never expire.
-     */
-    public Date getExpirationTime() {
-        return cloneDate(expirationTime);
-    }
+	 */
+	public Date getExpirationTime() {
+		return cloneDate(expirationTime);
+	}
 
-    /**
+	/**
      * For internal use only. This will *not* set the object's expiration time,
      * and is only used to set the value in the object after receiving the value
      * in a response from S3.
-     *
-     * @param expirationTime
-     *            The expiration time for the object.
-     */
-    public void setExpirationTime(Date expirationTime) {
-        this.expirationTime = expirationTime;
-    }
+	 *
+	 * @param expirationTime
+	 *            The expiration time for the object.
+	 */
+	public void setExpirationTime(Date expirationTime) {
+		this.expirationTime = expirationTime;
+	}
 
-    /**
+	/**
      * Returns the {@link BucketLifecycleConfiguration} rule ID for this
      * object's expiration, or null if it doesn't expire.
-     */
-    public String getExpirationTimeRuleId() {
-        return expirationTimeRuleId;
-    }
+	 */
+	public String getExpirationTimeRuleId() {
+		return expirationTimeRuleId;
+	}
 
-    /**
+	/**
      * For internal use only. This will *not* set the object's expiration time
      * rule id, and is only used to set the value in the object after receiving
      * the value in a response from S3.
-     */
-    public void setExpirationTimeRuleId(String expirationTimeRuleId) {
-        this.expirationTimeRuleId = expirationTimeRuleId;
-    }
+	 */
+	public void setExpirationTimeRuleId(String expirationTimeRuleId) {
+		this.expirationTimeRuleId = expirationTimeRuleId;
+	}
 
-
-    /**
+	/**
      * Returns the time at which an object that has been temporarily restored
      * from Amazon Glacier will expire, and will need to be restored again in
      * order to be accessed. Returns null if this is not a temporary copy of an
      * object restored from Glacier.
-     */
-    public Date getRestoreExpirationTime() {
-        return cloneDate(restoreExpirationTime);
-    }
+	 */
+	public Date getRestoreExpirationTime() {
+		return cloneDate(restoreExpirationTime);
+	}
 
-    /**
+	/**
      * For internal use only. This will *not* set the object's restore
      * expiration time, and is only used to set the value in the object after
      * receiving the value in a response from S3.
-     *
-     * @param restoreExpirationTime
-     *            The new restore expiration time for the object.
-     */
-    public void setRestoreExpirationTime(Date restoreExpirationTime) {
-        this.restoreExpirationTime = restoreExpirationTime;
-    }
+	 *
+	 * @param restoreExpirationTime
+	 *            The new restore expiration time for the object.
+	 */
+	public void setRestoreExpirationTime(Date restoreExpirationTime) {
+		this.restoreExpirationTime = restoreExpirationTime;
+	}
 
-    /**
+	/**
      * For internal use only. Sets the boolean value which indicates whether
      * there is ongoing restore request. Not intended to be called by external
      * code.
-     */
-    public void setOngoingRestore(boolean ongoingRestore) {
-        this.ongoingRestore = Boolean.valueOf(ongoingRestore);
-    }
+	 */
+	public void setOngoingRestore(boolean ongoingRestore) {
+		this.ongoingRestore = Boolean.valueOf(ongoingRestore);
+	}
 
-
-    /**
+	/**
      *  Returns the boolean value which indicates whether there is ongoing restore request.
-     */
-    public Boolean getOngoingRestore() {
-        return this.ongoingRestore;
-    }
+	 */
+	public Boolean getOngoingRestore() {
+		return this.ongoingRestore;
+	}
 
-    /**
-     *  Set the date when the object is no longer cacheable.
-     */
-    public void setHttpExpiresDate(Date httpExpiresDate) {
-        this.httpExpiresDate = httpExpiresDate;
-    }
+	/**
+	 * Set the date when the object is no longer cacheable.
+	 */
+	public void setHttpExpiresDate(Date httpExpiresDate) {
+		this.httpExpiresDate = httpExpiresDate;
+	}
 
-    /**
-     * Returns the date when the object is no longer cacheable.
-     */
-    public Date getHttpExpiresDate() {
-        return cloneDate(httpExpiresDate);
-    }
+	/**
+	 * Returns the date when the object is no longer cacheable.
+	 */
+	public Date getHttpExpiresDate() {
+		return cloneDate(httpExpiresDate);
+	}
 
-    /**
+	/**
      * @return The storage class of the object. Returns null if the object is in STANDARD storage.
      *         See {@link StorageClass} for possible values
-     */
-    public String getStorageClass() {
-        final Object storageClass = metadata.get(Headers.STORAGE_CLASS);
-        if (storageClass == null) {
-            return null;
-        }
-        return storageClass.toString();
-    }
+	 */
+	public String getStorageClass() {
+		final Object storageClass = metadata.get(Headers.STORAGE_CLASS);
+		if (storageClass == null) {
+			return null;
+		}
+		return storageClass.toString();
+	}
 
-    /**
-     * Returns the value of the specified user meta datum.
-     */
-    public String getUserMetaDataOf(String key) {
-        return userMetadata == null ? null : userMetadata.get(key);
-    }
+	/**
+	 * Returns the value of the specified user meta datum.
+	 */
+	public String getUserMetaDataOf(String key) {
+		return userMetadata == null ? null : userMetadata.get(key);
+	}
 
-    /**
+	/**
      * Returns a clone of this <code>ObjectMetadata</code>. Note the clone of
      * the internal {@link #metadata} is limited to a shallow copy due to the
      * unlimited type of value in the map. Other fields can be regarded as deep
      * clone.
-     */
-    public ObjectMetadata clone() {
-        return new ObjectMetadata(this);
-    }
+	 */
+	public ObjectMetadata clone() {
+		return new ObjectMetadata(this);
+	}
 
-    /**
+	/**
      * Returns the AWS Key Management System key id used for Server Side
      * Encryption of the Amazon S3 object.
-     */
-    public String getSSEAwsKmsKeyId() {
-        return (String) metadata
-                .get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
-    }
+	 */
+	public String getSSEAwsKmsKeyId() {
+		return (String) metadata.get(Headers.SERVER_SIDE_ENCRYPTION_AWS_KMS_KEYID);
+	}
 
-    @Override
-    public boolean isRequesterCharged() {
-        return metadata.get(Headers.REQUESTER_CHARGED_HEADER) != null;
-    }
+	@Override
+	public boolean isRequesterCharged() {
+		return metadata.get(Headers.REQUESTER_CHARGED_HEADER) != null;
+	}
 
-    @Override
-    public void setRequesterCharged(boolean isRequesterCharged) {
-        if (isRequesterCharged) {
-            metadata.put(Headers.REQUESTER_CHARGED_HEADER, Constants.REQUESTER_PAYS);
-        }
-    }
+	@Override
+	public void setRequesterCharged(boolean isRequesterCharged) {
+		if (isRequesterCharged) {
+			metadata.put(Headers.REQUESTER_CHARGED_HEADER, Constants.REQUESTER_PAYS);
+		}
+	}
 
-    /**
-     * <p>
-     * Returns the value of x-amz-mp-parts-count header.
-     * </p>
-     * <p>
+	/**
+	 * <p>
+	 * Returns the value of x-amz-mp-parts-count header.
+	 * </p>
+	 * <p>
      * The x-amz-mp-parts-count header is returned in the response only when
      * a valid partNumber is specified in the request and the object has more than 1 part.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * To find the part count of an object, set the partNumber to 1 in GetObjectRequest.
      * If the object has more than 1 part then part count will be returned,
      * otherwise null is returned.
-     * </p>
-     */
-    public Integer getPartCount() {
-        return (Integer) metadata.get(Headers.S3_PARTS_COUNT);
-    }
+	 * </p>
+	 */
+	public Integer getPartCount() {
+		return (Integer) metadata.get(Headers.S3_PARTS_COUNT);
+	}
 
-    /**
-     * <p>
+	/**
+	 * <p>
      * Returns the content range of the object if response contains the Content-Range header.
-     * </p>
-     * <p>
+	 * </p>
+	 * <p>
      * If the request specifies a range or part number, then response returns the Content-Range range header.
      * Otherwise, the response does not return Content-Range header.
-     * </p>
+	 * </p>
      * @return
      * 		Returns content range if the object is requested with specific range or part number,
      * 		null otherwise.
-     */
-    public Long[] getContentRange() {
-        String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
-        Long[] range = null;
-        if (contentRange != null) {
-            String[] tokens = contentRange.split("[ -/]+");
-            try {
-                range = new Long[] { Long.parseLong(tokens[1]), Long.parseLong(tokens[2]) };
-            } catch (NumberFormatException nfe) {
-                throw new SdkClientException(
-                        "Unable to parse content range. Header 'Content-Range' has corrupted data" + nfe.getMessage(),
-                        nfe);
-            }
-        }
-        return range;
-    }
+	 */
+	public Long[] getContentRange() {
+		String contentRange = (String) metadata.get(Headers.CONTENT_RANGE);
+		Long[] range = null;
+		if (contentRange != null) {
+			String[] tokens = contentRange.split("[ -/]+");
+			try {
+				range = new Long[] { Long.parseLong(tokens[1]), Long.parseLong(tokens[2]) };
+			} catch (NumberFormatException nfe) {
+				throw new SdkClientException(
+						"Unable to parse content range. Header 'Content-Range' has corrupted data" + nfe.getMessage(),
+						nfe);
+			}
+		}
+		return range;
+	}
 
-    /**
+	/**
      * @return The replication status of the object if it is from a bucket that
      * is the source or destination in a cross-region replication.
-     */
-    public String getReplicationStatus() {
-        return (String) metadata.get(Headers.OBJECT_REPLICATION_STATUS);
-    }
+	 */
+	public String getReplicationStatus() {
+		return (String) metadata.get(Headers.OBJECT_REPLICATION_STATUS);
+	}
 
     /**
      * The Object Lock mode applied to this object.


### PR DESCRIPTION
1 - Custom header values should be copied to download request for large files. 
2 - while downloading large files via Amazon Api Gateway, uploads parameter will be needed for CreateMultipartUpload. but because of the null value, it cannot be parsed. I added a random value for this field.
3 - Api gateway overrite the content-length field, and add "x-amzn-Remapped-Content-Length" for the file size. 
