### PR TITLE
Update ReceiveMessageBatchTask messages to be stored and removed in fifo order

### DIFF
--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/ReceiveQueueBuffer.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/ReceiveQueueBuffer.java
@@ -518,7 +518,7 @@ public class ReceiveQueueBuffer {
      */
     private class ReceiveMessageBatchTask implements Runnable {
         private Exception exception = null;
-        private List<Message> messages;
+        private LinkedList<Message> messages;
         private long visibilityDeadlineNano;
         private boolean open = false;
         private ReceiveQueueBuffer parentBuffer;
@@ -528,7 +528,7 @@ public class ReceiveQueueBuffer {
          */
         ReceiveMessageBatchTask(ReceiveQueueBuffer paramParentBuffer) {
             parentBuffer = paramParentBuffer;
-            messages = Collections.emptyList();
+            messages = new LinkedList<>();
         }
 
         synchronized boolean isEmpty() {
@@ -571,7 +571,7 @@ public class ReceiveQueueBuffer {
             if (messages.isEmpty())
                 return null;
             else
-                return messages.remove(messages.size() - 1);
+                return messages.poll();
         }
 
         boolean isExpired() {
@@ -637,7 +637,7 @@ public class ReceiveQueueBuffer {
                     request.withWaitTimeSeconds(config.getLongPollWaitTimeoutSeconds());
                 }
 
-                messages = sqsClient.receiveMessage(request).getMessages();
+                messages.addAll(sqsClient.receiveMessage(request).getMessages());
             } catch (AmazonClientException e) {
                 exception = e;
             } finally {


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
Messages retrieved by spawned Receive task are removed in reverse order. Updated to have them polled in order as they were received. This was not intended to make the Amazon SQS Buffered Asynchronous Client fully support FIFO queues, but it's a step in that direction.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
