### PR TITLE
Use environment variables proxy settings

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -1078,24 +1078,35 @@ public class ClientConfiguration {
     /**
      * Returns the Java system property for nonProxyHosts. We still honor this property even
      * {@link #getProtocol()} is https, see http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html.
+     * This method expects the property to be set as pipe separated list.
      */
     private String getNonProxyHostsProperty() {
         return getSystemProperty("http.nonProxyHosts");
     }
 
     /**
-     * Returns the value of the environment variable NO_PROXY/no_proxy.
+     * Returns the value of the environment variable NO_PROXY/no_proxy. This method expects
+     * the environment variable to be set as a comma separated list, so this method
+     * converts the comma separated list to pipe separated list to be used internally.
      */
     private String getNonProxyHostsEnvironment() {
-        return getEnvironmentVariableCaseInsensitive("NO_PROXY");
+        String nonProxyHosts = getEnvironmentVariableCaseInsensitive("NO_PROXY");
+        if (nonProxyHosts != null) {
+            nonProxyHosts = nonProxyHosts.replace(",", "|");
+        }
+
+        return nonProxyHosts;
     }
 
     /**
      * Returns the optional hosts the client will access without going
      * through the proxy. Returns either the nonProxyHosts set on this
      * object, or if not provided, returns the value of the Java system property
-     * http.nonProxyHosts. If neither are set, returns the value of the
-     * environment variable NO_PROXY/no_proxy.
+     * http.nonProxyHosts. We still honor this property even
+     * {@link #getProtocol()} is https, see http://docs.oracle.com/javase/7/docs/api/java/net/doc-files/net-properties.html.
+     * This property is expected to be set as a pipe separated list. If neither are set,
+     * returns the value of the environment variable NO_PROXY/no_proxy. This environment
+     * variable is expected to be set as a comma separated list.
      *
      * @return The hosts the client will connect through bypassing the proxy.
      */

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -630,11 +630,9 @@ public class ClientConfiguration {
      * the lowercase version of variable.
      */
     private String getEnvironmentVariableCaseInsensitive(String environmentVariable) {
-        if (getEnvironmentVariable(environmentVariable) != null) {
-            return getEnvironmentVariable(environmentVariable);
-        } else {
-            return getEnvironmentVariable(environmentVariable.toLowerCase());
-        }
+        return getEnvironmentVariable(environmentVariable) != null
+                ? getEnvironmentVariable(environmentVariable)
+                : getEnvironmentVariable(environmentVariable.toLowerCase());
     }
 
     /**

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -749,11 +749,10 @@ public class ClientConfiguration {
      * if the system property is not set with a valid port number.
      */
     private int getProxyPortProperty() {
-        final String proxyPortString = (getProtocol() == Protocol.HTTPS)
-                    ? getSystemProperty("https.proxyPort")
-                    : getSystemProperty("http.proxyPort");
         try {
-            return Integer.parseInt(proxyPortString);
+            return getProtocol() == Protocol.HTTPS
+                    ? Integer.parseInt(getSystemProperty("https.proxyPort"))
+                    : Integer.parseInt(getSystemProperty("http.proxyPort"));
         } catch (NumberFormatException e) {
             return proxyPort;
         }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -621,43 +621,20 @@ public class ClientConfiguration {
     /**
      * Returns the value for the given environment variable.
      */
-    private String getEnvironmentVariable(String variable) {
-        return System.getenv(variable);
+    private String getEnvironmentVariable(String environmentVariable) {
+        return System.getenv(environmentVariable);
     }
 
     /**
-     * Returns a URL object for the given environment variable, if can be constructed, null otherwise.
+     * Returns the value for the given environment variable if its set, otherwise returns
+     * the lowercase version of variable.
      */
-    private URL getUrlFromEnvironmentVariable(String variable) {
-        try {
-            return new URL(getEnvironmentVariable(variable));
-        } catch (MalformedURLException e) {
-            return null;
+    private String getEnvironmentVariableCaseInsensitive(String environmentVariable) {
+        if (getEnvironmentVariable(environmentVariable) != null) {
+            return getEnvironmentVariable(environmentVariable);
+        } else {
+            return getEnvironmentVariable(environmentVariable.toLowerCase());
         }
-    }
-
-    /**
-     * Returns a URL object for the environment variable HTTPS_PROXY or https_proxy if it is set, null otherwise.
-     */
-    private URL getHttpsProxyUrlFromEnvironment() {
-        if (getUrlFromEnvironmentVariable("HTTPS_PROXY") != null) {
-            return getUrlFromEnvironmentVariable("HTTPS_PROXY");
-        } else if (getUrlFromEnvironmentVariable("https_proxy") != null) {
-            return getUrlFromEnvironmentVariable("https_proxy");
-        }
-        return null;
-    }
-
-    /**
-     * Returns the a URL object for the environment variable HTTP_PROXY or http_proxy if it is set, null otherwise.
-     */
-    private URL getHttpProxyUrlFromEnvironment() {
-        if (getUrlFromEnvironmentVariable("HTTP_PROXY") != null) {
-            return getUrlFromEnvironmentVariable("HTTP_PROXY");
-        } else if (getUrlFromEnvironmentVariable("http_proxy") != null) {
-            return getUrlFromEnvironmentVariable("http_proxy");
-        }
-        return null;
     }
 
     /**
@@ -707,16 +684,13 @@ public class ClientConfiguration {
      * variable HTTP_PROXY/http_proxy.
      */
     private String getProxyHostEnvironment() {
-        if (getProtocol() == Protocol.HTTPS) {
-            if (getHttpsProxyUrlFromEnvironment() != null) {
-                return getHttpsProxyUrlFromEnvironment().getHost();
-            }
-        } else {
-            if (getHttpProxyUrlFromEnvironment() != null) {
-                return getHttpProxyUrlFromEnvironment().getHost();
-            }
+        try {
+            return getProtocol() == Protocol.HTTPS
+                    ? new URL(getEnvironmentVariableCaseInsensitive("HTTPS_PROXY")).getHost()
+                    : new URL(getEnvironmentVariableCaseInsensitive("HTTP_PROXY")).getHost();
+        } catch (MalformedURLException e) {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -793,16 +767,13 @@ public class ClientConfiguration {
      * variable HTTP_PROXY/http_proxy.
      */
     private int getProxyPortEnvironment() {
-        if (getProtocol() == Protocol.HTTPS) {
-            if (getHttpsProxyUrlFromEnvironment() != null) {
-                return getHttpsProxyUrlFromEnvironment().getPort();
-            }
-        } else {
-            if (getHttpProxyUrlFromEnvironment() != null) {
-                return getHttpProxyUrlFromEnvironment().getPort();
-            }
+        try {
+            return getProtocol() == Protocol.HTTPS
+                    ? new URL(getEnvironmentVariableCaseInsensitive("HTTPS_PROXY")).getPort()
+                    : new URL(getEnvironmentVariableCaseInsensitive("HTTP_PROXY")).getPort();
+        } catch (MalformedURLException e) {
+            return proxyPort;
         }
-        return proxyPort;
     }
 
     /**
@@ -901,16 +872,13 @@ public class ClientConfiguration {
      * the value of the environment variable HTTP_PROXY/http_proxy.
      */
     private String getProxyUsernameEnvironment() {
-        if (getProtocol() == Protocol.HTTPS) {
-            if (getHttpsProxyUrlFromEnvironment() != null) {
-                return getHttpsProxyUrlFromEnvironment().getUserInfo().split(":", 2)[0];
-            }
-        } else {
-            if (getHttpProxyUrlFromEnvironment() != null) {
-                return getHttpProxyUrlFromEnvironment().getUserInfo().split(":", 2)[0];
-            }
+        try {
+            return getProtocol() == Protocol.HTTPS
+                    ? new URL(getEnvironmentVariableCaseInsensitive("HTTPS_PROXY")).getUserInfo().split(":", 2)[0]
+                    : new URL(getEnvironmentVariableCaseInsensitive("HTTP_PROXY")).getUserInfo().split(":", 2)[0];
+        } catch (MalformedURLException e) {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -982,16 +950,13 @@ public class ClientConfiguration {
      * variable HTTP_PROXY/http_proxy.
      */
     private String getProxyPasswordEnvironment() {
-        if (getProtocol() == Protocol.HTTPS) {
-            if (getHttpsProxyUrlFromEnvironment() != null) {
-                return getHttpsProxyUrlFromEnvironment().getUserInfo().split(":", 2)[1];
-            }
-        } else {
-            if (getHttpProxyUrlFromEnvironment() != null) {
-                return getHttpProxyUrlFromEnvironment().getUserInfo().split(":", 2)[1];
-            }
+        try {
+            return getProtocol() == Protocol.HTTPS
+                    ? new URL(getEnvironmentVariableCaseInsensitive("HTTPS_PROXY")).getUserInfo().split(":", 2)[1]
+                    : new URL(getEnvironmentVariableCaseInsensitive("HTTP_PROXY")).getUserInfo().split(":", 2)[1];
+        } catch (MalformedURLException e) {
+            return null;
         }
-        return null;
     }
 
     /**
@@ -1125,11 +1090,7 @@ public class ClientConfiguration {
      * Returns the value of the environment variable NO_PROXY/no_proxy.
      */
     private String getNonProxyHostsEnvironment() {
-        if (getEnvironmentVariable("NO_PROXY") != null) {
-            return getEnvironmentVariable("NO_PROXY");
-        } else {
-            return getEnvironmentVariable("no_proxy");
-        }
+        return getEnvironmentVariableCaseInsensitive("NO_PROXY");
     }
 
     /**

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -186,12 +186,23 @@ public class ClientConfigurationTest {
         assertEquals(config.getProxyHost(), "foo");
         System.clearProperty("http.proxyHost");
 
+        System.setProperty("https.proxyPort", "bad");
+        config = new ClientConfiguration();
+        assertEquals(config.getProxyPort(), -1);
+        System.clearProperty("https.proxyPort");
+
         System.setProperty("https.proxyPort", "8443");
         config = new ClientConfiguration();
         assertEquals(config.getProxyPort(), 8443);
         config.setProtocol(Protocol.HTTP);
         assertEquals(config.getProxyPort(), -1);
         System.clearProperty("https.proxyPort");
+
+        System.setProperty("http.proxyPort", "bad");
+        config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(config.getProxyPort(), -1);
+        System.clearProperty("http.proxyPort");
 
         System.setProperty("http.proxyPort", "8080");
         config = new ClientConfiguration();

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -41,6 +41,7 @@ import org.apache.http.conn.socket.ConnectionSocketFactory;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.junit.Test;
 import org.mockito.Mockito;
+import utils.EnvironmentVariableHelper;
 
 public class ClientConfigurationTest {
 
@@ -226,6 +227,178 @@ public class ClientConfigurationTest {
         config.setProtocol(Protocol.HTTP);
         assertEquals(config.getProxyPassword(), "foo");
         System.clearProperty("http.proxyPassword");
+    }
+
+    @Test
+    public void testProxyHostEnvironmentVariables() {
+        clearProxyProperties();
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        ClientConfiguration config;
+
+        config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
+        environmentVariableHelper.set("https_proxy", "bad-url");
+        assertNull(config.getProxyHost());
+        environmentVariableHelper.set("https_proxy", "https://test1:1234");
+        assertEquals("test1", config.getProxyHost());
+        environmentVariableHelper.set("HTTPS_PROXY", "https://test2:1234");
+        assertEquals("test2", config.getProxyHost());
+        System.setProperty("https.proxyHost", "test3");
+        assertEquals("test3", config.getProxyHost());
+        config.setProxyHost("test4");
+        assertEquals("test4", config.getProxyHost());
+        System.clearProperty("https.proxyHost");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyHost());
+        environmentVariableHelper.set("http_proxy", "http://test1:1234");
+        assertEquals("test1", config.getProxyHost());
+        environmentVariableHelper.set("HTTP_PROXY", "http://test2:1234");
+        assertEquals("test2", config.getProxyHost());
+        System.setProperty("http.proxyHost", "test3");
+        assertEquals("test3", config.getProxyHost());
+        config.setProxyHost("test4");
+        assertEquals("test4", config.getProxyHost());
+        System.clearProperty("http.proxyHost");
+        environmentVariableHelper.reset();
+    }
+
+    @Test
+    public void testProxyPortEnvironmentVariables() {
+        clearProxyProperties();
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        ClientConfiguration config;
+
+        config = new ClientConfiguration();
+        assertEquals(-1, config.getProxyPort());
+        environmentVariableHelper.set("https_proxy", "bad-url");
+        assertEquals(-1, config.getProxyPort());
+        environmentVariableHelper.set("https_proxy", "https://test1:1");
+        assertEquals(1, config.getProxyPort());
+        environmentVariableHelper.set("HTTPS_PROXY", "https://test2:2");
+        assertEquals(2, config.getProxyPort());
+        System.setProperty("https.proxyPort", "3");
+        assertEquals(3, config.getProxyPort());
+        config.setProxyPort(4);
+        assertEquals(4, config.getProxyPort());
+        System.clearProperty("https.proxyPort");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTP);
+        assertEquals(-1, config.getProxyPort());
+        environmentVariableHelper.set("http_proxy", "http://test1:1");
+        assertEquals(1, config.getProxyPort());
+        environmentVariableHelper.set("HTTP_PROXY", "http://test2:2");
+        assertEquals(2, config.getProxyPort());
+        System.setProperty("http.proxyPort", "3");
+        assertEquals(3, config.getProxyPort());
+        config.setProxyPort(4);
+        assertEquals(4, config.getProxyPort());
+        System.clearProperty("http.proxyPort");
+        environmentVariableHelper.reset();
+    }
+
+    @Test
+    public void testProxyUsernameEnvironmentVariables() {
+        clearProxyProperties();
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        ClientConfiguration config;
+
+        config = new ClientConfiguration();
+        assertNull(config.getProxyUsername());
+        environmentVariableHelper.set("https_proxy", "bad-url");
+        assertNull(config.getProxyUsername());
+        environmentVariableHelper.set("https_proxy", "https://user1:pass@test:1234");
+        assertEquals("user1", config.getProxyUsername());
+        environmentVariableHelper.set("HTTPS_PROXY", "https://user2:pass@test:1234");
+        assertEquals("user2", config.getProxyUsername());
+        System.setProperty("https.proxyUser", "user3");
+        assertEquals("user3", config.getProxyUsername());
+        config.setProxyUsername("user4");
+        assertEquals("user4", config.getProxyUsername());
+        System.clearProperty("https.proxyUser");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyUsername());
+        environmentVariableHelper.set("http_proxy", "http://user1:pass@test:1234");
+        assertEquals("user1", config.getProxyUsername());
+        environmentVariableHelper.set("HTTP_PROXY", "http://user2:pass@test:1234");
+        assertEquals("user2", config.getProxyUsername());
+        System.setProperty("http.proxyUser", "user3");
+        assertEquals("user3", config.getProxyUsername());
+        config.setProxyUsername("user4");
+        assertEquals("user4", config.getProxyUsername());
+        System.clearProperty("http.proxyUser");
+        environmentVariableHelper.reset();
+    }
+
+    @Test
+    public void testProxyPasswordEnvironmentVariables() {
+        clearProxyProperties();
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        ClientConfiguration config;
+
+        config = new ClientConfiguration();
+        assertNull(config.getProxyPassword());
+        environmentVariableHelper.set("https_proxy", "bad-url");
+        assertNull(config.getProxyPassword());
+        environmentVariableHelper.set("https_proxy", "https://user:pass1@test:1234");
+        assertEquals("pass1", config.getProxyPassword());
+        environmentVariableHelper.set("HTTPS_PROXY", "https://user:pass2@test:1234");
+        assertEquals("pass2", config.getProxyPassword());
+        System.setProperty("https.proxyPassword", "pass3");
+        assertEquals("pass3", config.getProxyPassword());
+        config.setProxyPassword("pass4");
+        assertEquals("pass4", config.getProxyPassword());
+        System.clearProperty("https.proxyPassword");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getProxyPassword());
+        environmentVariableHelper.set("http_proxy", "http://user:pass1@test:1234");
+        assertEquals("pass1", config.getProxyPassword());
+        environmentVariableHelper.set("HTTP_PROXY", "http://user:pass2@test:1234");
+        assertEquals("pass2", config.getProxyPassword());
+        System.setProperty("http.proxyPassword", "pass3");
+        assertEquals("pass3", config.getProxyPassword());
+        config.setProxyPassword("pass4");
+        assertEquals("pass4", config.getProxyPassword());
+        System.clearProperty("http.proxyPassword");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        assertNull(config.getProxyPassword());
+        environmentVariableHelper.set("https_proxy", "http://user:pass:with:colon@test:1234");
+        assertEquals("pass:with:colon", config.getProxyPassword());
+        environmentVariableHelper.reset();
+    }
+
+    @Test
+    public void testNonProxyHostsEnvironmentVariables() {
+        clearProxyProperties();
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+        ClientConfiguration config;
+
+        config = new ClientConfiguration();
+        assertNull(config.getNonProxyHosts());
+        config.setProtocol(Protocol.HTTP);
+        assertNull(config.getNonProxyHosts());
+        environmentVariableHelper.set("no_proxy", "test1.com");
+        assertEquals("test1.com", config.getNonProxyHosts());
+        environmentVariableHelper.set("NO_PROXY", "test2.com");
+        assertEquals("test2.com", config.getNonProxyHosts());
+        System.setProperty("http.nonProxyHosts", "test3.com");
+        assertEquals("test3.com", config.getNonProxyHosts());
+        config.setNonProxyHosts("test4.com");
+        assertEquals("test4.com", config.getNonProxyHosts());
+        System.clearProperty("https.nonProxyHosts");
+        environmentVariableHelper.reset();
     }
 
     @Test

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -408,7 +408,16 @@ public class ClientConfigurationTest {
         assertEquals("test3.com", config.getNonProxyHosts());
         config.setNonProxyHosts("test4.com");
         assertEquals("test4.com", config.getNonProxyHosts());
-        System.clearProperty("https.nonProxyHosts");
+        System.clearProperty("http.nonProxyHosts");
+        environmentVariableHelper.reset();
+
+        config = new ClientConfiguration();
+        assertNull(config.getNonProxyHosts());
+        config.setProtocol(Protocol.HTTP);
+        environmentVariableHelper.set("no_proxy", "test1.com,test2.com,test3.com");
+        assertEquals("test1.com|test2.com|test3.com", config.getNonProxyHosts());
+        environmentVariableHelper.set("no_proxy", "test1.com|test2.com|test3.com");
+        assertEquals("test1.com|test2.com|test3.com", config.getNonProxyHosts());
         environmentVariableHelper.reset();
     }
 


### PR DESCRIPTION
#1959 

*Description of changes:*
Check if common environment variables `HTTPS_PROXY`/`HTTP_PROXY`/`https_proxy`/`http_proxy` are set if neither the configured variables or Java properties are set. Precedence is configured values, then Java system properties, then environment variables.

Also checks for non proxy hosts using `NO_PROXY` and `no_proxy`, again keeping same precedence as above.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.