### PR TITLE
Fix typos

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AbstractEnumMarshaller.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/AbstractEnumMarshaller.java
@@ -20,7 +20,7 @@ import static com.amazonaws.util.Throwables.failure;
  * Generic marshaller for enumerations.
  *
  * Please note, there are some risks in distributed systems when using
- * enumerations as attributes intead of simply using a String.
+ * enumerations as attributes instead of simply using a String.
  * When adding new values to the enumeration, the enum only changes must
  * be deployed before the enumeration value can be persisted. This will
  * ensure that all systems have the correct code to map it from the item

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTypeConvertedEnum.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTypeConvertedEnum.java
@@ -31,7 +31,7 @@ import java.lang.annotation.Target;
  * </pre>
  *
  * <p>Please note, there are some risks in distributed systems when using
- * enumerations as attributes intead of simply using a String.
+ * enumerations as attributes instead of simply using a String.
  * When adding new values to the enumeration, the enum only changes must
  * be deployed before the enumeration value can be persisted. This will
  * ensure that all systems have the correct code to map it from the item

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTyped.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTyped.java
@@ -106,7 +106,7 @@ import java.lang.annotation.Target;
  * <p><b>{@link Enum} to {@code S}</b></p>
  * <p>The {@code enum} type is only supported by override or custom converter.
  * There are some risks in distributed systems when using enumerations as
- * attributes intead of simply using a String. When adding new values to the
+ * attributes instead of simply using a String. When adding new values to the
  * enumeration, the enum only changes must deployed before the enumeration
  * value can be persisted. This will ensure that all systems have the correct
  * code to map it from the item record in DynamoDB to your objects.</p>


### PR DESCRIPTION
*Description of changes:*

The classes related to DynamoDB enum conversion had a typo of the word instead spelled as intead.

You can see an example in the [DynamoDBTypeConvertedEnum](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBTypeConvertedEnum.html) docs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
