### PR TITLE
Should be used Boolean.valueOf instead of Boolean.getBoolean

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/StringUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/StringUtils.java
@@ -54,7 +54,7 @@ public class StringUtils {
     }
 
     public static Boolean toBoolean(StringBuilder value) {
-        return Boolean.getBoolean(value.toString());
+        return Boolean.valueOf(value.toString());
     }
 
     public static String fromInteger(Integer value) {


### PR DESCRIPTION
getBoolean  Returns true if and only if the system property named by the argument exists and is equal to the string "true".