### PR TITLE
Add getInstaceAction with force param to avoid cached fetchData in EC2MetadataUtils

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
@@ -125,7 +125,16 @@ public class EC2MetadataUtils {
      * Valid values: none | shutdown | bundle-pending.
      */
     public static String getInstanceAction() {
-        return fetchData(EC2_METADATA_ROOT + "/instance-action");
+        return getInstanceAction(false);
+    }
+
+    /**
+     * Notifies the instance that it should reboot in preparation for bundling.
+     * @param force - indication to return cached value or fetch again.
+     * @return Valid values: none | shutdown | bundle-pending.
+     */
+    public static String getInstanceAction(boolean force) {
+        return fetchData(EC2_METADATA_ROOT + "/instance-action", force);
     }
 
     /**


### PR DESCRIPTION
*Issue #, if available:*

fixes : #2243 

*Description of changes:*

Add getInstaceAction with force param to avoid cached fetchData in EC2MetadataUtils.
```
public static String getInstanceAction(boolean force)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
