### PR TITLE
fix: specify how to configure Default location

### DIFF
--- a/aws-java-sdk-route53/src/main/java/com/amazonaws/services/route53/model/GeoLocation.java
+++ b/aws-java-sdk-route53/src/main/java/com/amazonaws/services/route53/model/GeoLocation.java
@@ -406,7 +406,7 @@ public class GeoLocation implements Serializable, Cloneable {
      * </p>
      * <p>
      * Amazon Route 53 uses the two-letter country codes that are specified in <a
-     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO standard 3166-1 alpha-2</a>.
+     * href="https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2">ISO standard 3166-1 alpha-2</a>. Also "*" is accepted to configure the Default location.
      * </p>
      * 
      * @param countryCode


### PR DESCRIPTION
There is no place specifying how to configure a geolocation record with Default location. I have checked other SDKs and it is not mentioned anywhere.