### PR TITLE
Adding logging to multifile output stream and observer

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/UploadObjectObserver.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/UploadObjectObserver.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 import com.amazonaws.AmazonWebServiceRequest;
@@ -52,6 +53,9 @@ import com.amazonaws.services.s3.model.UploadPartResult;
  * @see UploadObjectRequest
  */
 public class UploadObjectObserver {
+
+    private final Log log = LogFactory.getLog(getClass());
+
     private final List<Future<UploadPartResult>> futures = new ArrayList<Future<UploadPartResult>>();
     private UploadObjectRequest req;
     private String uploadId;
@@ -148,7 +152,10 @@ public class UploadObjectObserver {
                 // Upload the ciphertext directly via the non-encrypting
                 // s3 client
                 try {
-                    return uploadPart(reqUploadPart);
+                    log.info(String.format("Call S3 PUT, partNumber %s", reqUploadPart.getPartNumber()));
+                    UploadPartResult uploadPartResult = uploadPart(reqUploadPart);
+                    log.info(String.format("Finished uploading part %s", reqUploadPart.getPartNumber()));
+                    return uploadPartResult;
                 } finally {
                     // clean up part already uploaded
                     if (!part.delete()) {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MultiFileOutputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MultiFileOutputStream.java
@@ -21,6 +21,8 @@ import java.io.OutputStream;
 import java.util.UUID;
 import java.util.concurrent.Semaphore;
 
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.joda.time.DateTime;
 import org.joda.time.format.DateTimeFormat;
@@ -34,6 +36,10 @@ import com.amazonaws.services.s3.UploadObjectObserver;
  * parallel uploads.
  */
 public class MultiFileOutputStream extends OutputStream implements OnFileDelete {
+
+    private final Log log = LogFactory.getLog(getClass());
+    private long partStart;
+
     static final int DEFAULT_PART_SIZE = 5 << 20; // 5MB
     private final File root;
     private final String namePrefix;
@@ -167,6 +173,8 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
         if (os == null || currFileBytesWritten >= partSize) {
             if (os != null) {
                 os.close();
+                log.info(String.format("Finished encrypting and writing part %s in %s ms", filesCreated,
+                                       partDuration(System.nanoTime())));
                 // notify about the new file ready for processing
                 observer.onPartCreate(new PartCreationEvent(
                         getFile(filesCreated), filesCreated, false, this));
@@ -174,6 +182,8 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
             currFileBytesWritten = 0;
             filesCreated++;
             blockIfNecessary();
+            partStart = System.nanoTime();
+            log.info(String.format("Start writing and encrypting part %s", filesCreated));
             final File file = getFile(filesCreated);
             os = new FileOutputStream(file);
         }
@@ -225,11 +235,17 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
                             "Ignoring failure to delete empty file " + lastPart);
                 }
             } else {
+                log.info(String.format("Finished encrypting and writing part %s in %s ms", filesCreated,
+                                       partDuration(System.nanoTime())));
                 // notify about the new file ready for processing
                 observer.onPartCreate(new PartCreationEvent(
                         getFile(filesCreated), filesCreated, true, this));
             }
         }
+    }
+
+    private long partDuration(long endPartWriteTime) {
+        return TimeUnit.NANOSECONDS.toMillis(endPartWriteTime - partStart);
     }
 
     public void cleanup() {

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MultiFileOutputStream.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/MultiFileOutputStream.java
@@ -174,7 +174,7 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
             if (os != null) {
                 os.close();
                 log.info(String.format("Finished encrypting and writing part %s in %s ms", filesCreated,
-                                       partDuration(System.nanoTime())));
+                                       duration(partStart, System.nanoTime())));
                 // notify about the new file ready for processing
                 observer.onPartCreate(new PartCreationEvent(
                         getFile(filesCreated), filesCreated, false, this));
@@ -207,7 +207,9 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
         if (diskPermits == null || diskLimit == Long.MAX_VALUE)
             return;
         try {
+            long start = System.nanoTime();
             diskPermits.acquire();
+            log.info(String.format("Acquired disk permit in %s ms", duration(start, System.nanoTime())));
         } catch (InterruptedException e) {
             // don't want to re-interrupt so it won't cause SDK stream to be
             // closed in case the thread is reused for a different request
@@ -236,7 +238,7 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
                 }
             } else {
                 log.info(String.format("Finished encrypting and writing part %s in %s ms", filesCreated,
-                                       partDuration(System.nanoTime())));
+                                       duration(partStart, System.nanoTime())));
                 // notify about the new file ready for processing
                 observer.onPartCreate(new PartCreationEvent(
                         getFile(filesCreated), filesCreated, true, this));
@@ -244,8 +246,8 @@ public class MultiFileOutputStream extends OutputStream implements OnFileDelete 
         }
     }
 
-    private long partDuration(long endPartWriteTime) {
-        return TimeUnit.NANOSECONDS.toMillis(endPartWriteTime - partStart);
+    private static long duration(long start, long end) {
+        return TimeUnit.NANOSECONDS.toMillis(end - start);
     }
 
     public void cleanup() {


### PR DESCRIPTION
Logs encryption and uploads to S3 for each part in a multifile upload at INFO level

Example output:
~~~
2022-06-14 21:17:17,045 [main] INFO  com.amazonaws.services.s3.internal.MultiFileOutputStream - Start writing and encrypting part 12
2022-06-14 21:17:17,045 [pool-1-thread-11] INFO  com.amazonaws.services.s3.UploadObjectObserver - Call S3 PUT, partNumber 11
2022-06-14 21:17:17,119 [main] INFO  com.amazonaws.services.s3.internal.MultiFileOutputStream - Finished encrypting and writing part 12 in 74 ms
2022-06-14 21:17:17,119 [main] INFO  com.amazonaws.services.s3.internal.MultiFileOutputStream - Start writing and encrypting part 13
2022-06-14 21:17:17,119 [pool-1-thread-12] INFO  com.amazonaws.services.s3.UploadObjectObserver - Call S3 PUT, partNumber 12
2022-06-14 21:17:17,175 [main] INFO  com.amazonaws.services.s3.internal.MultiFileOutputStream - Finished encrypting and writing part 13 in 56 ms
2022-06-14 21:17:17,176 [pool-1-thread-13] INFO  com.amazonaws.services.s3.UploadObjectObserver - Call S3 PUT, partNumber 13
2022-06-14 21:21:25,322 [pool-1-thread-7] INFO  com.amazonaws.services.s3.UploadObjectObserver - Finished uploading part 7
2022-06-14 21:21:37,054 [pool-1-thread-12] INFO  com.amazonaws.services.s3.UploadObjectObserver - Finished uploading part 12
2022-06-14 21:21:55,135 [pool-1-thread-6] INFO  com.amazonaws.services.s3.UploadObjectObserver - Finished uploading part 6
2022-06-14 21:22:01,598 [pool-1-thread-10] INFO  com.amazonaws.services.s3.UploadObjectObserver - Finished uploading part 10
2022-06-14 21:22:02,513 [pool-1-thread-2] INFO  com.amazonaws.services.s3.UploadObjectObserver - Finished uploading part 2