### PR TITLE
Add Build-Time to jar MANIFEST

### DIFF
--- a/aws-java-sdk-core/pom.xml
+++ b/aws-java-sdk-core/pom.xml
@@ -102,11 +102,53 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
+    <filters>
+      <filter>${basedir}/target/filter.properties</filter>
+    </filters>
+
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <executions>
+          <execution>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>run</goal>
+            </goals>
+            <configuration>
+              <tasks>
+                <!-- Safety -->
+                <mkdir dir="${project.build.directory}"/>
+
+                <tstamp>
+                  <format property="last.updated" pattern="yyyy-MM-dd hh:mm:ss"/>
+                </tstamp>
+                <echo file="${basedir}/target/filter.properties" message="build.time=${last.updated}"/>
+              </tasks>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <useDefaultManifestFile>true</useDefaultManifestFile>
+        </configuration>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/aws-java-sdk-core/src/main/resources/META-INF/MANIFEST.MF
+++ b/aws-java-sdk-core/src/main/resources/META-INF/MANIFEST.MF
@@ -1,0 +1,1 @@
+Build-Time: ${build.time}

--- a/pom.xml
+++ b/pom.xml
@@ -322,6 +322,20 @@
 
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.4</version>
+          <configuration>
+            <archive>
+              <manifest>
+                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+              </manifest>
+            </archive>
+          </configuration>
+        </plugin>
+
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
           <version>2.9.1</version>
           <configuration>


### PR DESCRIPTION
*Issue #, if available:* NA

*Description of changes:* My organization uses a tool that keeps the dependencies updated. It does so by reading the version of the dependencies mentioned in pom.xml and checking if there is an update available. However, its not very wise to update the libraries as soon as they are released and our tool provides a way to configure the number of days it should wait after a library is released. And for this it looks for `Build-Time` in jar's MANIFEST.MF file. This PR aims to achieve the same.

Useful link: https://maven.apache.org/plugin-developers/cookbook/add-build-time-to-manifest.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
