### PR TITLE
Adding Map State to Step Functions Builder

### DIFF
--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilder.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilder.java
@@ -35,6 +35,7 @@ import com.amazonaws.services.stepfunctions.builder.conditions.TimestampGreaterT
 import com.amazonaws.services.stepfunctions.builder.conditions.TimestampLessThanCondition;
 import com.amazonaws.services.stepfunctions.builder.conditions.TimestampLessThanOrEqualCondition;
 import com.amazonaws.services.stepfunctions.builder.states.Branch;
+import com.amazonaws.services.stepfunctions.builder.states.Iterator;
 import com.amazonaws.services.stepfunctions.builder.states.Catcher;
 import com.amazonaws.services.stepfunctions.builder.states.Choice;
 import com.amazonaws.services.stepfunctions.builder.states.ChoiceState;
@@ -42,6 +43,7 @@ import com.amazonaws.services.stepfunctions.builder.states.EndTransition;
 import com.amazonaws.services.stepfunctions.builder.states.FailState;
 import com.amazonaws.services.stepfunctions.builder.states.NextStateTransition;
 import com.amazonaws.services.stepfunctions.builder.states.ParallelState;
+import com.amazonaws.services.stepfunctions.builder.states.MapState;
 import com.amazonaws.services.stepfunctions.builder.states.PassState;
 import com.amazonaws.services.stepfunctions.builder.states.Retrier;
 import com.amazonaws.services.stepfunctions.builder.states.SucceedState;
