### PR TITLE
Update STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java

### DIFF
--- a/aws-java-sdk-sts/pom.xml
+++ b/aws-java-sdk-sts/pom.xml
@@ -33,6 +33,12 @@
         <groupId>com.amazonaws</groupId>
         <optional>false</optional>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>${junit.version}</version>
+      <scope>test</scope>
+    </dependency>
 </dependencies>
 
   <build>

--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
@@ -227,7 +227,7 @@ public class STSAssumeRoleWithWebIdentitySessionCredentialsProvider implements A
         }
     }
 
-    private static class StsRetryCondition implements com.amazonaws.retry.RetryPolicy.RetryCondition {
+    static class StsRetryCondition implements com.amazonaws.retry.RetryPolicy.RetryCondition {
 
         @Override
         public boolean shouldRetry(AmazonWebServiceRequest originalRequest,

--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
@@ -234,11 +234,11 @@ public class STSAssumeRoleWithWebIdentitySessionCredentialsProvider implements A
                                    AmazonClientException exception,
                                    int retriesAttempted) {
             // Always retry on client exceptions caused by IOException
-            if (exception.getCause() instanceof IOException) return true;
+            if (exception instanceof IOException || exception.getCause() instanceof IOException) return true;
 
-            if (exception.getCause() instanceof InvalidIdentityTokenException) return true;
+            if (exception instanceof InvalidIdentityTokenException || exception.getCause() instanceof InvalidIdentityTokenException) return true;
 
-            if (exception.getCause() instanceof IDPCommunicationErrorException) return true;
+            if (exception instanceof IDPCommunicationErrorException || exception.getCause() instanceof IDPCommunicationErrorException) return true;
 
             // Only retry on a subset of service exceptions
             if (exception instanceof AmazonServiceException) {

--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/STSAssumeRoleWithWebIdentitySessionCredentialsProvider.java
@@ -234,7 +234,7 @@ public class STSAssumeRoleWithWebIdentitySessionCredentialsProvider implements A
                                    AmazonClientException exception,
                                    int retriesAttempted) {
             // Always retry on client exceptions caused by IOException
-            if (exception instanceof IOException || exception.getCause() instanceof IOException) return true;
+            if (exception.getCause() instanceof IOException) return true;
 
             if (exception instanceof InvalidIdentityTokenException || exception.getCause() instanceof InvalidIdentityTokenException) return true;
 

--- a/aws-java-sdk-sts/src/test/java/com.amazonaws.auth/STSAssumeRoleWithWebIdentitySessionCredentialsProviderStsRetryConditionTest.java
+++ b/aws-java-sdk-sts/src/test/java/com.amazonaws.auth/STSAssumeRoleWithWebIdentitySessionCredentialsProviderStsRetryConditionTest.java
@@ -1,0 +1,84 @@
+package com.amazonaws.auth;
+
+import com.amazonaws.AmazonClientException;
+import com.amazonaws.AmazonServiceException;
+import com.amazonaws.services.securitytoken.model.IDPCommunicationErrorException;
+import com.amazonaws.services.securitytoken.model.InvalidIdentityTokenException;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+
+
+public class STSAssumeRoleWithWebIdentitySessionCredentialsProviderStsRetryConditionTest {
+
+    private STSAssumeRoleWithWebIdentitySessionCredentialsProvider.StsRetryCondition condition =
+            new STSAssumeRoleWithWebIdentitySessionCredentialsProvider.StsRetryCondition();
+
+    @Test
+    public void shouldRetry_whenExceptionContainsInvalidIdentityTokenException() {
+        AmazonClientException exception = new AmazonClientException(new InvalidIdentityTokenException("TestMessage"));
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionIsInvalidIdentityTokenException() {
+        AmazonClientException exception = new InvalidIdentityTokenException("TestMessage");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionContainsIOException() {
+        AmazonClientException exception = new AmazonClientException(new IOException("TestMessage"));
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionContainsIDPCommunicationErrorException() {
+        AmazonClientException exception = new AmazonClientException(new IDPCommunicationErrorException("TestMessage"));
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionIsIDPCommunicationErrorException() {
+        AmazonClientException exception = new IDPCommunicationErrorException("TestMessage");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionIsAmazonServiceException_andIsRetryableServiceException() {
+        AmazonServiceException exception = new AmazonServiceException("TestMessage");
+        exception.setErrorCode("RequestTimeout");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionIsAmazonServiceException_andIsThrottlingException() {
+        AmazonServiceException exception = new AmazonServiceException("TestMessage");
+        exception.setErrorCode("Throttling");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldRetry_whenExceptionIsAmazonServiceException_andIsClockSkewError() {
+        AmazonServiceException exception = new AmazonServiceException("TestMessage");
+        exception.setErrorCode("RequestExpired");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertTrue(actual);
+    }
+
+    @Test
+    public void shouldNotRetry_whenExceptionIsSomethingElse() {
+        AmazonClientException exception = new AmazonClientException("TestMessage");
+        boolean actual = condition.shouldRetry(null, exception, 0);
+        Assert.assertFalse(actual);
+    }
+
+}


### PR DESCRIPTION
This is to fix a problem where a InvalidIdentityTokenException does not actually trigger the retries.

When the AmazonHttpClient creates the exception there is no inner cause so comparing the inner cause with the instance type doesn't work.