### PR TITLE
 Synchronization in AmazonS3Client::fetchRegionFromCache method

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -6171,7 +6171,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
      * doesn't have an entry, fetches the region from Amazon S3 and updates the
      * cache.
      */
-    private String fetchRegionFromCache(String bucketName) {
+    private synchronized String fetchRegionFromCache(String bucketName) {
         String bucketRegion = bucketRegionCache.get(bucketName);
         if (bucketRegion == null) {
             if (log.isDebugEnabled()) {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -6171,7 +6171,7 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
      * doesn't have an entry, fetches the region from Amazon S3 and updates the
      * cache.
      */
-    private synchronized String fetchRegionFromCache(String bucketName) {
+    private String fetchRegionFromCache(String bucketName) {
         String bucketRegion = bucketRegionCache.get(bucketName);
         if (bucketRegion == null) {
             if (log.isDebugEnabled()) {


### PR DESCRIPTION
https://github.com/aws/aws-sdk-java/issues/2488

*Description of changes:*
Synchronized AmazonS3Client::fetchRegionFromCache to avoid sending multiple HEAD requests when parallel threads invoke S3Client.
