### PR TITLE
Update annotation for DynamoDBVersionAttribute

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBVersionAttribute.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBVersionAttribute.java
@@ -32,16 +32,11 @@ import java.lang.annotation.Target;
  * <p>Only nullable, integral numeric types (e.g. Integer, Long) can be used as
  * version properties. On a save() operation, the {@link DynamoDBMapper} will
  * attempt to increment the version property and assert that the service's value
- * matches the client's. New objects will be assigned a version of 1 when saved.
- * <p>
- * Note that for batchWrite, and by extension batchSave and batchDelete, <b>no
+ * matches the client's. New objects will be assigned a version of 1 when saved.</p>
+ * <p>Note that for batchWrite, and by extension batchSave and batchDelete, <b>no
  * version checks are performed</b>, as required by the
  * {@link com.amazonaws.services.dynamodbv2.AmazonDynamoDB#batchWriteItem(BatchWriteItemRequest)}
- * API.
- *
- * <p>Note that for transactionWrite, <b>no version checks are performed</b>.
- * An {@link com.amazonaws.SdkClientException} exception is thrown, if class of
- * any input object is annotated with {@link DynamoDBVersionAttribute}.</p>
+ * API.</p>
  *
  * @see com.amazonaws.services.dynamodbv2.datamodeling.DynamoDBVersioned
  */


### PR DESCRIPTION
To resolve ticket D16400550, removing outdated note.

*Description of changes:*
Per [this blog post](https://aws.amazon.com/about-aws/whats-new/2019/10/dynamodbmapper-now-supports-optimistic-locking-for-amazon-dynamodb-transactional-api-calls/), the "no version checks" comment about transactionWrite for [the DynamoDBVersioned page in the API docs](https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBVersioned.html) is incorrect.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
