### PR TITLE
Add public factory method getInstance to WebIdentityTokenCredentialsProvider

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/WebIdentityTokenCredentialsProvider.java
@@ -26,6 +26,12 @@ public class WebIdentityTokenCredentialsProvider implements AWSCredentialsProvid
     private final AWSCredentialsProvider credentialsProvider;
     private final RuntimeException loadException;
 
+    private static final WebIdentityTokenCredentialsProvider INSTANCE = new WebIdentityTokenCredentialsProvider();
+
+    private WebIdentityTokenCredentialsProvider() {
+        this(new BuilderImpl());
+    }
+
     private WebIdentityTokenCredentialsProvider(BuilderImpl builder) {
         AWSCredentialsProvider credentialsProvider = null;
         RuntimeException loadException = null;
@@ -75,6 +81,10 @@ public class WebIdentityTokenCredentialsProvider implements AWSCredentialsProvid
     @Override
     public void refresh() {
 
+    }
+
+    public static WebIdentityTokenCredentialsProvider getInstance() {
+        return INSTANCE;
     }
 
     public static WebIdentityTokenCredentialsProvider create() {


### PR DESCRIPTION
The create() method does this, but other tools and libraries expect a
default constructor or getInstance() method for these purposes, such as
in the Hadoop s3a libraries.

For example if you attempt to use this provider in Hadoop explicitly:
```
<property>
  <name>fs.s3a.aws.credentials.provider</name>
  <value>com.amazonaws.auth.WebIdentityTokenCredentialsProvider</value>
</property>
```
Fails with:
```
Caused by: java.io.IOException: com.amazonaws.auth.WebIdentityTokenCredentialsProvider constructor exception.  A class specified in fs.s3a.aws.credentials.provider must provide a public constructor accepting Configuration, or a public factory method named getInstance that accepts no arguments, or a public default constructor.
        at org.apache.hadoop.fs.s3a.S3AUtils.createAWSCredentialProvider(S3AUtils.java:661) ~[hadoop-aws-3.1.1.jar:?]
        at org.apache.hadoop.fs.s3a.S3AUtils.cre
```
This PR should fix the above error.