### PR TITLE
Fix Authorization header for VPC endpoints

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/AwsHostNameUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/AwsHostNameUtils.java
@@ -214,8 +214,15 @@ public class AwsHostNameUtils {
             return "us-east-1";
         }
 
-        // host was 'service.[region].amazonaws.com'.
+        // host was 'service.[region].amazonaws.com' or
+        // 'domain.service.[region].vpce.amazonaws.com'.
         String region = fragment.substring(index + 1);
+
+        if ("vpce".equals(region)) {
+            // host was 'domain.service.[region].vpce.amazonaws.com'
+            region = fragment.substring(0, fragment.lastIndexOf(".vpce"));
+            region = region.substring(region.lastIndexOf('.') + 1);
+        }
 
         // Special case for iam.us-gov.amazonaws.com, which is actually
         // us-gov-west-1.

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWS4SignerTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/AWS4SignerTest.java
@@ -84,6 +84,9 @@ public class AWS4SignerTest {
         final String EXPECTED_AUTHORIZATION_HEADER_WITHOUT_SHA256_HEADER =
             "AWS4-HMAC-SHA256 Credential=access/19810216/us-east-1/demo/aws4_request, SignedHeaders=host;x-amz-archive-description;x-amz-date, Signature=77fe7c02927966018667f21d1dc3dfad9057e58401cbb9ed64f1b7868288e35a";
 
+        final String EXPECTED_VPC_ENDPOINT_AUTHORIZATION_HEADER_WITHOUT_SHA256_HEADER =
+            "AWS4-HMAC-SHA256 Credential=access/19810216/us-east-1/demo/aws4_request, SignedHeaders=host;x-amz-archive-description;x-amz-date, Signature=fe378122184db21f27a4da371497e497730166c7b54a687b5839ca77c25ca357";
+
         final String EXPECTED_AUTHORIZATION_HEADER_WITH_SHA256_HEADER =
             "AWS4-HMAC-SHA256 Credential=access/19810216/us-east-1/demo/aws4_request, SignedHeaders=host;x-amz-archive-description;x-amz-date;x-amz-sha256, Signature=e73e20539446307a5dc71252dbd5b97e861f1d1267456abda3ebd8d57e519951";
 
@@ -91,6 +94,7 @@ public class AWS4SignerTest {
         AWSCredentials credentials = new BasicAWSCredentials("access", "secret");
         // Test request without 'x-amz-sha256' header
         SignableRequest<?> request = generateBasicRequest();
+        SignableRequest<?> vpcEndpointRequest = generateBasicVPCEndpointRequest();
 
         Calendar c = new GregorianCalendar();
         c.set(1981, 1, 16, 6, 30, 0);
@@ -102,6 +106,10 @@ public class AWS4SignerTest {
         signer.sign(request, credentials);
         assertEquals(EXPECTED_AUTHORIZATION_HEADER_WITHOUT_SHA256_HEADER,
                 request.getHeaders().get("Authorization"));
+
+        signer.sign(vpcEndpointRequest, credentials);
+        assertEquals(EXPECTED_VPC_ENDPOINT_AUTHORIZATION_HEADER_WITHOUT_SHA256_HEADER,
+                vpcEndpointRequest.getHeaders().get("Authorization"));
 
 
         // Test request with 'x-amz-sha256' header
@@ -270,6 +278,15 @@ public class AWS4SignerTest {
                 .withHeader("x-amz-archive-description", "test  test")
                 .withPath("/")
                 .withEndpoint("http://demo.us-east-1.amazonaws.com").build();
+    }
+
+    private SignableRequest<?> generateBasicVPCEndpointRequest() {
+        return MockRequestBuilder.create()
+                .withContent(new ByteArrayInputStream("{\"TableName\": \"foo\"}".getBytes()))
+                .withHeader("Host", "demo.us-east-1.vpce.amazonaws.com")
+                .withHeader("x-amz-archive-description", "test  test")
+                .withPath("/")
+                .withEndpoint("http://demo.us-east-1.vpce.amazonaws.com").build();
     }
 
     private SignableRequest<?> generateBasicRequestToBjs() {

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/util/AwsHostNameUtilsTest.java
@@ -124,6 +124,9 @@ public class AwsHostNameUtilsTest {
 
         assertEquals("us-west-2", AwsHostNameUtils.parseRegion("cloudsearch.us-west-2.amazonaws.com", null));
         assertEquals("us-west-2", AwsHostNameUtils.parseRegion("domain.us-west-2.cloudsearch.amazonaws.com", null));
+
+        assertEquals("us-west-2", AwsHostNameUtils.parseRegion("domain.s3.us-west-2.vpce.amazonaws.com", null));
+        assertEquals("us-west-2", AwsHostNameUtils.parseRegion("domain.us-west-2.vpce.amazonaws.com", null));
     }
 
     @Test
@@ -143,6 +146,8 @@ public class AwsHostNameUtilsTest {
 
         assertEquals("us-west-2", AwsHostNameUtils.parseRegion("cloudsearch.us-west-2.amazonaws.com", "cloudsearch"));
         assertEquals("us-west-2", AwsHostNameUtils.parseRegion("domain.us-west-2.cloudsearch.amazonaws.com", "cloudsearch"));
+
+        assertEquals("us-west-2", AwsHostNameUtils.parseRegion("domain.s3.us-west-2.vpce.amazonaws.com", "s3"));
     }
 
     @Test


### PR DESCRIPTION
I believe that requests from this SDK to S3 via VPC endpoints are currently receiving 400 (Bad Request) responses. When I inspect the request headers being sent in by the SDK, I noticed a difference in the `Authorization` header:

```
Authorization: AWS4-HMAC-SHA256 Credential=ACCESS_KEY_ID/20210325/vpce/s3/aws4_request      # VPC endpoint
Authorization: AWS4-HMAC-SHA256 Credential=ACCESS_KEY_ID/20210325/us-east-2/s3/aws4_request # normal
```

The `Credential` value was being assembled using what the SDK misunderstood as the region in VPC endpoints, which have the structure `vpce-xxxxxxxxxxxxxxxxx-xxxxxxxx.s3.[region].vpce.amazonaws.com` in the case of S3.

Upon further inspection of the code, it seems the issue originates from the `AwsHostNameUtils.java` class, as you see in the diff of this pull request. I am however new to this codebase so if I am incorrectly addressing this issue, let me know. For what it is worth, I did confirm that my test in `AWS4SignerTest.java` fails in the absence of my change in `AwsHostNameUtils.java`.