### PR TITLE
S3 uploading: keep original cancellation exception

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadMonitor.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/transfer/internal/UploadMonitor.java
@@ -134,7 +134,7 @@ public class UploadMonitor implements Callable<Void>, TransferMonitor {
         } catch (CancellationException e) {
             transfer.setState(TransferState.Canceled);
             publishProgress(listener, ProgressEventType.TRANSFER_CANCELED_EVENT);
-            SdkClientException exception = new SdkClientException("Upload canceled");
+            SdkClientException exception = new SdkClientException("Upload canceled", e);
             resultFuture.setDelegate(new FailedFuture<UploadResult>(exception));
         } catch (Throwable e) {
             transfer.setState(TransferState.Failed);


### PR DESCRIPTION
*Description of changes:*

Original cancellation exception is ignored and not logged so it is not clear what was the reason for the `Upload canceled` exception.
In order to mitigate that it is possible to keep the original `CancellationException` as reason for the `SdkClientException`.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.