### PR TITLE
store headers case-insensitively in DefaultRequest

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/DefaultRequest.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/DefaultRequest.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Default implementation of the {@linkplain com.amazonaws.Request} interface.
@@ -53,7 +54,7 @@ public class DefaultRequest<T> implements Request<T> {
     private Map<String, List<String>> parameters = new LinkedHashMap<String, List<String>>();
 
     /** Map of the headers included in this request */
-    private Map<String, String> headers = new HashMap<String, String>();
+    private Map<String, String> headers = new TreeMap<String, String>(String.CASE_INSENSITIVE_ORDER);
 
     /** The service endpoint to which this request should be sent */
     private URI endpoint;

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/DefaultRequestTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/DefaultRequestTest.java
@@ -58,4 +58,17 @@ public class DefaultRequestTest {
         Assert.assertEquals("Hello2", modelRequest.getHandlerContext(context));
         Assert.assertEquals("Hello3", request.getHandlerContext(context));
     }
+
+    @Test
+    public void defaultRequestShouldTreatHeadersCaseInsensitive() {
+
+        AmazonWebServiceRequest modelRequest = new AmazonWebServiceRequest() {};
+        DefaultRequest<?> request = new DefaultRequest<Object>(modelRequest, "service-name");
+
+        request.addHeader("Content-Length", "100");
+        request.addHeader("content-length", "0");
+
+        Assert.assertEquals("0", request.getHeaders().get("Content-Length"));
+        Assert.assertEquals("0", request.getHeaders().get("content-length"));
+    }
 }


### PR DESCRIPTION
DefaultRequest stores headers prior case-sensitively, which
can lead to funky problems in the apache http client.

Such a scenario can exist if you try to double store Content-Length
in mixed casing -- the apache http client will throw a
ClientProtocolException.

fixes https://github.com/aws/aws-sdk-java/issues/2108

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
