### PR TITLE
Better customization of DefaultBatchLoadRetryStrategy

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperConfig.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapperConfig.java
@@ -806,6 +806,23 @@ public class DynamoDBMapperConfig {
         private static final int MAX_RETRIES = 5;
         private static final long MAX_BACKOFF_IN_MILLISECONDS = 1000 * 3;
 
+        private final int maxRetry;
+
+        /**
+         * Retry load a default number of times
+         */
+        public DefaultBatchLoadRetryStrategy() {
+            this(MAX_RETRIES);
+        }
+
+        /**
+         * Retry load a certain number of times
+         * @param maxRetry How many times to retry the load
+         */
+        public DefaultBatchLoadRetryStrategy(int maxRetry) {
+            this.maxRetry = maxRetry;
+        }
+
         @Override
         public long getDelayBeforeNextRetry(final BatchLoadContext batchLoadContext) {
             Map<String, KeysAndAttributes> requestedKeys = batchLoadContext.getBatchGetItemRequest().getRequestItems();
@@ -827,7 +844,7 @@ public class DynamoDBMapperConfig {
         @Override
         public boolean shouldRetry(BatchLoadContext batchLoadContext) {
             Map<String, KeysAndAttributes> unprocessedKeys = batchLoadContext.getBatchGetItemResult().getUnprocessedKeys();
-            return (unprocessedKeys != null && unprocessedKeys.size() > 0 && batchLoadContext.getRetriesAttempted() < MAX_RETRIES);
+            return (unprocessedKeys != null && unprocessedKeys.size() > 0 && batchLoadContext.getRetriesAttempted() < maxRetry);
         }
 
         public final DynamoDBMapperConfig config() {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The `DefaultBatchLoadRetryStrategy` did not support customization for the number of retries to attempt. I found this odd as the `DefaultBatchWriteRetryStrategy` did allow this feature, so I ported a fix over. While a small change, I find this to be a net positive as these operations are very similar and having different ctor args felt off to me.

I'm a SDE within Prime Video and this use case came up for us when we wanted to specify our own Builder config. I find it interesting how we're the first group to want a change to the default max retry count.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
