### PR TITLE
Empty environment variables should be treated as null when dealing with proxy configuraton

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -637,7 +637,8 @@ public class ClientConfiguration {
      * Returns the value for the given environment variable.
      */
     private String getEnvironmentVariable(String environmentVariable) {
-        return System.getenv(environmentVariable);
+        String value = System.getenv(environmentVariable);
+        return value != null && !value.trim().isEmpty() ? value : null;
     }
 
     /**

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -253,6 +253,10 @@ public class ClientConfigurationTest {
         config = new ClientConfiguration();
         assertNull(config.getProxyHost());
 
+        environmentVariableHelper.set("https_proxy", "");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
+
         environmentVariableHelper.set("https_proxy", "bad-url");
         config = new ClientConfiguration();
         assertNull(config.getProxyHost());
@@ -303,6 +307,10 @@ public class ClientConfigurationTest {
         EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
         ClientConfiguration config;
 
+        config = new ClientConfiguration();
+        assertEquals(-1, config.getProxyPort());
+
+        environmentVariableHelper.set("https_proxy", "");
         config = new ClientConfiguration();
         assertEquals(-1, config.getProxyPort());
 
@@ -359,6 +367,10 @@ public class ClientConfigurationTest {
         config = new ClientConfiguration();
         assertNull(config.getProxyUsername());
 
+        environmentVariableHelper.set("https_proxy", "");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyUsername());
+
         environmentVariableHelper.set("https_proxy", "bad-url");
         config = new ClientConfiguration();
         assertNull(config.getProxyUsername());
@@ -409,6 +421,10 @@ public class ClientConfigurationTest {
         EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
         ClientConfiguration config;
 
+        config = new ClientConfiguration();
+        assertNull(config.getProxyPassword());
+
+        environmentVariableHelper.set("https_proxy", "");
         config = new ClientConfiguration();
         assertNull(config.getProxyPassword());
 
@@ -636,6 +652,21 @@ public class ClientConfigurationTest {
         cfg.setProtocol(Protocol.HTTP);
         assertThat(cfg.getProxyHost(), equalTo("http-proxy"));
 
+        environmentVariableHelper.reset();
+    }
+
+    @Test
+    public void getProxyHost_envVarSet_emptyUrl_doesNotThrow() {
+        EnvironmentVariableHelper environmentVariableHelper = new EnvironmentVariableHelper();
+
+        environmentVariableHelper.set("https_proxy", "");
+        ClientConfiguration config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
+        environmentVariableHelper.reset();
+
+        environmentVariableHelper.set("http_proxy", "");
+        config = new ClientConfiguration();
+        assertNull(config.getProxyHost());
         environmentVariableHelper.reset();
     }
 


### PR DESCRIPTION
Change on `getEnvironmentVariable` method to check for empty variables, and return those as null. This will evict malformed URL warnings when there's actually no proxy configured. Also some tests to check that new condition.

Issue #2176


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
