### PR TITLE
Don't allow httpclient to normalize URIs #1919

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/utils/ApacheUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/apache/utils/ApacheUtils.java
@@ -28,6 +28,7 @@ import org.apache.http.auth.Credentials;
 import org.apache.http.auth.NTCredentials;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.CredentialsProvider;
+import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.entity.BufferedHttpEntity;
@@ -137,6 +138,12 @@ public class ApacheUtils {
         addPreemptiveAuthenticationProxy(clientContext, settings);
 
         clientContext.setAttribute(HttpContextUtils.DISABLE_SOCKET_PROXY_PROPERTY, settings.disableSocketProxy());
+        try {
+            // don't normalize URIs - the default behavior before httpclient 4.5.7
+            clientContext.setRequestConfig(RequestConfig.custom().setNormalizeUri(false).build());
+        } catch (NoSuchMethodError e) {
+            // this method was added in httpclient 4.5.8
+        }
         return clientContext;
 
     }

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
         the aggregate ZIP artifact -->
       <javax.mail.version>1.4.6</javax.mail.version>
       <jre.version>1.6</jre.version>
-      <httpcomponents.httpclient.version>4.5.5</httpcomponents.httpclient.version>
+      <httpcomponents.httpclient.version>4.5.9</httpcomponents.httpclient.version>
       <!-- These properties are used by cucumber tests related code -->
       <cucumber.info.cukes.version>1.2.4</cucumber.info.cukes.version>
       <cucumber.guice.version>4.0</cucumber.guice.version>


### PR DESCRIPTION
#1919

Set option in HttpClient RequestConfig to not normalize URIs. This was the default behavior before httpclient 4.5.7.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.