### PR TITLE
setting scanFilter if scanExpression.getScanFilter() is not null. Fix…

### DIFF
--- a/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
+++ b/aws-java-sdk-dynamodb/src/main/java/com/amazonaws/services/dynamodbv2/datamodeling/DynamoDBMapper.java
@@ -1688,7 +1688,9 @@ public class DynamoDBMapper extends AbstractDynamoDBMapper {
 
         scanRequest.setTableName(getTableName(clazz, config));
         scanRequest.setIndexName(scanExpression.getIndexName());
-        scanRequest.setScanFilter(scanExpression.getScanFilter());
+        if (scanExpression.getScanFilter() != null) {
+            scanRequest.setScanFilter(scanExpression.getScanFilter());
+        }
         scanRequest.setLimit(scanExpression.getLimit());
         scanRequest.setExclusiveStartKey(scanExpression.getExclusiveStartKey());
         scanRequest.setTotalSegments(scanExpression.getTotalSegments());


### PR DESCRIPTION
setting scanFilter if scanExpression.getScanFilter() is not null. Fix for the NPE experienced in few cases
*Issue [DynamoDBMapper Scan NPE](https://github.com/aws/aws-sdk-java/issues/2460) *

*Description of changes: Checking scanExpression.getScanFilter() for null *