### PR TITLE
resovles #1648 set content type multipart upload

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/InitiateMultipartUploadRequest.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/InitiateMultipartUploadRequest.java
@@ -16,7 +16,9 @@ package com.amazonaws.services.s3.model;
 
 import com.amazonaws.AmazonWebServiceRequest;
 import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.internal.Mimetypes;
 
+import java.io.File;
 import java.io.Serializable;
 import java.util.Date;
 
@@ -534,6 +536,39 @@ public class InitiateMultipartUploadRequest extends AmazonWebServiceRequest
      */
     public InitiateMultipartUploadRequest withObjectMetadata(ObjectMetadata objectMetadata) {
         setObjectMetadata(objectMetadata);
+        return this;
+    }
+
+    /**
+     * Sets the additional information of content type about the new object being created.
+     * Sets content type in the object metadata. Creates object metadata if does not exist.
+     *
+     * @param file
+     *            File that would be uploaded. Uses file extension to determine
+     *            mimetype.
+     */
+    public void setObjectMetadataContentTypeFromFile(File file) {
+        if (this.objectMetadata == null) {
+            this.objectMetadata = new ObjectMetadata();
+        }
+        this.objectMetadata.setContentType(Mimetypes.getInstance().getMimetype(file));
+    }
+
+    /**
+     * Sets the additional information of content type about the new object being created.
+     * Sets content type in the object metadata. Creates object metadata if does not exist.
+     * <p>
+     * Returns this updated InitiateMultipartUploadRequest object so that
+     * additional method calls can be chained together.
+     *
+     * @param file
+     *            File that would be uploaded. Uses file extension to determine
+     *            mimetype.
+     *
+     * @return This updated InitiateMultipartUploadRequest object.
+     */
+    public InitiateMultipartUploadRequest withObjectMetadataContentTypeFromFile(File file) {
+        setObjectMetadataContentTypeFromFile(file);
         return this;
     }
 

--- a/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/model/InitiateMultipartUploadRequestTest.java
+++ b/aws-java-sdk-s3/src/test/java/com/amazonaws/services/s3/model/InitiateMultipartUploadRequestTest.java
@@ -1,0 +1,35 @@
+package com.amazonaws.services.s3.model;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+import java.io.File;
+
+/**
+ * Test Model InitiateMultipartUploadRequest
+ */
+public class InitiateMultipartUploadRequestTest {
+
+    /**
+     * Test setting the content type of the metadata for the multipart upload request
+     */
+    @Test
+    public void testWithObjectMetadataContentTypeFromFile(){
+        InitiateMultipartUploadRequest request = new InitiateMultipartUploadRequest("bucketName", "key", new ObjectMetadata());
+        File file = new File("textFile.txt");
+        request = request.withObjectMetadataContentTypeFromFile(file);
+        assertEquals("text/plain", request.getObjectMetadata().getContentType());
+    }
+
+    /**
+     * Test setting the content type of the metadata for the multipart upload request
+     * Creates the metadata object if it does not exist
+     */
+    @Test
+    public void testWithObjectMetadataContentTypeFromFileCreatesMetadata(){
+        InitiateMultipartUploadRequest request = new InitiateMultipartUploadRequest("bucketName", "key");
+        File file = new File("textFile.txt");
+        request = request.withObjectMetadataContentTypeFromFile(file);
+        assertEquals("text/plain", request.getObjectMetadata().getContentType());
+    }
+}


### PR DESCRIPTION
Resolves #1648 

The issue is a feature request calling for automatically setting the content-type header of a multipart upload.  Similar to how the putObject method in the S3Client does it, by using the file extension.  Multipart uploads happen in 3 parts, initiate, send parts, and close.   The initiate does not take a file.  Initiate allows setting the content type in the object metadata.   I expect that initiateMultipartUpload will continue to determine content type from object metadata.   This seems like a fine way to do it, but I see there is still an open issue here, and is flagged for community help-wanted.   I added helper methods to set the content type given a file that will upload.  I kept the method name long and descriptive to show this is setting the content type in the object metadata, while there is still the existing setters to set the metadata.  Use of existing methods is not disrupted or changed in any way.

Also, I see there are no unit tests in the src code, but I also read in gitter that unit tests are welcome in pull requests.  I can remove those if needed.  

In the issue #1648, the question was because spring-cloud-aws was not allowing the user to set the content type.  This has since been fixed.  https://github.com/spring-cloud/spring-cloud-aws/issues/262.
