### PR TITLE
Throw exception when credentials field is null for AbstractAWSSigner.sanitizeCredentials

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/AbstractAWSSigner.java
@@ -414,6 +414,9 @@ public abstract class AbstractAWSSigner implements Signer {
         String accessKeyId = null;
         String secretKey   = null;
         String token = null;
+        if (credentials == null) {
+             throw new SdkClientException("Please use withCredentials on AmazonS3ClientBuilder");
+        }
         synchronized (credentials) {
             accessKeyId = credentials.getAWSAccessKeyId();
             secretKey   = credentials.getAWSSecretKey();


### PR DESCRIPTION
Currently if withCredentials() is not called on AmazonS3ClientBuilder, the user would get NPE similar to the following:
```
Exception in thread "main" java.lang.NullPointerException
	at com.amazonaws.auth.AbstractAWSSigner.sanitizeCredentials(AbstractAWSSigner.java:411)
	at com.amazonaws.auth.AWS4Signer.presignRequest(AWS4Signer.java:273)
	at com.amazonaws.services.s3.AmazonS3Client.generatePresignedUrl(AmazonS3Client.java:3009)
```
This PR checks whether credentials field is null in AbstractAWSSigner.sanitizeCredentials . If the field is null, throw exception alerting user of the scenario.