### PR TITLE
Fixing import statement.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AbstractFileTlsKeyManagersProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AbstractFileTlsKeyManagersProvider.java
@@ -19,7 +19,7 @@ import com.amazonaws.util.IOUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;;
+import java.io.InputStream;
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;


### PR DESCRIPTION
Fixing a possible simple typo error causing java project error in Ecipse and JDK 1.8\nThe error message received is "Syntax error on token ";", delete this token"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
