### PR TITLE
Implementing equals & hashCode for HeadBucketRequest

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/HeadBucketRequest.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/HeadBucketRequest.java
@@ -36,4 +36,30 @@ public class HeadBucketRequest extends AmazonWebServiceRequest implements Serial
     public HeadBucketRequest(String bucketName) {
         this.bucketName = bucketName;
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+
+        if (obj instanceof HeadBucketRequest == false){
+            return false;
+        }
+        HeadBucketRequest other = (HeadBucketRequest)obj;
+        if(other.getBucketName() == null ^ this.getBucketName() == null)
+            return false;
+        if (other.getBucketName() != null && !other.getBucketName().equals(this.getBucketName()))
+            return false;
+        return true;
+    }
+
+    @Override
+    public int hashCode(){
+        final int prime = 31;
+        int hashCode = 1;
+        hashCode = prime * hashCode + ((getBucketName() == null) ? 0 : getBucketName().hashCode());
+        return hashCode;
+    }
 }

--- a/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/model/HeadBucketRequestTest.java
+++ b/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/model/HeadBucketRequestTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.s3.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class HeadBucketRequestTest {
+
+    @Test
+    public void equalRequestsTest() {
+        String bucketName1 = "test-bucket";
+        String bucketName2 = "test-bucket";
+        Assert.assertEquals(new HeadBucketRequest(bucketName1), new HeadBucketRequest(bucketName2));
+    }
+
+    @Test
+    public void equalByReferenceTest() {
+        HeadBucketRequest headBucketRequest = new HeadBucketRequest("bucket-name");
+        Assert.assertEquals(headBucketRequest, headBucketRequest);
+    }
+
+    @Test
+    public void notEqualRequestsTest() {
+        String bucketName1 = "test-bucket1";
+        String bucketName2 = "test-bucket2";
+        Assert.assertNotEquals(new HeadBucketRequest(bucketName1), new HeadBucketRequest(bucketName2));
+    }
+}


### PR DESCRIPTION
#2073

Adds an implementation of equals & hashcode to HeadBucketRequest class, this PR includes unit tests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
