### PR TITLE
When multipart uploads fail, cancel remaining part transfers

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/CompleteMultipartUpload.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/CompleteMultipartUpload.java
@@ -115,7 +115,7 @@ public class CompleteMultipartUpload implements Callable<UploadResult> {
      */
     private List<PartETag> collectPartETags() {
 
-        final List<PartETag> partETags = new ArrayList<PartETag>(eTagsBeforeResume.size());
+        final List<PartETag> partETags = new ArrayList<PartETag>(eTagsBeforeResume.size() +  futures.size());
         partETags.addAll(eTagsBeforeResume);
 
         int index = 0;


### PR DESCRIPTION
Suppose we have 10 parts, if we fail on part #2 we fire a "TRANSFER_FAILED_EVENT" back to the client. We should assume that clients will react to this failure, possibly with custom logic to retry. Supposing that part #3 succeeds, the client will then get other transfer events past the "TRANSFER_FAILED_EVENT". I assume here that "TRANSFER_FAILED_EVENT" is a terminal event and that a client should not expect to receive further events for that transfer, successful or not. However, the meaning of TRANSFER_FAILED_EVENT is not clearly defined in the javadocs.

relates to: https://github.com/aws/aws-sdk-java/issues/2267

