### PR TITLE
Make EndpointToRegion.guessRegionOrRegionNameForEndpoint tolerate the format 127.0.0.1:1234

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/regions/EndpointToRegion.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/regions/EndpointToRegion.java
@@ -17,6 +17,7 @@ package com.amazonaws.regions;
 import com.amazonaws.annotation.SdkProtectedApi;
 import com.amazonaws.util.AwsHostNameUtils;
 import java.net.URI;
+import java.net.URISyntaxException;
 
 /**
  * Utilities to attempt to convert from a hostname/endpoint to an AWS region.
@@ -68,7 +69,12 @@ public class EndpointToRegion {
             return new RegionOrRegionName();
         }
 
-        String host = URI.create(endpoint).getHost();
+        String host = null;
+        try {
+            host = new URI(endpoint).getHost();
+        } catch (URISyntaxException x) {
+            // proceed
+        }
         if (host == null) {
             host = URI.create("http://" + endpoint).getHost();
         }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/regions/EndpointToRegionTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/regions/EndpointToRegionTest.java
@@ -111,6 +111,18 @@ public class EndpointToRegionTest {
         verifyRegionAndPartitionForHostname("us-gov-west-1", "aws-us-gov", "iam.us-gov-west-1.banana.com", "iam");
     }
 
+    @Test
+    public void guessRegionForHostname_ipAddress() {
+        assertNull(guessRegionNameForEndpoint("http://localhost"));
+        assertNull(guessRegionNameForEndpoint("http://localhost:1234"));
+        assertNull(guessRegionNameForEndpoint("http://127.0.0.1"));
+        assertNull(guessRegionNameForEndpoint("http://127.0.0.1:1234"));
+        assertNull(guessRegionNameForEndpoint("localhost"));
+        assertNull(guessRegionNameForEndpoint("localhost:1234"));
+        assertNull(guessRegionNameForEndpoint("127.0.0.1"));
+        assertNull(guessRegionNameForEndpoint("127.0.0.1:1234"));
+    }
+
     /**
      * We migrated from AwsHostNameUtils.parseRegion to EndpointToRegion.guessRegionNameForHostname, because EndpointToRegion
      * can consider the contents of endpoints.json.


### PR DESCRIPTION
Fixes #2255. Without the fix, the last line of the new test case fails with an error.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
