### PR TITLE
Change changelog of version 1.11.618 to add the docs of STS regional endpoints setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4950,6 +4950,10 @@
   - ### Features
     - Amazon Transcribe - support transcriptions from audio sources in Russian (ru-RU) and Chinese (zh-CN).
 
+## __AWS SDK for Java__
+  - ### Features
+    - AWS Java SDK now supports setting STS regional endpoints option in config file. See https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-sts_regional_endpoints.html for more details.
+
 # __1.11.617__ __2019-08-22__
 ## __AWS DataSync__
   - ### Features


### PR DESCRIPTION
*Description of changes:*
We've enabled the setting of STS regional endpoints option, but this change wasn't added in the changelog. To prevent any misunderstanding about this behavior, and let the customers track this change easilier, here we add a new item in the change log about this change.




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
