### PR TITLE
Respect DEFAULT_METRICS_SYSTEM_PROPERTY when exporting metrics for JMX

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/metrics/AwsSdkMetrics.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/metrics/AwsSdkMetrics.java
@@ -344,6 +344,12 @@ public enum AwsSdkMetrics {
             perHostMetricsIncluded = includePerHostMetrics;
             singleMetricNamespace = useSingleMetricNamespace;
             httpSocketReadMetricEnabled = enableHttpSocketReadMetric;
+            // Exports AwsSdkMetrics for JMX access.
+            try {
+                registerMetricAdminMBean();
+            } catch(Exception ex) {
+                LogFactory.getLog(AwsSdkMetrics.class).warn("", ex);
+            }
         }
     }
 
@@ -353,14 +359,6 @@ public enum AwsSdkMetrics {
      * Used to disallow re-entrancy in enabling the default metric collection system.
      */
     private static boolean dirtyEnabling;
-    /** Exports AwsSdkMetrics for JMX access. */
-    static {
-        try {
-            registerMetricAdminMBean();
-        } catch(Exception ex) {
-            LogFactory.getLog(AwsSdkMetrics.class).warn("", ex);
-        }
-    }
 
     /**
      * Returns true if the metric admin MBean is currently registered for JMX


### PR DESCRIPTION
Currently `AwsSdkMetrics` registers metrics even if we specify that default metrics are disabled.

*Issue #, if available:*
No issue available. I can create one if needed.

*Description of changes:*
Moving registerMetricAdminMBean call from one static initialization blocks, to the one that 
checks if metrics are disabled.

I'd love to provide a repro test but it's hard to test static initializers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.