### PR TITLE
Add fromString to S3Event enum and include S3Event in S3EventNotificationRecord

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
@@ -330,6 +330,7 @@ public class S3EventNotification {
 
         private final String awsRegion;
         private final String eventName;
+        private final S3Event s3Event;
         private final String eventSource;
         private DateTime eventTime;
         private final String eventVersion;
@@ -343,6 +344,7 @@ public class S3EventNotification {
         public S3EventNotificationRecord(
                 String awsRegion,
                 String eventName,
+                S3Event s3Event,
                 String eventSource,
                 String eventTime,
                 String eventVersion,
@@ -353,6 +355,7 @@ public class S3EventNotification {
         {
             this(awsRegion,
                  eventName,
+                 s3Event,
                  eventSource,
                  eventTime,
                  eventVersion,
@@ -367,6 +370,7 @@ public class S3EventNotification {
         public S3EventNotificationRecord(
                 @JsonProperty(value = "awsRegion") String awsRegion,
                 @JsonProperty(value = "eventName") String eventName,
+                @JsonProperty(value = "s3Event") S3Event s3Event,
                 @JsonProperty(value = "eventSource") String eventSource,
                 @JsonProperty(value = "eventTime") String eventTime,
                 @JsonProperty(value = "eventVersion") String eventVersion,
@@ -379,6 +383,7 @@ public class S3EventNotification {
             this.awsRegion = awsRegion;
             this.eventName = eventName;
             this.eventSource = eventSource;
+            this.s3Event = S3Event.fromString(eventName);
 
             if (eventTime != null)
             {
@@ -399,6 +404,10 @@ public class S3EventNotification {
 
         public String getEventName() {
             return eventName;
+        }
+        
+        public S3Event getS3Event() {
+        	return s3Event;
         }
 
         public String getEventSource() {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
@@ -330,7 +330,6 @@ public class S3EventNotification {
 
         private final String awsRegion;
         private final String eventName;
-        private final S3Event s3Event;
         private final String eventSource;
         private DateTime eventTime;
         private final String eventVersion;
@@ -363,37 +362,11 @@ public class S3EventNotification {
                  userIdentity,
                  null);
         }
-        
-        public S3EventNotificationRecord(
-                String awsRegion,
-                String eventName,
-                S3Event s3Event,
-                String eventSource,
-                String eventTime,
-                String eventVersion,
-                RequestParametersEntity requestParameters,
-                ResponseElementsEntity responseElements,
-                S3Entity s3,
-                UserIdentityEntity userIdentity)
-        {
-            this(awsRegion,
-                 eventName,
-                 s3Event,
-                 eventSource,
-                 eventTime,
-                 eventVersion,
-                 requestParameters,
-                 responseElements,
-                 s3,
-                 userIdentity,
-                 null);
-        }
 
         @JsonCreator
         public S3EventNotificationRecord(
                 @JsonProperty(value = "awsRegion") String awsRegion,
                 @JsonProperty(value = "eventName") String eventName,
-                @JsonProperty(value = "s3Event") S3Event s3Event,
                 @JsonProperty(value = "eventSource") String eventSource,
                 @JsonProperty(value = "eventTime") String eventTime,
                 @JsonProperty(value = "eventVersion") String eventVersion,
@@ -406,7 +379,6 @@ public class S3EventNotification {
             this.awsRegion = awsRegion;
             this.eventName = eventName;
             this.eventSource = eventSource;
-            this.s3Event = S3Event.fromValue(eventName);
 
             if (eventTime != null)
             {
@@ -428,9 +400,9 @@ public class S3EventNotification {
         public String getEventName() {
             return eventName;
         }
-        
-        public S3Event getS3Event() {
-        	return s3Event;
+
+        public S3Event getEventNameAsEnum() {
+        	return S3Event.fromValue(eventName);
         }
 
         public String getEventSource() {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/event/S3EventNotification.java
@@ -344,6 +344,29 @@ public class S3EventNotification {
         public S3EventNotificationRecord(
                 String awsRegion,
                 String eventName,
+                String eventSource,
+                String eventTime,
+                String eventVersion,
+                RequestParametersEntity requestParameters,
+                ResponseElementsEntity responseElements,
+                S3Entity s3,
+                UserIdentityEntity userIdentity)
+        {
+            this(awsRegion,
+                 eventName,
+                 eventSource,
+                 eventTime,
+                 eventVersion,
+                 requestParameters,
+                 responseElements,
+                 s3,
+                 userIdentity,
+                 null);
+        }
+        
+        public S3EventNotificationRecord(
+                String awsRegion,
+                String eventName,
                 S3Event s3Event,
                 String eventSource,
                 String eventTime,
@@ -383,7 +406,7 @@ public class S3EventNotification {
             this.awsRegion = awsRegion;
             this.eventName = eventName;
             this.eventSource = eventSource;
-            this.s3Event = S3Event.fromString(eventName);
+            this.s3Event = S3Event.fromValue(eventName);
 
             if (eventTime != null)
             {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Event.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Event.java
@@ -15,9 +15,6 @@
 
 package com.amazonaws.services.s3.model;
 
-import java.util.HashMap;
-import java.util.Map;
-
 /**
  * A enum class for all Amazon S3 events.
  */
@@ -47,7 +44,7 @@ public enum S3Event {
     ;
 
     private final String event;
-	private static final String S3_PREFIX = "S3:";
+	private static final String S3_PREFIX = "s3:";
 
     private S3Event(String event) {
         this.event = event;
@@ -57,22 +54,27 @@ public enum S3Event {
     public String toString() {
         return this.event;
     }
-    
-	private static final Map<String, S3Event> stringToEnum = new HashMap<>();
 
-	static {
-		for(S3Event s3Event : S3Event.values()) {
-			stringToEnum.put(s3Event.toString().toUpperCase(), s3Event);
-		}
-	}
+    /**
+     *
+     * @param value
+     *        real value
+     * @return S3Event corresponding to the value
+     *
+     * @throws IllegalArgumentException
+     *         If the specified value does not map to one of the known values in this enum.
+     */
+    public static S3Event fromValue(String value) {
+        if (value == null || "".equals(value)) {
+            throw new IllegalArgumentException("Value cannot be null or empty!");
+        }
 
-	public static S3Event fromString(String key) {
-		S3Event s3Event = stringToEnum.get(key.toUpperCase());
-		if (s3Event == null) {
-			// the S3 record returned for an event differs slightly from the value in the enum
-			// so here we try to match the value adding the s3: prefix
-			s3Event = stringToEnum.get(S3_PREFIX.concat(key.toUpperCase()));
-		}
-		return s3Event;
-	}
+        for (S3Event enumEntry : S3Event.values()) {
+            if (enumEntry.toString().equals(value) || enumEntry.toString().equals(S3_PREFIX.concat(value))) {
+                return enumEntry;
+            }
+        }
+
+        throw new IllegalArgumentException("Cannot create enum from " + value + " value!");
+    }
 }

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Event.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/S3Event.java
@@ -15,6 +15,9 @@
 
 package com.amazonaws.services.s3.model;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * A enum class for all Amazon S3 events.
  */
@@ -44,6 +47,7 @@ public enum S3Event {
     ;
 
     private final String event;
+	private static final String S3_PREFIX = "S3:";
 
     private S3Event(String event) {
         this.event = event;
@@ -53,4 +57,22 @@ public enum S3Event {
     public String toString() {
         return this.event;
     }
+    
+	private static final Map<String, S3Event> stringToEnum = new HashMap<>();
+
+	static {
+		for(S3Event s3Event : S3Event.values()) {
+			stringToEnum.put(s3Event.toString().toUpperCase(), s3Event);
+		}
+	}
+
+	public static S3Event fromString(String key) {
+		S3Event s3Event = stringToEnum.get(key.toUpperCase());
+		if (s3Event == null) {
+			// the S3 record returned for an event differs slightly from the value in the enum
+			// so here we try to match the value adding the s3: prefix
+			s3Event = stringToEnum.get(S3_PREFIX.concat(key.toUpperCase()));
+		}
+		return s3Event;
+	}
 }


### PR DESCRIPTION
#2080 

Include an S3Event object inside an S3EventNotification when parsing the JSON sent by an S3 event, instead of just a string with the event name. 
Also, add _fromString_ method to S3Event enum to make easier decoding the value. Given that S3 events return strings like _ObjectRestore:Completed_ but the values in the enum look like _s3:ObjectRestore:Completed_, I decided to include the prefix if no values match.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
