### PR TITLE
Rethrowing an original IOException within SdkClientException

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -1580,7 +1580,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         try {
             return IOUtils.toString(object.getObjectContent());
         } catch (IOException e) {
-            throw new SdkClientException("Error streaming content from S3 during download");
+            throw new SdkClientException("Error streaming content from S3 during download", e);
         } finally {
             IOUtils.closeQuietly(object, log);
         }


### PR DESCRIPTION
*When IOException occurs while reading file content, original exception must be populated within custom SdkClientException*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
