### PR TITLE
support weak etags in getObject checks

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -1544,7 +1544,12 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
         // stream in a validator that calculates an MD5 of the downloaded
         // bytes and complains if what we received doesn't match the Etag.
         if (!skipClientSideValidation) {
-            byte[] serverSideHash = BinaryUtils.fromHex(s3Object.getObjectMetadata().getETag());
+            String etag = s3Object.getObjectMetadata().getETag();
+            if (etag.startsWith("W/")) {
+                // weak etags are of the form `W/"etag"` so we trim accordingly
+                etag = etag.substring(3, etag.length() - 1);
+            }
+            byte[] serverSideHash = BinaryUtils.fromHex(etag);
             try {
                 // No content length check is performed when the
                 // MD5 check is enabled, since a correct MD5 check would


### PR DESCRIPTION
According to ETag spec (https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag) ETags can be of weak form, which is the case for us when we use Ceph as a storage. In general, I don't think this is backwards-incompatible as no existing functionality is harmed. 
With this change support for etags marked as weak is added.
Not sure what's the QA process is supposed to be but I guess a brief glance at the code should suffice.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
