### PR TITLE
Correction for bad issue link in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
     - Update Apache http client version to `4.5.9`.
 
   - ### Bugfixes
-    - Disable apache normalization to handle breaking change introduced in apache httpclient `4.5.7`. See [aws/aws-sdk-java[[#1919](https://github.com/aws/aws-sdk-java/issues/1919)](https://github.com/aws/aws-sdk-java-v2/issues/1919)](https://github.com/aws/aws-sdk-java/issues/1919) for more information.
+    - Disable Apache normalization to handle breaking change introduced in Apache httpclient `4.5.7`. See [aws/aws-sdk-java #1919](https://github.com/aws/aws-sdk-java/issues/1919) for more information.
 
 ## __AWS Shield__
   - ### Features


### PR DESCRIPTION
The link to issue #1919 for release `1.11.596` (2019-07-22) is somewhat garbled, as described in Issue #2056.

I believe this change fixes that.

*Issue Link*

#2056 

*Description of changes:*

Fix the bad link to issue number 1919 in the [CHANGELOG entry for `1.11.596`](https://github.com/aws/aws-sdk-java/blob/master/CHANGELOG.md#111596-2019-07-22).

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*

Damn straight.