### PR TITLE
Add DeliveryDelay to SES EventType enum

### DIFF
--- a/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/model/EventType.java
+++ b/aws-java-sdk-ses/src/main/java/com/amazonaws/services/simpleemail/model/EventType.java
@@ -27,7 +27,8 @@ public enum EventType {
     Delivery("delivery"),
     Open("open"),
     Click("click"),
-    RenderingFailure("renderingFailure");
+    RenderingFailure("renderingFailure"),
+    DeliveryDelay("deliveryDelay");
 
     private String value;
 


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/aws/aws-sdk-java/issues/2384

*Description of changes:*

Manually adds the `DeliveryDelay` event type to the relevant `enum` class. This may not be the right thing to do - I am aware that this class appears to have been automatically generated somehow (`@Generated("com.amazonaws:aws-java-sdk-code-generator")`). However, as there is no `README` in the code generator stuff I've got no idea how I'd go about rerunning/changing that so I thought I'd see what the feedback was :shrug: 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
