### PR TITLE
Adding github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,38 @@
+---
+name: "\U0001F41B Bug report"
+about: Create a report to help us improve
+labels: bug, needs-triage
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Describe the bug
+<!--- A clear and concise description of what the bug is -->
+
+## Expected Behavior
+<!--- Tell us what should happen -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+<!--- Include full errors, uncaught exceptions, stack traces, and relevant logs -->
+<!--- To turn on SDK logging, follow instructions here: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-logging.html-->
+<!--- If service responses are relevant, please include wirelogs -->
+
+## Steps to Reproduce
+<!--- Provide a self-contained, concise snippet of code that can be used to reproduce the issue -->
+<!--- For more complex issues provide a repo with the smallest sample that reproduces the bug -->
+<!--- Avoid including business logic or unrelated code, it makes diagnosis more difficult -->
+
+## Possible Solution
+<!--- Not required, but suggest a fix/reason for the bug -->
+
+## Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment where the bug was discovered -->
+* AWS Java SDK version used:
+* JDK version used:
+* Operating System and version:

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,29 @@
+---
+name: "\U0001F680 Feature Request"
+about: Suggest an idea for this project
+labels: feature-request, needs-triage
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Describe the Feature
+<!--- A clear and concise description of the feature you are proposing -->
+
+## Is your Feature Request related to a problem?
+<!--- A description of the issue, e.g. I'm always frustrated when... -->
+
+## Proposed Solution
+<!--- Not required, but suggest how to implement the addition or change -->
+
+## Describe alternatives you've considered
+<!--- Any alternative solutions or features you've considered -->
+
+## Additional Context
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment where the bug was discovered -->
+* AWS Java SDK version used:
+* JDK version used:
+* Operating System and version:

--- a/.github/ISSUE_TEMPLATE/general-issue.md
+++ b/.github/ISSUE_TEMPLATE/general-issue.md
@@ -1,0 +1,28 @@
+---
+name: "\U0001F4AC General Issue"
+about: Create a new issue
+labels: guidance, needs-triage
+---
+
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Describe the issue
+<!--- A clear and concise description of the issue -->
+
+## Steps to Reproduce
+<!--- Provide a self-contained, concise snippet of code that can be used to reproduce the issue -->
+<!--- For more complex issues provide a repo with the smallest reproducible example -->
+<!--- Avoid including business logic or unrelated code, it makes diagnosis more difficult -->
+
+## Current Behavior
+<!--- Tell us what happens instead of the expected behavior -->
+
+<!--- Include full errors, uncaught exceptions, stack traces, and relevant logs -->
+<!--- To turn on SDK logging, follow instructions here: https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/java-dg-logging.html -->
+<!--- If service responses are relevant, please include wirelogs -->
+
+## Your Environment
+<!--- Include as many relevant details about the environment where the bug was discovered -->
+* AWS Java SDK version used:
+* JDK version used:
+* Operating System and version:


### PR DESCRIPTION
### Description
Creating 3 different templates for issues: bug, feature request and general issue.

### Motivation and Context
Standardizing the use of templates among SDK repos and help in labeling automation.
For more details about github issue templates see [here](https://help.github.com/en/github/building-a-strong-community/about-issue-and-pull-request-templates).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
