### PR TITLE
Get sublist of PaginatedList w/o loading full set

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/PaginatedList.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/PaginatedList.java
@@ -394,6 +394,14 @@ public abstract class PaginatedList<T> implements List<T> {
         return Collections.unmodifiableList(allResults.subList(arg0, arg1));
     }
 
+    /**
+     * Returns a sub-list in the range specified, loading more results as
+     * necessary. May return a list of size less than (arg1 - arg2)
+     * if arg2 > result size
+     * <p>
+     * Not supported in ITERATION_ONLY mode.
+     * </p>
+     */
     public List<T> safeSubList(int arg0, int arg1) {
         checkUnsupportedOperationForIterationOnlyMode("safeSubList(int arg0, int arg1)");
         

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/PaginatedList.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/PaginatedList.java
@@ -394,6 +394,16 @@ public abstract class PaginatedList<T> implements List<T> {
         return Collections.unmodifiableList(allResults.subList(arg0, arg1));
     }
 
+    public List<T> safeSubList(int arg0, int arg1) {
+        checkUnsupportedOperationForIterationOnlyMode("safeSubList(int arg0, int arg1)");
+        
+        while ( allResults.size() < arg1 && nextResultsAvailable() ) {
+            moveNextResults(false);
+        }
+        
+        return Collections.unmodifiableList(allResults.subList(arg0, Math.min(arg1, allResults.size())));
+    }
+    
     /**
      * Returns the first index of the object given in the list. Additional
      * results are loaded incrementally as necessary.


### PR DESCRIPTION
We should not have to load the entire result set in order to determine the upper bound for the sublist method. This is currently necessary because we do not know if our upper bound index is out of range of the result set.

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
