### PR TITLE
Make javax.mail dependency optional for OSGi bundle

### DIFF
--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -1077,7 +1077,7 @@
         <configuration>
           <instructions>
             <Export-Package>com.amazonaws.*</Export-Package>
-            <Import-Package>!org.junit.*,!org.springframework.*,!org.apache.avalon.*,!org.apache.log.*,!org.aspectj.*,org.apache.http.conn.routing,com.sun.org.apache.xerces.internal.jaxp.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.ref.*;resolution:=optional,com.sun.org.apache.xpath.internal.*;resolution:=optional,*</Import-Package>
+            <Import-Package>!org.junit.*,!org.springframework.*,!org.apache.avalon.*,!org.apache.log.*,!org.aspectj.*,org.apache.http.conn.routing,com.sun.org.apache.xerces.internal.jaxp.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.ref.*;resolution:=optional,com.sun.org.apache.xpath.internal.*;resolution:=optional,javax.mail;resolution:=optional,*</Import-Package>
             <Embed-Dependency>*;scope=compile;inline=true</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
           </instructions>


### PR DESCRIPTION
In the good tradition to fix your own issues:
This should fix #1915