### PR TITLE
Force DynamoDBMapper::transactionWrite to respect SaveBehavior.CLOBBER

### DIFF
--- a/aws-java-sdk-dynamodb/pom.xml
+++ b/aws-java-sdk-dynamodb/pom.xml
@@ -56,6 +56,12 @@
         <version>${mockito.all.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-all</artifactId>
+      <version>${hamcrest.all.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
         <artifactId>jmespath-java</artifactId>
         <groupId>com.amazonaws</groupId>
         <optional>false</optional>

--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -2444,7 +2444,7 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
                 new VersionAttributeConditionExpressionGenerator();
         for (final DynamoDBMapperFieldModel<Object,Object> field : model.fields()) {
             AttributeValue currentValue = null;
-            if (field.versioned()) {
+            if (field.versioned() && SaveBehavior.CLOBBER != config.getSaveBehavior()) {
                 if (writeExpression != null) {
                     throw new SdkClientException("A transactional write operation may not also specify a condition " +
                                                          "expression if a versioned attribute is present on the " +

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
@@ -1,0 +1,111 @@
+package com.amazonaws.services.dynamodbv2.datamodeling;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.verify;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
+import com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBMapperConfig.SaveBehavior;
+import com.amazonaws.services.dynamodbv2.model.TransactWriteItemsRequest;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DynamoDBMapperTest {
+    @Mock
+    private AmazonDynamoDB mockAmazonDynamoDB;
+
+    @InjectMocks
+    private DynamoDBMapper sut;
+
+    @Test
+    public void shouldIncludeConditionWithSaveBehaviorPut() {
+        // given
+        SaveBehavior saveBehavior = SaveBehavior.PUT;
+
+        // when
+        TransactWriteItemsRequest capturedTransactWriteItemsRequest = doTransactionWriteAndCapture(saveBehavior);
+
+        // then ensure there IS a condition expression
+        assertNotNull(extractConditionExpression(capturedTransactWriteItemsRequest));
+    }
+
+    @Test
+    public void shouldNotIncludeConditionWithSaveBehaviorClobber() {
+        // given
+        SaveBehavior saveBehavior = SaveBehavior.CLOBBER;
+
+        // when
+        TransactWriteItemsRequest capturedTransactWriteItemsRequest = doTransactionWriteAndCapture(saveBehavior);
+
+        // then ensure there is NOT a condition expression
+        assertNull(extractConditionExpression(capturedTransactWriteItemsRequest));
+    }
+
+    // =-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-
+
+    private TransactWriteItemsRequest doTransactionWriteAndCapture(SaveBehavior saveBehavior) {
+        // setup a capture of the TransactWriteItemsRequest sent to AmazonDynamoDB
+        ArgumentCaptor<TransactWriteItemsRequest> transactWriteItemsRequestCaptor = ArgumentCaptor.forClass(
+                TransactWriteItemsRequest.class);
+
+        // create a dummy request
+        TransactionWriteRequest deleteStubItemRequest = new TransactionWriteRequest();
+        deleteStubItemRequest.addDelete(createDummyVersionedItem());
+
+        // send the dummy request to the sut
+        sut.transactionWrite(deleteStubItemRequest, DynamoDBMapperConfig.builder()
+                                                                        .withSaveBehavior(saveBehavior)
+                                                                        .build());
+
+        // capture the TransactWriteItemsRequest sent to AmazonDynamoDB
+        verify(mockAmazonDynamoDB).transactWriteItems(transactWriteItemsRequestCaptor.capture());
+
+        return transactWriteItemsRequestCaptor.getValue();
+    }
+
+    private String extractConditionExpression(TransactWriteItemsRequest capturedTransactWriteItemsRequest) {
+        return capturedTransactWriteItemsRequest.getTransactItems()
+                                                .get(0)
+                                                .getDelete()
+                                                .getConditionExpression();
+    }
+
+    private StubVersionedItem createDummyVersionedItem() {
+        StubVersionedItem stubVersionedItem = new StubVersionedItem();
+
+        stubVersionedItem.setDummyHashKey("Dummy");
+
+        return stubVersionedItem;
+    }
+}
+
+@DynamoDBTable(tableName = "StubTableName")
+class StubVersionedItem {
+    @DynamoDBHashKey(attributeName = "StubTableHashKey")
+    private String dummyHashKey;
+
+    @DynamoDBVersionAttribute
+    private Long version;
+
+    public String getDummyHashKey() {
+        return dummyHashKey;
+    }
+
+    public void setDummyHashKey(String dummyHashKey) {
+        this.dummyHashKey = dummyHashKey;
+    }
+
+    public Long getVersion() {
+        return version;
+    }
+
+    public void setVersion(Long version) {
+        this.version = version;
+    }
+}

--- a/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
+++ b/aws-java-sdk-dynamodb/src/test/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperTest.java
@@ -56,7 +56,7 @@ public class DynamoDBMapperTest {
 
         // create a dummy request
         TransactionWriteRequest deleteStubItemRequest = new TransactionWriteRequest();
-        deleteStubItemRequest.addDelete(createDummyVersionedItem());
+        deleteStubItemRequest.addDelete(createStubVersionedItem());
 
         // send the dummy request to the sut
         sut.transactionWrite(deleteStubItemRequest, DynamoDBMapperConfig.builder()
@@ -76,10 +76,10 @@ public class DynamoDBMapperTest {
                                                 .getConditionExpression();
     }
 
-    private StubVersionedItem createDummyVersionedItem() {
+    private StubVersionedItem createStubVersionedItem() {
         StubVersionedItem stubVersionedItem = new StubVersionedItem();
 
-        stubVersionedItem.setDummyHashKey("Dummy");
+        stubVersionedItem.setHashKey("Dummy");
 
         return stubVersionedItem;
     }
@@ -88,17 +88,17 @@ public class DynamoDBMapperTest {
 @DynamoDBTable(tableName = "StubTableName")
 class StubVersionedItem {
     @DynamoDBHashKey(attributeName = "StubTableHashKey")
-    private String dummyHashKey;
+    private String hashKey;
 
     @DynamoDBVersionAttribute
     private Long version;
 
-    public String getDummyHashKey() {
-        return dummyHashKey;
+    public String getHashKey() {
+        return hashKey;
     }
 
-    public void setDummyHashKey(String dummyHashKey) {
-        this.dummyHashKey = dummyHashKey;
+    public void setHashKey(String dummyHashKey) {
+        this.hashKey = dummyHashKey;
     }
 
     public Long getVersion() {


### PR DESCRIPTION
**Issue #, if available:**
https://github.com/aws/aws-sdk-java/issues/2230

**Description of changes:**
Ensures that the version attribute condition expression is NOT appended if the SaveBehavior is CLOBBER.

_By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice._