### PR TITLE
Remove commons-logging dependency

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -14,11 +14,6 @@
   <url>https://aws.amazon.com/sdkforjava</url>
   <dependencies>
     <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>${commons.logging.version}</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${httpcomponents.httpclient.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -241,7 +241,6 @@
       <ion.java.version>1.0.2</ion.java.version>
       <junit.version>4.12</junit.version>
       <easymock.version>3.2</easymock.version>
-      <commons.logging.version>1.1.3</commons.logging.version>
       <jodatime.version>2.8.1</jodatime.version>
       <wiremock.version>1.55</wiremock.version>
       <log4j.version>1.2.17</log4j.version>


### PR DESCRIPTION
This dependency is already transitively added by `org.apache.httpcomponents:httpclient`

Resolves https://github.com/aws/aws-sdk-java/issues/1108

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.