### PR TITLE
use PropertyNamingStrategy's static field instead of new its subclass

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/monitoring/internal/AsynchronousAgentDispatcher.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/monitoring/internal/AsynchronousAgentDispatcher.java
@@ -57,7 +57,7 @@ public class AsynchronousAgentDispatcher {
     private AsynchronousAgentDispatcher() {
         this.writer = new ObjectMapper()
                 .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-                .setPropertyNamingStrategy(new PropertyNamingStrategy.PascalCaseStrategy())
+                .setPropertyNamingStrategy(PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE)
                 .writer();
     }
 

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/transform/JsonErrorUnmarshaller.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/transform/JsonErrorUnmarshaller.java
@@ -20,7 +20,7 @@ import com.amazonaws.annotation.ThreadSafe;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy.PascalCaseStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 
 /**
  * Unmarshaller for JSON error responses from AWS services.
@@ -34,7 +34,7 @@ public class JsonErrorUnmarshaller extends AbstractErrorUnmarshaller<JsonNode> {
 
     private static final ObjectMapper MAPPER = new ObjectMapper().configure(
             DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false).setPropertyNamingStrategy(
-            new PascalCaseStrategy());
+            PropertyNamingStrategy.PASCAL_CASE_TO_CAMEL_CASE);
 
     private final String handledErrorCode;
 


### PR DESCRIPTION
bypass the potential deadlock when PropertyNamingStrategy class initialization

see: https://github.com/FasterXML/jackson-databind/issues/2715
