### PR TITLE
Add ability to specify default return consumed capacity in DynamoDBMapper

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -21,7 +21,6 @@ import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.retry.RetryUtils;
 import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.BatchLoadRetryStrategy;
-import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.BatchWriteRetryStrategy;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.ConsistentReads;
 import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.SaveBehavior;
 import com.amazonaws.services.dynamodbv2.model.AttributeAction;
@@ -59,7 +58,6 @@ import com.amazonaws.services.dynamodbv2.model.UpdateItemResult;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import com.amazonaws.services.s3.model.Region;
 import com.amazonaws.util.VersionInfoUtils;
-
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -403,7 +401,8 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         String tableName = getTableName(clazz, keyObject, config);
 
         GetItemRequest rq = new GetItemRequest()
-            .withRequestMetricCollector(config.getRequestMetricCollector());
+                .withReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity())
+                .withRequestMetricCollector(config.getRequestMetricCollector());
 
         Map<String, AttributeValue> key = model.convertKey(keyObject);
 
@@ -1048,7 +1047,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         }
 
         DeleteItemRequest req = new DeleteItemRequest().withKey(key)
-                .withTableName(tableName).withExpected(internalAssertions)
+                .withTableName(tableName)
+                .withExpected(internalAssertions)
+                .withReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity())
                 .withRequestMetricCollector(config.getRequestMetricCollector());
 
         if (deleteExpression != null) {
@@ -1134,7 +1135,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         // Break into chunks of 25 items and make service requests to DynamoDB
         for (final StringListMap<WriteRequest> batch : requestItems.subMaps(MAX_ITEMS_PER_BATCH, true)) {
-            List<FailedBatch> failedBatches = writeOneBatch(batch, config.getBatchWriteRetryStrategy());
+            List<FailedBatch> failedBatches = writeOneBatch(batch, config);
             if (failedBatches != null) {
                 totalFailedBatches.addAll(failedBatches);
 
@@ -1160,10 +1161,10 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
      */
     private List<FailedBatch> writeOneBatch(
             StringListMap<WriteRequest> batch,
-            BatchWriteRetryStrategy batchWriteRetryStrategy) {
+            DynamoDBMapperConfig config) {
 
         List<FailedBatch> failedBatches = new LinkedList<FailedBatch>();
-        FailedBatch failedBatch = doBatchWriteItemWithRetry(batch, batchWriteRetryStrategy);
+        FailedBatch failedBatch = doBatchWriteItemWithRetry(batch, config);
 
         if (failedBatch != null) {
             // If the exception is request entity too large, we divide the batch
@@ -1178,7 +1179,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
                     failedBatches.add(failedBatch);
                 } else {
                     for (final StringListMap<WriteRequest> subBatch : batch.subMaps(2, false)) {
-                        failedBatches.addAll(writeOneBatch(subBatch, batchWriteRetryStrategy));
+                        failedBatches.addAll(writeOneBatch(subBatch, config));
                     }
                 }
 
@@ -1208,11 +1209,11 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
      */
     private FailedBatch doBatchWriteItemWithRetry(
             Map<String, List<WriteRequest>> batch,
-            BatchWriteRetryStrategy batchWriteRetryStrategy) {
+            DynamoDBMapperConfig config) {
 
         BatchWriteItemResult result = null;
         int retries = 0;
-        int maxRetries = batchWriteRetryStrategy
+        int maxRetries = config.getBatchWriteRetryStrategy()
                 .getMaxRetryOnUnprocessedItems(Collections
                         .unmodifiableMap(batch));
 
@@ -1221,8 +1222,10 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         while (true) {
             try {
-                result = db.batchWriteItem(applyBatchOperationUserAgent(
-                        new BatchWriteItemRequest().withRequestItems(pendingItems)));
+                BatchWriteItemRequest req = new BatchWriteItemRequest()
+                        .withReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity())
+                        .withRequestItems(pendingItems);
+                result = db.batchWriteItem(applyBatchOperationUserAgent(req));
             } catch (Exception e) {
                 failedBatch = new FailedBatch();
                 failedBatch.setUnprocessedItems(pendingItems);
@@ -1241,7 +1244,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
                     return failedBatch;
                 }
 
-                pause(batchWriteRetryStrategy.getDelayBeforeRetryUnprocessedItems(
+                pause(config.getBatchWriteRetryStrategy().getDelayBeforeRetryUnprocessedItems(
                         Collections.unmodifiableMap(pendingItems), retries));
                 retries++;
             } else {
@@ -1324,8 +1327,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         BatchGetItemResult batchGetItemResult = null;
         BatchGetItemRequest batchGetItemRequest = new BatchGetItemRequest()
-            .withRequestMetricCollector(config.getRequestMetricCollector());
-        batchGetItemRequest.setRequestItems(requestItems);
+                .withReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity())
+                .withRequestItems(requestItems)
+                .withRequestMetricCollector(config.getRequestMetricCollector());
 
         BatchLoadRetryStrategy batchLoadStrategy = config.getBatchLoadRetryStrategy();
 
@@ -1453,6 +1457,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         config = mergeConfig(config);
 
         ScanRequest scanRequest = createScanRequestFromExpression(clazz, scanExpression, config);
+        if (scanExpression.getReturnConsumedCapacity() == null) {
+            scanExpression.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         ScanResult scanResult = db.scan(applyUserAgent(scanRequest));
         return new PaginatedScanList<T>(this, clazz, db, scanRequest, scanResult, config.getPaginationLoadingStrategy(), config);
@@ -1479,6 +1486,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         config = mergeConfig(config);
 
         ScanRequest scanRequest = createScanRequestFromExpression(clazz, scanExpression, config);
+        if (scanRequest.getReturnConsumedCapacity() == null) {
+            scanRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         ScanResult scanResult = db.scan(applyUserAgent(scanRequest));
         ScanResultPage<T> result = new ScanResultPage<T>();
@@ -1501,6 +1511,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         config = mergeConfig(config);
 
         QueryRequest queryRequest = createQueryRequestFromExpression(clazz, queryExpression, config);
+        if (queryRequest.getReturnConsumedCapacity() == null) {
+            queryRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         QueryResult queryResult = db.query(applyUserAgent(queryRequest));
         return new PaginatedQueryList<T>(this, clazz, db, queryRequest, queryResult, config.getPaginationLoadingStrategy(), config);
@@ -1513,6 +1526,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         config = mergeConfig(config);
 
         QueryRequest queryRequest = createQueryRequestFromExpression(clazz, queryExpression, config);
+        if (queryRequest.getReturnConsumedCapacity() == null) {
+            queryRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         QueryResult queryResult = db.query(applyUserAgent(queryRequest));
         QueryResultPage<T> result = new QueryResultPage<T>();
@@ -1535,6 +1551,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         ScanRequest scanRequest = createScanRequestFromExpression(clazz, scanExpression, config);
         scanRequest.setSelect(Select.COUNT);
+        if (scanRequest.getReturnConsumedCapacity() == null) {
+            scanRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         // Count scans can also be truncated for large datasets
         int count = 0;
@@ -1554,6 +1573,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         QueryRequest queryRequest = createQueryRequestFromExpression(clazz, queryExpression, config);
         queryRequest.setSelect(Select.COUNT);
+        if (queryRequest.getReturnConsumedCapacity() == null) {
+            queryRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+        }
 
         // Count queries can also be truncated for large datasets
         int count = 0;
@@ -1613,6 +1635,10 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
         List<ScanRequest> parallelScanRequests= new LinkedList<ScanRequest>();
         for (int segment = 0; segment < totalSegments; segment++) {
             ScanRequest scanRequest = createScanRequestFromExpression(clazz, scanExpression, config);
+            if (scanRequest.getReturnConsumedCapacity() == null) {
+                scanRequest.setReturnConsumedCapacity(config.getDefaultReturnConsumedCapacity());
+            }
+
             parallelScanRequests.add(scanRequest
                     .withSegment(segment).withTotalSegments(totalSegments)
                     .withExclusiveStartKey(null));

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperConfig.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperConfig.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.dynamodbv2.datamodeling;
 
 import com.amazonaws.metrics.RequestMetricCollector;
 import com.amazonaws.services.dynamodbv2.model.KeysAndAttributes;
+import com.amazonaws.services.dynamodbv2.model.ReturnConsumedCapacity;
 import com.amazonaws.services.dynamodbv2.model.WriteRequest;
 import java.util.List;
 import java.util.Map;
@@ -64,6 +65,7 @@ public class DynamoDBMapperConfig {
         .withBatchLoadRetryStrategy(DefaultBatchLoadRetryStrategy.INSTANCE)
         .withTypeConverterFactory(DynamoDBTypeConverterFactory.standard())
         .withConversionSchema(ConversionSchemas.DEFAULT)
+        .withDefaultReturnConsumedCapacity(ReturnConsumedCapacity.NONE)
         .build();
 
     /**
@@ -89,6 +91,7 @@ public class DynamoDBMapperConfig {
         private BatchWriteRetryStrategy batchWriteRetryStrategy;
         private BatchLoadRetryStrategy batchLoadRetryStrategy;
         private DynamoDBTypeConverterFactory typeConverterFactory;
+        private ReturnConsumedCapacity defaultReturnConsumedCapacity;
 
         /**
          * Creates a new builder initialized with the {@link #DEFAULT} values.
@@ -108,6 +111,7 @@ public class DynamoDBMapperConfig {
                 conversionSchema = DEFAULT.getConversionSchema();
                 batchWriteRetryStrategy = DEFAULT.getBatchWriteRetryStrategy();
                 batchLoadRetryStrategy = DEFAULT.getBatchLoadRetryStrategy();
+                defaultReturnConsumedCapacity = null;
             }
         }
 
@@ -127,6 +131,7 @@ public class DynamoDBMapperConfig {
             if (o.batchWriteRetryStrategy != null) batchWriteRetryStrategy = o.batchWriteRetryStrategy;
             if (o.batchLoadRetryStrategy != null) batchLoadRetryStrategy = o.batchLoadRetryStrategy;
             if (o.typeConverterFactory != null) typeConverterFactory = o.typeConverterFactory;
+            if (o.defaultReturnConsumedCapacity != null) defaultReturnConsumedCapacity = o.defaultReturnConsumedCapacity;
             return this;
         }
 
@@ -419,6 +424,29 @@ public class DynamoDBMapperConfig {
          */
         public final Builder withTypeConverterFactory(DynamoDBTypeConverterFactory value) {
             setTypeConverterFactory(value);
+            return this;
+        }
+
+        /**
+         * @return the current default {@link ReturnConsumedCapacity}.
+         */
+        public ReturnConsumedCapacity getDefaultReturnConsumedCapacity() {
+            return defaultReturnConsumedCapacity;
+        }
+
+        /**
+         * @param value the new default {@link ReturnConsumedCapacity}.
+         */
+        public void setDefaultReturnConsumedCapacity(ReturnConsumedCapacity value) {
+            defaultReturnConsumedCapacity = value;
+        }
+
+        /**
+         * @param value the new default {@link ReturnConsumedCapacity}.
+         * @return this builder
+         */
+        public Builder withDefaultReturnConsumedCapacity(ReturnConsumedCapacity value) {
+            setDefaultReturnConsumedCapacity(value);
             return this;
         }
 
@@ -902,6 +930,7 @@ public class DynamoDBMapperConfig {
     private final BatchWriteRetryStrategy batchWriteRetryStrategy;
     private final BatchLoadRetryStrategy batchLoadRetryStrategy;
     private final DynamoDBTypeConverterFactory typeConverterFactory;
+    private final ReturnConsumedCapacity defaultReturnConsumedCapacity;
 
     /**
      * Internal constructor; builds from the builder.
@@ -918,6 +947,7 @@ public class DynamoDBMapperConfig {
         this.batchWriteRetryStrategy = builder.batchWriteRetryStrategy;
         this.batchLoadRetryStrategy = builder.batchLoadRetryStrategy;
         this.typeConverterFactory = builder.typeConverterFactory;
+        this.defaultReturnConsumedCapacity = builder.defaultReturnConsumedCapacity;
     }
 
     /**
@@ -1003,7 +1033,8 @@ public class DynamoDBMapperConfig {
                 requestMetricCollector,
                 DEFAULT.getConversionSchema(),
                 DEFAULT.getBatchWriteRetryStrategy(),
-                DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getBatchLoadRetryStrategy(),
+                DEFAULT.getDefaultReturnConsumedCapacity());
     }
 
     private DynamoDBMapperConfig(
@@ -1016,7 +1047,8 @@ public class DynamoDBMapperConfig {
             RequestMetricCollector requestMetricCollector,
             ConversionSchema conversionSchema,
             BatchWriteRetryStrategy batchWriteRetryStrategy,
-            BatchLoadRetryStrategy batchLoadRetryStrategy) {
+            BatchLoadRetryStrategy batchLoadRetryStrategy,
+            ReturnConsumedCapacity defaultReturnConsumedCapacity) {
 
         this.saveBehavior = saveBehavior;
         this.consistentReads = consistentReads;
@@ -1029,6 +1061,7 @@ public class DynamoDBMapperConfig {
         this.batchWriteRetryStrategy = batchWriteRetryStrategy;
         this.batchLoadRetryStrategy = batchLoadRetryStrategy;
         this.typeConverterFactory = null;
+        this.defaultReturnConsumedCapacity = defaultReturnConsumedCapacity;
     }
 
     /**
@@ -1038,7 +1071,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(SaveBehavior saveBehavior) {
         this(saveBehavior, null, null, null, null, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1049,7 +1083,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(ConsistentReads consistentReads) {
         this(null, consistentReads, null, null, null, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1059,7 +1094,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(TableNameOverride tableNameOverride) {
         this(null, null, tableNameOverride, null, null, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1069,7 +1105,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(TableNameResolver tableNameResolver) {
         this(null, null, null, tableNameResolver, null, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1079,7 +1116,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(ObjectTableNameResolver objectTableNameResolver) {
         this(null, null, null, null, objectTableNameResolver, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1089,7 +1127,8 @@ public class DynamoDBMapperConfig {
     @Deprecated
     public DynamoDBMapperConfig(TableNameResolver tableNameResolver, ObjectTableNameResolver objectTableNameResolver) {
         this(null, null, null, tableNameResolver, objectTableNameResolver, null, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1102,7 +1141,8 @@ public class DynamoDBMapperConfig {
             PaginationLoadingStrategy paginationLoadingStrategy) {
 
         this(null, null, null, null, null, paginationLoadingStrategy, null,
-                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+                DEFAULT.getConversionSchema(), DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1111,7 +1151,8 @@ public class DynamoDBMapperConfig {
      */
     @Deprecated
     public DynamoDBMapperConfig(ConversionSchema conversionSchema) {
-        this(null, null, null, null, null, null, null, conversionSchema, DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy());
+        this(null, null, null, null, null, null, null, conversionSchema, DEFAULT.getBatchWriteRetryStrategy(), DEFAULT.getBatchLoadRetryStrategy(),
+                null);
     }
 
     /**
@@ -1225,6 +1266,13 @@ public class DynamoDBMapperConfig {
      */
     public final DynamoDBTypeConverterFactory getTypeConverterFactory() {
         return typeConverterFactory;
+    }
+
+    /**
+     * @return the current default {@link ReturnConsumedCapacity}.
+     */
+    public final ReturnConsumedCapacity getDefaultReturnConsumedCapacity() {
+        return defaultReturnConsumedCapacity;
     }
 
 }


### PR DESCRIPTION
**Issue:** https://github.com/aws/aws-sdk-java/issues/1862

**Description of changes:** Adds the ability to specify a default `ReturnConsumedCapacity` value for operations using the `DynamoDBMapper`. We don't have the ability to set the `ReturnConsumedCapacity` on individual DynamoDB operations as they are built up inside of the DynamoDBMapper. We currently get around this when using DynamoDB by using reflection and setting a `ReturnConsumedCapacity` on all requests; however, there are no pre-request hooks available when using DAX. This will allow us to move forward with DAX without losing the ability to track consumed capacity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