@@ -94,6 +96,27 @@ public final class StepFunctionBuilder {
      */
     public static Branch.Builder branch() {
         return Branch.builder();
+    }
+
+    /**
+     * State that allows for applying the same {@link Iterator} to multiple input elements.
+     * The Map State (identified by "Type": "Map") causes the interpreter to process all the elements of an array,
+     * potentially in parallel, with the processing of each element independent of the others.
+     *
+     * @return Builder used to configure a {@link MapState}.
+     * @see <a href="https://states-language.net/spec.html#map-state">https://states-language.net/spec.html#map-state</a>
+     */
+    public static MapState.Builder mapState() {
+        return MapState.builder();
+    }
+
+    /**
+     * An iterator to apply against a list of inputs. See {@link MapState}.
+     *
+     * @return Builder used to configure a {@link Iterator}.
+     */
+    public static Iterator.Builder iterator() {
+        return Iterator.builder();
     }
 
     /**

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/PropertyNames.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/PropertyNames.java
@@ -33,6 +33,7 @@ public class PropertyNames {
     public static final String RESULT_PATH = "ResultPath";
     public static final String INPUT_PATH = "InputPath";
     public static final String OUTPUT_PATH = "OutputPath";
+    public static final String ITEMS_PATH = "ItemsPath";
     public static final String PARAMETERS = "Parameters";
     public static final String END = "End";
     public static final String VERSION = "Version";
@@ -43,6 +44,10 @@ public class PropertyNames {
 
     // ParallelState property names
     public static final String BRANCHES = "Branches";
+
+    // MapState property names
+    public static final String ITERATOR = "Iterator";
+    public static final String MAX_CONCURRENCY = "MaxConcurrency";
 
     // FailState property names
     public static final String ERROR = "Error";

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/Location.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/Location.java
@@ -22,6 +22,7 @@ enum Location {
     State,
     Choice,
     Branch,
+    Iterator,
     Catcher,
     Retrier,
     Unknown;

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/StateMachineValidator.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/StateMachineValidator.java
@@ -22,12 +22,14 @@ import com.amazonaws.services.stepfunctions.builder.conditions.NAryCondition;
 import com.amazonaws.services.stepfunctions.builder.conditions.NotCondition;
 import com.amazonaws.services.stepfunctions.builder.internal.PropertyNames;
 import com.amazonaws.services.stepfunctions.builder.states.Branch;
+import com.amazonaws.services.stepfunctions.builder.states.Iterator;
 import com.amazonaws.services.stepfunctions.builder.states.Catcher;
 import com.amazonaws.services.stepfunctions.builder.states.Choice;
 import com.amazonaws.services.stepfunctions.builder.states.ChoiceState;
 import com.amazonaws.services.stepfunctions.builder.states.FailState;
 import com.amazonaws.services.stepfunctions.builder.states.NextStateTransition;
 import com.amazonaws.services.stepfunctions.builder.states.ParallelState;
+import com.amazonaws.services.stepfunctions.builder.states.MapState;
 import com.amazonaws.services.stepfunctions.builder.states.PassState;
 import com.amazonaws.services.stepfunctions.builder.states.Retrier;
 import com.amazonaws.services.stepfunctions.builder.states.State;
@@ -141,6 +143,9 @@ public class StateMachineValidator {
             if (state instanceof ParallelState) {
                 validateParallelState(stateContext, (ParallelState) state);
             }
+            if (state instanceof MapState) {
+                validateMapState(stateContext, (MapState) state);
+            }
             if (state.isTerminalState()) {
                 return true;
             } else if (state instanceof TransitionState) {
@@ -162,6 +167,14 @@ public class StateMachineValidator {
                                    branch.getStates()).validate();
                 index++;
             }
+        }
+
+        private void validateMapState(ValidationContext stateContext, MapState state) {
+            Iterator iterator = state.getIterator();
+            new GraphValidator(stateContext.iterator(),
+                    Collections.<String, State>emptyMap(),
+                    iterator.getStartAt(),
+                    iterator.getStates()).validate();
         }
 
         private boolean validateChoiceState(ValidationContext stateContext, ChoiceState choiceState) {
@@ -286,6 +299,30 @@ public class StateMachineValidator {
                                                                                     PropertyNames.START_AT)));
                 }
                 index++;
+            }
+        }
+
+        @Override
+        public Void visit(MapState mapState) {
+            currentContext.assertIsValidItemsPath(mapState.getItemsPath());
+            currentContext.assertIsValidInputPath(mapState.getInputPath());
+            currentContext.assertIsValidOutputPath(mapState.getOutputPath());
+            currentContext.assertIsValidResultPath(mapState.getResultPath());
+            validateTransition(mapState.getTransition());
+            validateRetriers(mapState.getRetriers());
+            validateCatchers(mapState.getCatchers());
+            validateIterator(mapState);
+            return null;
+        }
+
+        private void validateIterator(MapState mapState) {
+            currentContext.assertNotNull(mapState.getIterator(), PropertyNames.ITERATOR);
+            Iterator iterator = mapState.getIterator();
+            ValidationContext iteratorContext = currentContext.iterator();
+            validateStates(iteratorContext, iterator.getStates());
+            if (!iterator.getStates().containsKey(iterator.getStartAt())) {
+                problemReporter.report(new Problem(iteratorContext, String.format("%s references a non existent state.",
+                        PropertyNames.START_AT)));
             }
         }
 

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/ValidationContext.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/validation/ValidationContext.java
@@ -159,6 +159,13 @@ final class ValidationContext {
     /**
      * Asserts that the string represents a valid JsonPath expression.
      *
+     * @param path Path expression to validate.
+     */
+    public void assertIsValidItemsPath(String path) { assertIsValidReferencePath(path, PropertyNames.ITEMS_PATH); }
+
+    /**
+     * Asserts that the string represents a valid JsonPath expression.
+     *
      * @param path         Path expression to validate.
      * @param propertyName Name of property.
      */
@@ -218,6 +225,15 @@ final class ValidationContext {
         return newChildContext()
                 .identifier(String.valueOf(index))
                 .location(Location.Branch)
+                .build();
+    }
+
+    /**
+     * @return Iterator sub-context.
+     */
+    public ValidationContext iterator() {
+        return newChildContext()
+                .location(Location.Iterator)
                 .build();
     }
 

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/InputOutputResultItemsPathBuilder.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/InputOutputResultItemsPathBuilder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.services.stepfunctions.builder.states;
+
+/**
+ * Interface for all builders that expose all of 'InputPath', 'OutputPath', 'ResultPath', and 'ItemsPath'
+ *
+ * <p>This interface should not be implemented outside the SDK.</p>
+ *
+ * @param <BuilderT> Type of concrete builder (for method chaining).
+ */
+public interface InputOutputResultItemsPathBuilder<BuilderT>
+        extends InputOutputResultPathBuilder<BuilderT> {
+    /**
+     * OPTIONAL. The value of “ItemsPath” MUST be a path, with is a reference path identifying where in the effective
+     * input the array field is found. If not provided then the whole input is used.
+     * used.
+     *
+     * @param itemsPath New path value.
+     * @return This object for method chaining.
+     */
+    BuilderT itemsPath(String itemsPath);
+}

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/Iterator.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/Iterator.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2011-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.stepfunctions.builder.states;
+
+import com.amazonaws.services.stepfunctions.builder.internal.Buildable;
+import com.amazonaws.services.stepfunctions.builder.internal.PropertyNames;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * An iterator to apply against a list of inputs. See {@link MapState}.
+ *
+ * @see <a href="https://states-language.net/spec.html#map-state">https://states-language.net/spec.html#map-state</a>
+ */
+public final class Iterator {
+
+    @JsonProperty(PropertyNames.START_AT)
+    private final String startAt;
+
+    @JsonProperty(PropertyNames.COMMENT)
+    private final String comment;
+
+    @JsonProperty(PropertyNames.STATES)
+    private final Map<String, State> states;
+
+    private Iterator(Builder builder) {
+        this.startAt = builder.startAt;
+        this.comment = builder.comment;
+        this.states = Buildable.Utils.build(builder.stateBuilders);
+    }
+
+
+    /**
+     * @return Name of the state to start iterator execution at.
+     */
+    public String getStartAt() {
+        return startAt;
+    }
+
+    /**
+     * @return Human readable description for the state machine.
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * @return The states for this iterator.
+     */
+    public Map<String, State> getStates() {
+        return states;
+    }
+
+    /**
+     * @return Builder instance to construct a {@link Iterator}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for a {@link Iterator}.
+     */
+    public static final class Builder implements Buildable<Iterator> {
+
+        @JsonProperty(PropertyNames.START_AT)
+        private String startAt;
+
+        @JsonProperty(PropertyNames.COMMENT)
+        private String comment;
+
+        @JsonProperty(PropertyNames.STATES)
+        private Map<String, State.Builder> stateBuilders = new LinkedHashMap<String, State.Builder>();
+
+        private Builder() {
+        }
+
+        /**
+         * REQUIRED. Name of the state to start iterator execution at. Must match a state name provided via {@link #state(String,
+         * State.Builder)}.
+         *
+         * @param startAt Name of starting state.
+         * @return This object for method chaining.
+         */
+        public Builder startAt(String startAt) {
+            this.startAt = startAt;
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Human readable description for the state machine.
+         *
+         * @param comment New comment.
+         * @return This object for method chaining.
+         */
+        public Builder comment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        /**
+         * REQUIRED. Adds a new state to the iterator. A iterator MUST have at least one state.
+         *
+         * @param stateName    Name of the state
+         * @param stateBuilder Instance of {@link State.Builder}. Note that
+         *                     the {@link State}
+         *                     object is not built until the {@link Iterator} is built so any modifications on the state builder
+         *                     will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder state(String stateName, State.Builder stateBuilder) {
+            this.stateBuilders.put(stateName, stateBuilder);
+            return this;
+        }
+
+        /**
+         * @return An immutable {@link Iterator} object.
+         */
+        @Override
+        public Iterator build() {
+            return new Iterator(this);
+        }
+    }
+
+}

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/MapState.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/MapState.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright 2011-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.services.stepfunctions.builder.states;
+
+import com.amazonaws.services.stepfunctions.builder.internal.Buildable;
+import com.amazonaws.services.stepfunctions.builder.internal.PropertyNames;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.amazonaws.services.stepfunctions.builder.internal.JacksonUtils.*;
+
+/**
+ * State that allows for applying the same {@link Iterator} to multiple input elements.
+ * The Map State (identified by "Type": "Map") causes the interpreter to process all the elements of an array,
+ * potentially in parallel, with the processing of each element independent of the others.
+ *
+ * @see <a href="https://states-language.net/spec.html#map-state">https://states-language.net/spec.html#map-state</a>
+ */
+public final class MapState extends TransitionState {
+
+    @JsonProperty(PropertyNames.COMMENT)
+    private final String comment;
+
+    @JsonProperty(PropertyNames.ITERATOR)
+    private final Iterator iterator;
+
+    @JsonProperty(PropertyNames.MAX_CONCURRENCY)
+    private final Integer maxConcurrency;
+
+    @JsonUnwrapped
+    private final PathContainer pathContainer;
+
+    @JsonUnwrapped
+    private final Transition transition;
+
+    @JsonProperty(PropertyNames.RETRY)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<Retrier> retriers;
+
+    @JsonProperty(PropertyNames.CATCH)
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private final List<Catcher> catchers;
+
+    private MapState(Builder builder) {
+        this.comment = builder.comment;
+        this.iterator = builder.iterator.build();
+        this.pathContainer = builder.pathContainer.build();
+        this.maxConcurrency = builder.maxConcurrency;
+        this.transition = builder.transition.build();
+        this.retriers = Buildable.Utils.build(builder.retriers);
+        this.catchers = Buildable.Utils.build(builder.catchers);
+    }
+
+    /**
+     * @return Type identifier of {@link MapState}.
+     */
+    @Override
+    public String getType() {
+        return "Map";
+    }
+
+    /**
+     * @return The transition that will occur when all branches have executed successfully.
+     */
+    public Transition getTransition() {
+        return transition;
+    }
+
+    /**
+     * @return Human readable description for the state.
+     */
+    public String getComment() {
+        return comment;
+    }
+
+    /**
+     * @return Max Concurrency provides an upper bound on how many invocations of the Iterator may run in parallel
+     */
+    public Integer getMaxConcurrency() {
+        return maxConcurrency;
+    }
+
+    /**
+     * @return The iterator for this {@link MapState}.
+     */
+    public Iterator getIterator() {
+        return iterator;
+    }
+
+    /**
+     * @return The input path expression that may optionally transform the input to this state.
+     */
+    @JsonIgnore
+    public String getInputPath() {
+        return pathContainer.getInputPath();
+    }
+
+    /**
+     * @return The result path expression that may optionally combine or replace the state's raw input with it's result.
+     */
+    @JsonIgnore
+    public String getResultPath() {
+        return pathContainer.getResultPath();
+    }
+
+    /**
+     * @return The items path expression that is a reference path identifying where in the effective input the array field is found
+     */
+    @JsonIgnore
+    public String getItemsPath() {
+        return pathContainer.getItemsPath();
+    }
+
+    /**
+     * @return The output path expression that may optionally transform the output to this state.
+     */
+    @JsonIgnore
+    public String getOutputPath() {
+        return pathContainer.getOutputPath();
+    }
+
+    /**
+     * @return The Parameters JSON document that may optionally transform the effective input to the task.
+     */
+    @JsonIgnore
+    public String getParameters() {
+        return jsonToString(pathContainer.getParameters());
+    }
+
+    /**
+     * @return The list of {@link Retrier}s for this state.
+     */
+    public List<Retrier> getRetriers() {
+        return retriers;
+    }
+
+    /**
+     * @return The list of {@link Catcher}s for this state.
+     */
+    public List<Catcher> getCatchers() {
+        return catchers;
+    }
+
+    @Override
+    public <T> T accept(StateVisitor<T> visitor) {
+        return visitor.visit(this);
+    }
+
+    /**
+     * @return Builder instance to construct a {@link MapState}.
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for a {@link MapState}.
+     */
+    public static final class Builder extends TransitionStateBuilder
+        implements InputOutputResultItemsPathBuilder<Builder>, ParametersBuilder<Builder> {
+
+        @JsonProperty(PropertyNames.COMMENT)
+        private String comment;
+
+        @JsonProperty(PropertyNames.MAX_CONCURRENCY)
+        private Integer maxConcurrency;
+
+        @JsonProperty(PropertyNames.ITERATOR)
+        private Iterator.Builder iterator = Iterator.builder();
+
+        @JsonUnwrapped
+        private final PathContainer.Builder pathContainer = PathContainer.builder();
+
+        private Transition.Builder transition = Transition.NULL_BUILDER;
+
+        @JsonProperty(PropertyNames.RETRY)
+        private List<Retrier.Builder> retriers = new ArrayList<Retrier.Builder>();
+
+        @JsonProperty(PropertyNames.CATCH)
+        private List<Catcher.Builder> catchers = new ArrayList<Catcher.Builder>();
+
+        private Builder() {
+        }
+
+        /**
+         * OPTIONAL. Human readable description for the state.
+         *
+         * @param comment New comment.
+         * @return This object for method chaining.
+         */
+        public Builder comment(String comment) {
+            this.comment = comment;
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Max Concurrency provides an upper bound on how many invocations of the Iterator may run in parallel
+         *
+         * @param maxConcurrency New comment.
+         * @return This object for method chaining.
+         */
+        public Builder maxConcurrency(Integer maxConcurrency) {
+            this.maxConcurrency = maxConcurrency;
+            return this;
+        }
+
+        /**
+         * REQUIRED. Iterator for this Map state.
+         *
+         * @param iteratorBuilder Instance of {@link Iterator.Builder}. Note that
+         *                      the {@link
+         *                      Iterator} object is not built until the {@link MapState} is built so any modifications on the
+         *                      state builder will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder iterator(Iterator.Builder iteratorBuilder) {
+            this.iterator = iteratorBuilder;
+            return this;
+        }
+
+        @Override
+        public Builder inputPath(String inputPath) {
+            pathContainer.inputPath(inputPath);
+            return this;
+        }
+
+        @Override
+        public Builder resultPath(String resultPath) {
+            pathContainer.resultPath(resultPath);
+            return this;
+        }
+
+        @Override
+        public Builder itemsPath(String itemsPath) {
+            pathContainer.itemsPath(itemsPath);
+            return this;
+        }
+
+        @Override
+        public Builder outputPath(String outputPath) {
+            pathContainer.outputPath(outputPath);
+            return this;
+        }
+
+        @Override
+        public Builder parameters(String parameters) {
+            pathContainer.parameters(stringToJsonNode("Parameters", parameters));
+            return this;
+        }
+
+        @Override
+        public Builder parameters(Object parameters) {
+            pathContainer.parameters(objectToJsonNode(parameters));
+            return this;
+        }
+
+        /**
+         * REQUIRED. Sets the transition that will occur when all branches in this map
+         * state have executed successfully.
+         *
+         * @param builder New transition.
+         * @return This object for method chaining.
+         */
+        @Override
+        public Builder transition(Transition.Builder builder) {
+            this.transition = builder;
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Adds the {@link Retrier}s to this states retries. If a single branch fails then the entire map state is
+         * considered failed and eligible for retry.
+         *
+         * @param retrierBuilders Instances of {@link Retrier.Builder}. Note
+         *                        that the {@link
+         *                        Retrier} object is not built until the {@link MapState} is built so any modifications on
+         *                        the state builder will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder retriers(Retrier.Builder... retrierBuilders) {
+            for (Retrier.Builder retrierBuilder : retrierBuilders) {
+                retrier(retrierBuilder);
+            }
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Adds the {@link Retrier} to this states retries. If a single branch fails then the entire map state is
+         * considered failed and eligible for retry.
+         *
+         * @param retrierBuilder Instance of {@link Retrier.Builder}. Note
+         *                       that the {@link
+         *                       Retrier} object is not built until the {@link MapState} is built so any modifications on
+         *                       the
+         *                       state builder will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder retrier(Retrier.Builder retrierBuilder) {
+            this.retriers.add(retrierBuilder);
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Adds the {@link Catcher}s to this states catchers.  If a single branch fails then the entire map state
+         * is considered failed and eligible to be caught.
+         *
+         * @param catcherBuilders Instances of {@link Catcher.Builder}. Note
+         *                        that the {@link
+         *                        Catcher} object is not built until the {@link MapState} is built so any modifications on
+         *                        the state builder will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder catchers(Catcher.Builder... catcherBuilders) {
+            for (Catcher.Builder catcherBuilder : catcherBuilders) {
+                catcher(catcherBuilder);
+            }
+            return this;
+        }
+
+        /**
+         * OPTIONAL. Adds the {@link Catcher} to this states catchers.  If a single branch fails then the entire map state
+         * is
+         * considered failed and eligible to be caught.
+         *
+         * @param catcherBuilder Instance of {@link Catcher.Builder}. Note
+         *                       that the {@link
+         *                       Catcher} object is not built until the {@link MapState} is built so any modifications on
+         *                       the
+         *                       state builder will be reflected in this object.
+         * @return This object for method chaining.
+         */
+        public Builder catcher(Catcher.Builder catcherBuilder) {
+            this.catchers.add(catcherBuilder);
+            return this;
+        }
+
+        /**
+         * @return An immutable {@link MapState} object.
+         */
+        public MapState build() {
+            return new MapState(this);
+        }
+    }
+}

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/PathContainer.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/PathContainer.java
@@ -29,7 +29,7 @@ import com.fasterxml.jackson.databind.node.TextNode;
 import java.io.IOException;
 
 /**
- * Container for the InputPath, OutputPath, and ResultPath fields to handle serialization concerns.
+ * Container for the InputPath, OutputPath, ResultPath, and ItemsPath fields to handle serialization concerns.
  */
 @SdkInternalApi
 final class PathContainer {
@@ -46,6 +46,10 @@ final class PathContainer {
     @JsonSerialize(using = PathSerializer.class)
     private final JsonNode resultPath;
 
+    @JsonProperty(PropertyNames.ITEMS_PATH)
+    @JsonSerialize(using = PathSerializer.class)
+    private final JsonNode itemsPath;
+
     @JsonProperty(PropertyNames.PARAMETERS)
     @JsonSerialize(using = PathSerializer.class)
     private final JsonNode parameters;
@@ -54,6 +58,7 @@ final class PathContainer {
         this.inputPath = builder.inputPath;
         this.outputPath = builder.outputPath;
         this.resultPath = builder.resultPath;
+        this.itemsPath = builder.itemsPath;
         this.parameters = builder.parameters;
     }
 
@@ -70,6 +75,11 @@ final class PathContainer {
     @JsonIgnore
     public String getResultPath() {
         return nodeToString(resultPath);
+    }
+
+    @JsonIgnore
+    public String getItemsPath() {
+        return nodeToString(itemsPath);
     }
 
     @JsonIgnore
@@ -102,6 +112,8 @@ final class PathContainer {
 
         private JsonNode resultPath;
 
+        private JsonNode itemsPath;
+
         private JsonNode parameters;
 
         protected Builder() {
@@ -122,6 +134,12 @@ final class PathContainer {
         @JsonProperty(PropertyNames.RESULT_PATH)
         public Builder resultPath(String resultPath) {
             this.resultPath = resolvePath(resultPath);
+            return this;
+        }
+
+        @JsonProperty(PropertyNames.ITEMS_PATH)
+        public Builder itemsPath(String itemsPath) {
+            this.itemsPath = resolvePath(itemsPath);
             return this;
         }
 

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/State.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/State.java
@@ -45,6 +45,11 @@ public interface State {
     String PARALLEL = "Parallel";
 
     /**
+     * Type identifier for a {@link MapState}.
+     */
+    String MAP = "Map";
+
+    /**
      * Type identifier for a {@link PassState}.
      */
     String PASS = "Pass";
@@ -86,6 +91,7 @@ public interface State {
             @JsonSubTypes.Type(value = ChoiceState.Builder.class, name = CHOICE),
             @JsonSubTypes.Type(value = FailState.Builder.class, name = FAIL),
             @JsonSubTypes.Type(value = ParallelState.Builder.class, name = PARALLEL),
+            @JsonSubTypes.Type(value = MapState.Builder.class, name = MAP),
             @JsonSubTypes.Type(value = PassState.Builder.class, name = PASS),
             @JsonSubTypes.Type(value = SucceedState.Builder.class, name = SUCCEED),
             @JsonSubTypes.Type(value = TaskState.Builder.class, name = TASK),

--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/StateVisitor.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/states/StateVisitor.java
@@ -49,4 +49,8 @@ public abstract class StateVisitor<T> {
         return null;
     }
 
+    public T visit(MapState mapState) {
+        return null;
+    }
+
 }

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/JsonDocumentSettersTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/JsonDocumentSettersTest.java
@@ -17,10 +17,12 @@ package com.amazonaws.services.stepfunctions.builder;
 import static com.amazonaws.services.stepfunctions.builder.StatesAsserts.assertJsonEquals;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.end;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.parallelState;
+import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.mapState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.passState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.taskState;
 
 import com.amazonaws.services.stepfunctions.builder.states.ParallelState;
+import com.amazonaws.services.stepfunctions.builder.states.MapState;
 import com.amazonaws.services.stepfunctions.builder.states.PassState;
 import com.amazonaws.services.stepfunctions.builder.states.TaskState;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,8 +34,8 @@ import org.junit.runners.Parameterized;
 
 /**
  * Tests various builders that accept a raw JSON string or POJO to be serialized as JSON. This includes
- * {@link PassState} which has a JSON result object, and PassState, {@link ParallelState}, and {@link TaskState} which
- * accepts JSON for the Parameters field.
+ * {@link PassState} which has a JSON result object, and PassState, {@link ParallelState}, {@link MapState},
+ * and {@link TaskState} which accepts JSON for the Parameters field.
  */
 @RunWith(Parameterized.class)
 public class JsonDocumentSettersTest {
@@ -143,6 +145,25 @@ public class JsonDocumentSettersTest {
                         return result.build().getParameters();
                     }
                 }
+            },
+            // MapState#parameters
+            {
+                    new Handler() {
+
+                        @Override
+                        public String setString(String json) {
+                            return build(newMapState().parameters(json));
+                        }
+
+                        @Override
+                        public String setPojo(Object pojo) {
+                            return build(newMapState().parameters(pojo));
+                        }
+
+                        private String build(MapState.Builder result) {
+                            return result.build().getParameters();
+                        }
+                    }
             }
         });
     }
@@ -209,5 +230,9 @@ public class JsonDocumentSettersTest {
 
     private static ParallelState.Builder newParallelState() {
         return parallelState().transition(end());
+    }
+
+    private static MapState.Builder newMapState() {
+        return mapState().transition(end());
     }
 }

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/PathSerializationTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/PathSerializationTest.java
@@ -15,6 +15,7 @@
 package com.amazonaws.services.stepfunctions.builder;
 
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.branch;
+import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.iterator;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.catcher;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.choice;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.choiceState;
@@ -22,6 +23,7 @@ import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.e
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.eq;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.next;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.parallelState;
+import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.mapState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.passState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.seconds;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.stateMachine;
@@ -119,6 +121,56 @@ public class PathSerializationTest {
                         .transition(end()))
                 .build();
         assertStateMachineMatches("ParallelStateWithNonNullPaths.json", stateMachine);
+    }
+
+    @Test
+    public void mapStateWithNoPathsProvided_DoesNotHavePathFieldsInJson() {
+        final StateMachine stateMachine = stateMachine()
+                .startAt("InitialState")
+                .state("InitialState", mapState()
+                        .iterator(iterator()
+                                .startAt("IteratorState")
+                                .state("IteratorState", succeedState()))
+                        .transition(end()))
+                .build();
+        assertStateMachineMatches("MapStateWithNoExplicitPaths.json", stateMachine);
+    }
+
+    @Test
+    public void mapStateWithExplicitNullPaths_HasExplicitJsonNullInJson() {
+        final StateMachine stateMachine = stateMachine()
+                .startAt("InitialState")
+                .state("InitialState", mapState()
+                        .iterator(iterator()
+                                .startAt("IteratorState")
+                                .state("IteratorState", succeedState()))
+                        .itemsPath(null)
+                        .inputPath(null)
+                        .outputPath(null)
+                        .resultPath(null)
+                        .parameters(null)
+                        .transition(end()))
+                .build();
+        assertStateMachineMatches("MapStateWithExplicitNullPaths.json", stateMachine);
+    }
+
+    @Test
+    public void mapStateWithNonNullPaths_HasCorrectPathsInJson() {
+        final StateMachine stateMachine = stateMachine()
+                .startAt("InitialState")
+                .state("InitialState", mapState()
+                        .iterator(iterator()
+                                .startAt("IteratorState")
+                                .state("IteratorState", succeedState()))
+                        .itemsPath("$.items")
+                        .inputPath("$.input")
+                        .outputPath("$.output")
+                        .resultPath("$.result")
+                        .parameters("[42, \"foo\", {}]")
+                        .maxConcurrency(10)
+                        .transition(end()))
+                .build();
+        assertStateMachineMatches("MapStateWithNonNullPaths.json", stateMachine);
     }
 
     @Test

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/internal/validation/StateMachineValidatorTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/internal/validation/StateMachineValidatorTest.java
@@ -16,6 +16,7 @@ package com.amazonaws.services.stepfunctions.builder.internal.validation;
 
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.and;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.branch;
+import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.iterator;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.catcher;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.choice;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.choiceState;
@@ -24,6 +25,7 @@ import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.e
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.failState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.next;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.parallelState;
+import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.mapState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.passState;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.retrier;
 import static com.amazonaws.services.stepfunctions.builder.StepFunctionBuilder.seconds;
@@ -658,6 +660,79 @@ public class StateMachineValidatorTest {
                         .transition(end())
                         .catcher(catcher()
                                          .transition(next("NoSuchState"))))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateWithNoIterator_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .transition(end()))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateWithInvalidTransition_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .iterator(iterator()
+                                .startAt("InitialBranchState")
+                                .state("InitialBranchState", succeedState()))
+                        .transition(next("NoSuchState")))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateIteratorStartAtStateInvalid_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .iterator(iterator()
+                                .startAt("NoSuchState")
+                                .state("InitialBranchState", succeedState()))
+                        .transition(end()))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateInvalidIteratorState_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .iterator(iterator()
+                                .startAt("InitialBranchState")
+                                .state("InitialBranchState", failState()))
+                        .transition(end()))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateInvalidRetrier_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .iterator(iterator()
+                                .startAt("InitialBranchState")
+                                .state("InitialBranchState", succeedState()))
+                        .transition(end())
+                        .retrier(retrier()
+                                .intervalSeconds(-1)))
+                .build();
+    }
+
+    @Test(expected = ValidationException.class)
+    public void mapStateInvalidCatcher_IsNotValid() {
+        stateMachine()
+                .startAt("Initial")
+                .state("Initial", mapState()
+                        .iterator(iterator()
+                                .startAt("InitialBranchState")
+                                .state("InitialBranchState", succeedState()))
+                        .transition(end())
+                        .catcher(catcher()
+                                .transition(next("NoSuchState"))))
                 .build();
     }
 }

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/states/StateVisitorTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/states/StateVisitorTest.java
@@ -35,6 +35,7 @@ public class StateVisitorTest {
         assertNull(visitor.visit(failState().build()));
         assertNull(visitor.visit(choiceState().build()));
         assertNull(visitor.visit(parallelState().build()));
+        assertNull(visitor.visit(mapState().build()));
         assertNull(visitor.visit(succeedState().build()));
         assertNull(visitor.visit(taskState().build()));
         assertNull(visitor.visit(waitState().build()));

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/IntegrationTestStateMachine.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/IntegrationTestStateMachine.json
@@ -9,7 +9,7 @@
       "OutputPath":"$.parallel.output",
       "ResultPath":"$.parallel.result",
       "Parameters":"foo",
-      "Next":"WaitForTimestamp",
+      "Next":"MapState",
       "Comment":"This is a parallel state",
       "Branches":[
         {
@@ -69,6 +69,48 @@
         }
       ],
       "Type":"Parallel"
+    },
+    "MapState":{
+      "ItemsPath":"$.map.items",
+      "InputPath":"$.map.input",
+      "OutputPath":"$.map.output",
+      "ResultPath":"$.map.result",
+      "MaxConcurrency":10,
+      "Parameters":"foo",
+      "Next":"WaitForTimestamp",
+      "Comment":"This is a map state",
+      "Iterator": {
+        "StartAt":"IteratorStart",
+        "Comment":"Iterator start",
+        "States":{
+          "IteratorStart":{
+            "InputPath":"$.succeed.input",
+            "OutputPath":"$.succeed.output",
+            "Comment":"Succeed state",
+            "Type":"Succeed"
+          }
+        }
+      },
+      "Retry":[
+        {
+          "ErrorEquals":[
+            "States.ALL"
+          ],
+          "IntervalSeconds":5,
+          "MaxAttempts":3,
+          "BackoffRate":1.2
+        }
+      ],
+      "Catch":[
+        {
+          "ResultPath":"$.catcher.result",
+          "Next":"EndState",
+          "ErrorEquals":[
+            "States.ALL"
+          ]
+        }
+      ],
+      "Type":"Map"
     },
     "WaitForTimestamp":{
       "Timestamp":"2100-07-07T06:43:30.000Z",

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/MapStateWithCatchers.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/MapStateWithCatchers.json
@@ -1,0 +1,43 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "ItemsPath": "$.items",
+      "MaxConcurrency" : 10,
+      "End": true,
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "Comment": "Iterator state machine",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      },
+      "Catch": [
+        {
+          "ErrorEquals": [
+            "Foo",
+            "Bar"
+          ],
+          "Next": "RecoveryState",
+          "ResultPath": "$.result"
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "Next": "OtherRecoveryState",
+          "ResultPath": "$.result"
+        }
+      ]
+    },
+    "RecoveryState": {
+      "Type": "Succeed"
+    },
+    "OtherRecoveryState": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/MapStateWithRetriers.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/MapStateWithRetriers.json
@@ -1,0 +1,39 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "ItemsPath": "$.items",
+      "MaxConcurrency" : 10,
+      "End": true,
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "Comment": "Iterator state machine",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Foo",
+            "Bar"
+          ],
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.0,
+          "MaxAttempts": 3
+        },
+        {
+          "ErrorEquals": [
+            "States.ALL"
+          ],
+          "IntervalSeconds": 10,
+          "BackoffRate": 1.0,
+          "MaxAttempts": 3
+        }
+      ]
+    }
+  }
+}

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/SimpleMapState.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/SimpleMapState.json
@@ -1,0 +1,30 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "Comment": "My map state",
+      "ItemsPath": "$.items",
+      "InputPath": "$.input",
+      "OutputPath": "$.output",
+      "ResultPath": "$.result",
+      "MaxConcurrency": 50,
+      "Parameters": {
+        "foo.$": "$.val"
+      },
+      "Next": "NextState",
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "Comment": "Iterator state machine",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      }
+    },
+    "NextState": {
+      "Type": "Succeed"
+    }
+  }
+}

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithExplicitNullPaths.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithExplicitNullPaths.json
@@ -1,0 +1,22 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "ItemsPath": null,
+      "InputPath": null,
+      "OutputPath": null,
+      "ResultPath": null,
+      "Parameters": null,
+      "End": true,
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithNoExplicitPaths.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithNoExplicitPaths.json
@@ -1,0 +1,17 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "End": true,
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      }
+    }
+  }
+}

--- a/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithNonNullPaths.json
+++ b/aws-java-sdk-stepfunctions/src/test/resources/resources/state_machines/paths/MapStateWithNonNullPaths.json
@@ -1,0 +1,23 @@
+{
+  "StartAt": "InitialState",
+  "States": {
+    "InitialState": {
+      "Type": "Map",
+      "ItemsPath": "$.items",
+      "InputPath": "$.input",
+      "OutputPath": "$.output",
+      "ResultPath": "$.result",
+      "Parameters": [42, "foo", {}],
+      "MaxConcurrency": 10,
+      "End": true,
+      "Iterator": {
+        "StartAt": "IteratorState",
+        "States": {
+          "IteratorState": {
+            "Type": "Succeed"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-sdk-java/issues/2104

*Description of changes:*
Adding the missing [MapState](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-map-state.html) and corresponding Iterator to the Step Function Builder. This is, for the most part, following the same patterns used for the ParallelState Builder since the two are so similar. The main difference is rather than multiple branches, Map State contains a single _Iterator_ to apply against a list of inputs. 
There are also two additional fields for Map State that do not exist in Parallel State: 
**ItemsPath** - optional, follows the same pattern as InputPath, OutputPath, ResultPath
**MaxConcurrency** - optional, Integer

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
