### PR TITLE
updated plugins for Reproducible Builds (excl osgi)

### DIFF
--- a/aws-java-sdk-bundle/pom.xml
+++ b/aws-java-sdk-bundle/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.4.3</version>
+                <version>3.2.2</version>
                 <configuration>
                     <artifactSet>
                         <includes>

--- a/aws-java-sdk-bundle/pom.xml
+++ b/aws-java-sdk-bundle/pom.xml
@@ -33,7 +33,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.2</version>
+                <version>3.2.3</version>
                 <configuration>
                     <artifactSet>
                         <includes>

--- a/aws-java-sdk-codegen-maven-plugin/pom.xml
+++ b/aws-java-sdk-codegen-maven-plugin/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>default-descriptor</id>

--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -1341,7 +1341,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
         <configuration>
           <archive>
             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
@@ -1374,7 +1373,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -2510,7 +2509,7 @@
                   <!-- Invoke the Assembly plugin to create the ZIP archive -->
                   <plugin>
                       <artifactId>maven-assembly-plugin</artifactId>
-                      <version>2.6</version>
+                      <version>3.2.0</version>
                       <configuration>
                           <descriptors>
                               <descriptor>src/assembly/sdk-zip-archive-assembly.xml</descriptor>

--- a/aws-java-sdk-osgi/pom.xml
+++ b/aws-java-sdk-osgi/pom.xml
@@ -1367,13 +1367,14 @@
             <Import-Package>!org.junit.*,!org.springframework.*,!org.apache.avalon.*,!org.apache.log.*,!org.aspectj.*,org.apache.http.conn.routing,com.sun.org.apache.xerces.internal.jaxp.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.*;resolution:=optional,com.sun.org.apache.xml.internal.dtm.ref.*;resolution:=optional,com.sun.org.apache.xpath.internal.*;resolution:=optional,javax.mail;resolution:=optional,*</Import-Package>
             <Embed-Dependency>*;scope=compile;inline=true</Embed-Dependency>
             <Embed-Transitive>false</Embed-Transitive>
+            <_removeheaders>Bnd-LastModified</_removeheaders>
           </instructions>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.2.2</version>
+        <version>3.2.3</version>
         <executions>
           <execution>
             <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -295,6 +295,8 @@
       <unitils.version>3.3</unitils.version>
       <!-- Netty is used by Kinesis Video -->
       <netty.version>4.1.44.Final</netty.version>
+      <!-- Reproducible Builds jar entries timestamp: https://maven.apache.org/guides/mini/guide-reproducible-builds.html -->
+      <project.build.outputTimestamp>2020-02-08T08:04:00Z</project.build.outputTimestamp>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -350,6 +352,12 @@
               <include>**/*TestCase.java</include>
             </includes>
           </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>3.2.0</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
aws-java-sdk-osgi is the only remaining non-reproducible module, waiting
for Felix maven-bundle-plugin improvement

see https://maven.apache.org/guides/mini/guide-reproducible-builds.html for more information on how to configure a Maven build to get Reproducible Build

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
