### PR TITLE
Update maven-plugin-plugin version to 3.6.0.

### DIFF
--- a/aws-java-sdk-codegen-maven-plugin/pom.xml
+++ b/aws-java-sdk-codegen-maven-plugin/pom.xml
@@ -54,7 +54,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-plugin-plugin</artifactId>
-        <version>3.4</version>
+        <version>3.6.0</version>
         <executions>
           <execution>
             <id>default-descriptor</id>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

We want to build aws-sdk-java with jackson version update (2.10.0). However, building aws-java-sdk with the jackson update fails with following error. Updating maven-plugin-plugin version can avoid the build error.

```
$ mvn package
..
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-plugin-plugin:3.4:descriptor (default-descriptor) on project aws-java-sdk-codegen-maven-plugin: Execution default-descriptor of goal org.apache.maven.plugins:maven-plugin-plugin:3.4:descriptor failed.: IllegalArgumentException -> [Help 1]
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
