### PR TITLE
Adding support for "Version" to State Machine definition

### DIFF
--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/StateMachine.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/StateMachine.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.io.IOException;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -52,11 +51,15 @@ public final class StateMachine {
     @JsonProperty(PropertyNames.STATES)
     private final Map<String, State> states;
 
+    @JsonProperty(PropertyNames.VERSION)
+    private final String version;
+
     private StateMachine(Builder builder) {
-        this.comment = builder.comment;
-        this.startAt = builder.startAt;
-        this.timeoutSeconds = builder.timeoutSeconds;
-        this.states = Buildable.Utils.build(builder.states);
+        comment = builder.comment;
+        startAt = builder.startAt;
+        timeoutSeconds = builder.timeoutSeconds;
+        states = Buildable.Utils.build(builder.states);
+        version = builder.version;
     }
 
     /**
@@ -86,6 +89,13 @@ public final class StateMachine {
      */
     public Map<String, State> getStates() {
         return states;
+    }
+
+    /**
+     * @return The version for this state machine, if explicitly declared.
+     */
+    public String getVersion() {
+        return version;
     }
 
     /**
@@ -151,6 +161,9 @@ public final class StateMachine {
         @JsonProperty(PropertyNames.STATES)
         private final Map<String, State.Builder> states = new LinkedHashMap<String, State.Builder>();
 
+        @JsonProperty(PropertyNames.VERSION)
+        private String version;
+
         private Builder() {
         }
 
@@ -201,6 +214,17 @@ public final class StateMachine {
          */
         public Builder state(String stateName, State.Builder stateBuilder) {
             this.states.put(stateName, stateBuilder);
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Version of the states language, if specified.
+         *
+         * @param version Version value.
+         * @return This object for method chaining.
+         */
+        public Builder version(String version) {
+            this.version = version;
             return this;
         }
 

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/PropertyNames.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/PropertyNames.java
@@ -35,6 +35,7 @@ public class PropertyNames {
     public static final String OUTPUT_PATH = "OutputPath";
     public static final String PARAMETERS = "Parameters";
     public static final String END = "End";
+    public static final String VERSION = "Version";
 
     // TaskState property names
     public static final String RESOURCE = "Resource";

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilderIntegrationTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilderIntegrationTest.java
@@ -88,7 +88,7 @@ public class StepFunctionBuilderIntegrationTest extends AWSIntegrationTestBase {
     }
 
     @Test
-    public void rountripStateMachine() {
+    public void roundTripStateMachine() {
         StateMachine stateMachine =
             stateMachine().state("ParallelState", testParallelState())
                           .state("WaitForTimestamp", testWaitForTimestamp())
@@ -100,6 +100,9 @@ public class StepFunctionBuilderIntegrationTest extends AWSIntegrationTestBase {
                           .state("PassState", passState().transition(next("EndState")))
                           .state("EndState", succeedState())
                           .startAt("ParallelState")
+                          .comment("This is a state machine")
+                          .timeoutSeconds(180)
+                          .version("1.0")
                           .build();
         CreateStateMachineResult createResult = client.createStateMachine(
             new CreateStateMachineRequest().withName(STATE_MACHINE_NAME)

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/IntegrationTestStateMachine.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/IntegrationTestStateMachine.json
@@ -1,4 +1,7 @@
 {
+  "Comment": "This is a state machine",
+  "TimeoutSeconds": 180,
+  "Version": "1.0",
   "StartAt":"ParallelState",
   "States":{
     "ParallelState":{


### PR DESCRIPTION
Fixes https://github.com/aws/aws-sdk-java/issues/2015

*Description of changes:*

Adds support to `StateMachine` and `StateMachine.Builder` to parse and write the "Version" top-level field, per the states language specification. Integration tests have been updated.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
