### PR TITLE
Synchronize overridden synchronized methods

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/event/ProgressInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/event/ProgressInputStream.java
@@ -164,7 +164,7 @@ public abstract class ProgressInputStream extends SdkFilterInputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         super.reset();
         onReset();
         unnotifiedByteCount = 0;

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateInputStream.java
@@ -52,10 +52,10 @@ public class DelegateInputStream extends InputStream {
         in.close();
     }
 
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         in.mark(readlimit);
     }
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         in.reset();
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateSSLSocket.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateSSLSocket.java
@@ -129,32 +129,32 @@ public class DelegateSSLSocket extends SSLSocket {
     }
 
     @Override
-    public void setSoTimeout(int timeout) throws SocketException {
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
         sock.setSoTimeout(timeout);
     }
 
     @Override
-    public int getSoTimeout() throws SocketException {
+    public synchronized int getSoTimeout() throws SocketException {
         return sock.getSoTimeout();
     }
 
     @Override
-    public void setSendBufferSize(int size) throws SocketException {
+    public synchronized void setSendBufferSize(int size) throws SocketException {
         sock.setSendBufferSize(size);
     }
 
     @Override
-    public int getSendBufferSize() throws SocketException {
+    public synchronized int getSendBufferSize() throws SocketException {
         return sock.getSendBufferSize();
     }
 
     @Override
-    public void setReceiveBufferSize(int size) throws SocketException {
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
         sock.setReceiveBufferSize(size);
     }
 
     @Override
-    public int getReceiveBufferSize() throws SocketException {
+    public synchronized int getReceiveBufferSize() throws SocketException {
         return sock.getReceiveBufferSize();
     }
 
@@ -189,7 +189,7 @@ public class DelegateSSLSocket extends SSLSocket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         sock.close();
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateSocket.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/DelegateSocket.java
@@ -133,32 +133,32 @@ public class DelegateSocket extends Socket {
     }
 
     @Override
-    public void setSoTimeout(int timeout) throws SocketException {
+    public synchronized void setSoTimeout(int timeout) throws SocketException {
         sock.setSoTimeout(timeout);
     }
 
     @Override
-    public int getSoTimeout() throws SocketException {
+    public synchronized int getSoTimeout() throws SocketException {
         return sock.getSoTimeout();
     }
 
     @Override
-    public void setSendBufferSize(int size) throws SocketException {
+    public synchronized void setSendBufferSize(int size) throws SocketException {
         sock.setSendBufferSize(size);
     }
 
     @Override
-    public int getSendBufferSize() throws SocketException {
+    public synchronized int getSendBufferSize() throws SocketException {
         return sock.getSendBufferSize();
     }
 
     @Override
-    public void setReceiveBufferSize(int size) throws SocketException {
+    public synchronized void setReceiveBufferSize(int size) throws SocketException {
         sock.setReceiveBufferSize(size);
     }
 
     @Override
-    public int getReceiveBufferSize() throws SocketException {
+    public synchronized int getReceiveBufferSize() throws SocketException {
         return sock.getReceiveBufferSize();
     }
 
@@ -193,7 +193,7 @@ public class DelegateSocket extends Socket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         sock.close();
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/ResettableInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/ResettableInputStream.java
@@ -140,7 +140,7 @@ public class ResettableInputStream extends ReleasableInputStream {
      *            ignored
      */
     @Override
-    public void mark(int _) {
+    public synchronized void mark(int _) {
         abortIfNeeded();
         try {
             markPos = fileChannel.position();
@@ -169,7 +169,7 @@ public class ResettableInputStream extends ReleasableInputStream {
      * becomes the only way to truly close the opened file.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         fileChannel.position(markPos);
         if (log.isTraceEnabled())

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkBufferedInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkBufferedInputStream.java
@@ -65,25 +65,25 @@ public class SdkBufferedInputStream extends BufferedInputStream implements
     }
 
     @Override
-    public int read() throws IOException {
+    public synchronized int read() throws IOException {
         abortIfNeeded();
         return super.read();
     }
 
     @Override
-    public int read(byte b[], int off, int len) throws IOException {
+    public synchronized int read(byte b[], int off, int len) throws IOException {
         abortIfNeeded();
         return super.read(b, off, len);
     }
 
     @Override
-    public long skip(long n) throws IOException {
+    public synchronized long skip(long n) throws IOException {
         abortIfNeeded();
         return super.skip(n);
     }
 
     @Override
-    public int available() throws IOException {
+    public synchronized int available() throws IOException {
         abortIfNeeded();
         return super.available();
     }
@@ -95,13 +95,13 @@ public class SdkBufferedInputStream extends BufferedInputStream implements
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         abortIfNeeded();
         super.mark(readlimit);
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         super.reset();
     }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkSSLSocket.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkSSLSocket.java
@@ -57,7 +57,7 @@ public class SdkSSLSocket extends DelegateSSLSocket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (log.isDebugEnabled())
             log.debug("closing " + endpoint());
         sock.close();

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkSocket.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/SdkSocket.java
@@ -56,7 +56,7 @@ public class SdkSocket extends DelegateSocket {
     }
 
     @Override
-    public void close() throws IOException {
+    public synchronized void close() throws IOException {
         if (log.isDebugEnabled())
             log.debug("closing " + endpoint());
         sock.close();

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/LengthCheckInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/LengthCheckInputStream.java
@@ -111,7 +111,7 @@ public class LengthCheckInputStream extends SdkFilterInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         if (markSupported()) {
             super.mark(readlimit);
             marked = dataLength;
@@ -121,7 +121,7 @@ public class LengthCheckInputStream extends SdkFilterInputStream {
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         if (markSupported()) {
             super.reset();
             dataLength = marked;

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/UnreliableFilterInputStream.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/UnreliableFilterInputStream.java
@@ -72,13 +72,13 @@ public class UnreliableFilterInputStream extends FilterInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         super.mark(readlimit);
         marked = position;
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         resetCount++;
         super.reset();
         position = marked;

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/auth/AwsChunkedEncodingInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/auth/AwsChunkedEncodingInputStream.java
@@ -212,7 +212,7 @@ public final class AwsChunkedEncodingInputStream extends SdkInputStream {
      * The readlimit parameter is ignored.
      */
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         abortIfNeeded();
         if ( !isAtStart )
             throw new UnsupportedOperationException("Chunk-encoded stream only supports mark() at the start of the stream.");
@@ -237,7 +237,7 @@ public final class AwsChunkedEncodingInputStream extends SdkInputStream {
      * buffer created by this class.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         // Clear up any encoded data
         currentChunkIterator = null;

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractRepeatableCipherInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/AbstractRepeatableCipherInputStream.java
@@ -80,7 +80,7 @@ public abstract class AbstractRepeatableCipherInputStream<T>
     }
     
     @Override
-    public void mark(final int readlimit) {
+    public synchronized void mark(final int readlimit) {
         abortIfNeeded();
         if (hasBeenAccessed) {
             throw new UnsupportedOperationException(
@@ -92,7 +92,7 @@ public abstract class AbstractRepeatableCipherInputStream<T>
     }
 
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         unencryptedDataStream.reset();
         in = createCipherInputStream(unencryptedDataStream, cipherFactory);

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MD5DigestCalculatingInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MD5DigestCalculatingInputStream.java
@@ -89,7 +89,7 @@ public class MD5DigestCalculatingInputStream extends SdkFilterInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         if (markSupported()) {
             super.mark(readlimit);
             digestLastMarked = cloneFrom(digest);
@@ -100,7 +100,7 @@ public class MD5DigestCalculatingInputStream extends SdkFilterInputStream {
      * Resets the wrapped input stream and the in progress message digest.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         if (markSupported()) {
             super.reset();
 

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RepeatableFileInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RepeatableFileInputStream.java
@@ -81,7 +81,7 @@ public class RepeatableFileInputStream extends SdkInputStream {
      *             when the FileInputStream cannot be re-created.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         this.fis.close();
         abortIfNeeded();
         this.fis = new FileInputStream(file);
@@ -106,7 +106,7 @@ public class RepeatableFileInputStream extends SdkInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         abortIfNeeded();
         this.markPoint += bytesReadPastMarkPoint;
         this.bytesReadPastMarkPoint = 0;

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RepeatableInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RepeatableInputStream.java
@@ -82,7 +82,7 @@ public class RepeatableInputStream extends SdkInputStream {
      *             When the available buffer size has been exceeded, in which
      *             case the input stream data cannot be repeated.
      */
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         if (bytesReadPastMark <= bufferSize) {
             if (log.isDebugEnabled()) {
@@ -108,7 +108,7 @@ public class RepeatableInputStream extends SdkInputStream {
      * stream than fits into the buffer. The readLimit parameter is ignored
      * entirely.
      */
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         abortIfNeeded();
         if (log.isDebugEnabled()) {
             log.debug("Input stream marked at " + bytesReadPastMark + " bytes");

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CipherLiteInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/CipherLiteInputStream.java
@@ -181,7 +181,7 @@ public class CipherLiteInputStream extends SdkFilterInputStream {
     }
 
     @Override
-    public void mark(int readlimit) {
+    public synchronized void mark(int readlimit) {
         abortIfNeeded();
         in.mark(readlimit);
         cipherLite.mark();
@@ -194,7 +194,7 @@ public class CipherLiteInputStream extends SdkFilterInputStream {
      * states consistent.  REF: TT0036173414, ISSUE-JAVA-547.
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         in.reset();
         cipherLite.reset();

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/RenewableCipherLiteInputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/crypto/RenewableCipherLiteInputStream.java
@@ -66,7 +66,7 @@ public final class RenewableCipherLiteInputStream extends CipherLiteInputStream 
      *             if mark is called after this stream has been accessed.
      */
     @Override
-    public void mark(final int readlimit) {
+    public synchronized void mark(final int readlimit) {
         abortIfNeeded();
         if (hasBeenAccessed) {
             throw new UnsupportedOperationException(
@@ -85,7 +85,7 @@ public final class RenewableCipherLiteInputStream extends CipherLiteInputStream 
      * stream (but not anywhere else).
      */
     @Override
-    public void reset() throws IOException {
+    public synchronized void reset() throws IOException {
         abortIfNeeded();
         in.reset();
         renewCipherLite();

--- a/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
+++ b/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/AWSJavaMailTransport.java
@@ -339,7 +339,7 @@ public class AWSJavaMailTransport extends Transport {
     }
 
     @Override
-    public void close() throws MessagingException {
+    public synchronized void close() throws MessagingException {
         super.close();
         this.emailService = null;
     }


### PR DESCRIPTION
All the below overridden methods are marked `synchronized` in the
OpenJDK.  If a synchronized method is overridden in a subclass, and
the overriding method is not synchronized, the thread-safety of the
subclass may be broken.

Since there are no thread-safety comments in these files, I'm not sure
you'll want to merge these.  If we decide not to merge though, it
would be great to document that the classes are no longer thread safe.