### PR TITLE
Update Jackson (jackson-databind) dependency to just released 2.6.7.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
       <awsjavasdk.version>${project.version}</awsjavasdk.version>
       <!-- The SDK requires Jackson 2.6 to support Java 6 customers. Feel free to override in your own application -->
       <jackson.version>2.6.7</jackson.version>
-      <jackson.databind.version>2.6.7.2</jackson.databind.version>
+      <jackson.databind.version>2.6.7.3</jackson.databind.version>
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>


### PR DESCRIPTION
Update to `jackson-databind` dependency, from 2.6.7.2 to just released 2.6.7.3, which contains every security fix up to and including 2.9.10 (plus 2 fixes that will be in 2.9.10.1).
See https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.6.7.x).
I realize that aws-sdk-java is not vulnerable (as per README), but many security tools can't tell the difference so this should be useful to many users.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
