### PR TITLE
Catch Throwable to deal with NoClassDefFoundError (#1863)

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/Base64.java
@@ -57,7 +57,7 @@ public enum Base64 {
                              "results of the encodeAsString() method may be incorrect. Implementation: " +
                              inconsistentJaxbImpls.get(className));
                 }
-            } catch (Exception ignored) {
+            } catch (Throwable ignored) {
             }
         } else {
             LOG.warn("JAXB is unavailable. Will fallback to SDK implementation which may be less performant");


### PR DESCRIPTION
Not having certain classes on the classpath results in a
NoClassDefFoundError (that wraps a ClassNotFoundException)
which causes static initialization failure. Protect against
that by catching Throwable instead of Exception.