### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: java
+cache:
+  directories:
+  - $HOME/.m2
 addons:
   hosts:
     - javasdk


### PR DESCRIPTION
*Would be interested to know why maven dependencies haven't been cached on Travis. Thank you.*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
