### PR TITLE
Make KeyManagerFactory agnostic of JRE provider

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/AbstractFileTlsKeyManagersProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/AbstractFileTlsKeyManagersProvider.java
@@ -40,7 +40,7 @@ abstract class AbstractFileTlsKeyManagersProvider implements TlsKeyManagersProvi
 
     protected final KeyManager[] createKeyManagers(File storePath, String storeType, char[] password) throws CertificateException, NoSuchAlgorithmException, KeyStoreException, IOException, UnrecoverableKeyException {
         KeyStore ks = createKeyStore(storePath, storeType, password);
-        KeyManagerFactory kmf = KeyManagerFactory.getInstance("SunX509");
+        KeyManagerFactory kmf = KeyManagerFactory.getInstance(KeyManagerFactory.getDefaultAlgorithm());
         kmf.init(ks, password);
         return kmf.getKeyManagers();
     }


### PR DESCRIPTION
* Fixes #2390
* This simply pulls the default algorithm rather than asking for the hard-coded "SunX509"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.