### PR TITLE
 Update ObjectMetadata getContentLength javadoc to correctly describe the default value

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/ObjectMetadata.java
@@ -288,8 +288,8 @@ public class ObjectMetadata implements ServerSideEncryptionResult, S3RequesterCh
      * </p>
      *
      * @return The Content-Length HTTP header indicating the size of the
-     *         associated object in bytes. Returns <code>null</code>
-     *         if it hasn't been set yet.
+     *         associated object in bytes. Returns <code>0</code> if it
+     *         hasn't been set yet.
      *
      * @see ObjectMetadata#setContentLength(long)
      */


### PR DESCRIPTION
*Issue #, if available:*
none

*Description of changes:*
Fixes the javadoc of `ObjectMetadata#getContentLength()` to say that it returns `0` instead of `null` "if [the Content-Length header] hasn't been yet" to match the implementation of the method, which does
```java
if (contentLength == null) return 0;
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.