### PR TITLE
Enable AWS SQS JSON Preview

### DIFF
--- a/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/IntermediateModelBuilder.java
+++ b/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/IntermediateModelBuilder.java
@@ -23,6 +23,7 @@ import com.amazonaws.codegen.internal.Utils;
 import com.amazonaws.codegen.model.config.BasicCodeGenConfig;
 import com.amazonaws.codegen.model.config.customization.CustomizationConfig;
 import com.amazonaws.codegen.model.intermediate.AuthorizerModel;
+import com.amazonaws.codegen.model.intermediate.AwsQueryCompatibleModel;
 import com.amazonaws.codegen.model.intermediate.IntermediateModel;
 import com.amazonaws.codegen.model.intermediate.MemberModel;
 import com.amazonaws.codegen.model.intermediate.OperationModel;
@@ -45,6 +46,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static com.amazonaws.codegen.AddMetadata.constructMetadata;
 import static com.amazonaws.codegen.RemoveUnusedShapes.removeUnusedShapes;
@@ -140,9 +142,22 @@ public class IntermediateModelBuilder {
 
         System.out.println(shapes.size() + " shapes found in total.");
 
+        Map<String, AwsQueryCompatibleModel> awsQueryCompatibleMap;
+        if (service.getAwsQueryCompatible() == null) {
+            awsQueryCompatibleMap = Collections.emptyMap();
+        } else {
+            awsQueryCompatibleMap = service.getAwsQueryCompatible().entrySet().stream()
+                    .collect(Collectors.toMap(
+                                    kv -> kv.getKey(),
+                                    kv -> new AwsQueryCompatibleModel(kv.getValue().getName(), kv.getValue().getCode()))
+                    );
+        }
+
+        System.out.println(awsQueryCompatibleMap.size() + " AwsQuery mappings were found in total.");
+
         IntermediateModel fullModel = new IntermediateModel(
                 constructMetadata(service, codeGenConfig, customConfig), operations, shapes,
-                customConfig, examples, endpointOperation, waiters, authorizers);
+                customConfig, examples, awsQueryCompatibleMap, endpointOperation, waiters, authorizers);
 
         customization.postprocess(fullModel);
 
@@ -158,6 +173,7 @@ public class IntermediateModelBuilder {
                                                                trimmedShapes,
                                                                fullModel.getCustomizationConfig(),
                                                                fullModel.getExamples(),
+                                                               awsQueryCompatibleMap,
                                                                fullModel.getEndpointOperation(),
                                                                fullModel.getWaiters(),
                                                                fullModel.getCustomAuthorizers());

--- a/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/intermediate/AwsQueryCompatibleModel.java
+++ b/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/intermediate/AwsQueryCompatibleModel.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2010-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.codegen.model.intermediate;
+
+public class AwsQueryCompatibleModel {
+    private final String name;
+    private final String code;
+
+    public AwsQueryCompatibleModel(String name, String code) {
+        this.name = name;
+        this.code = code;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+}

--- a/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/intermediate/IntermediateModel.java
+++ b/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/intermediate/IntermediateModel.java
@@ -46,6 +46,8 @@ public class IntermediateModel {
 
     private final ServiceExamples examples;
 
+    private final Map<String, AwsQueryCompatibleModel> awsQueryCompatible;
+
     @JsonIgnore
     private final Map<String, AuthorizerModel> customAuthorizers;
 
@@ -61,9 +63,10 @@ public class IntermediateModel {
             @JsonProperty("operations") Map<String, OperationModel> operations,
             @JsonProperty("shapes") Map<String, ShapeModel> shapes,
             @JsonProperty("customizationConfig") CustomizationConfig customizationConfig,
-            @JsonProperty("serviceExamples") ServiceExamples examples) {
+            @JsonProperty("serviceExamples") ServiceExamples examples,
+            @JsonProperty("awsQueryCompatible") Map<String, AwsQueryCompatibleModel> awsQueryCompatible) {
 
-        this(metadata, operations, shapes, customizationConfig, examples, null, Collections.emptyMap(), Collections.emptyMap());
+        this(metadata, operations, shapes, customizationConfig, examples, awsQueryCompatible, null, Collections.emptyMap(), Collections.emptyMap());
     }
 
     public IntermediateModel(
@@ -72,6 +75,7 @@ public class IntermediateModel {
             Map<String, ShapeModel> shapes,
             CustomizationConfig customizationConfig,
             ServiceExamples examples,
+            @JsonProperty("awsQueryCompatible") Map<String, AwsQueryCompatibleModel> awsQueryCompatible,
             OperationModel endpointOperation,
             Map<String, WaiterDefinitionModel> waiters,
             Map<String, AuthorizerModel> customAuthorizers) {
@@ -80,6 +84,7 @@ public class IntermediateModel {
         this.shapes = shapes;
         this.customizationConfig = customizationConfig;
         this.examples = examples;
+        this.awsQueryCompatible = awsQueryCompatible;
         this.endpointOperation = endpointOperation;
         this.waiters = ValidationUtils.assertNotNull(waiters, "waiters");
         this.customAuthorizers = customAuthorizers;
@@ -212,5 +217,9 @@ public class IntermediateModel {
      */
     public String getTransformPackage() {
         return metadata.getPackageName() + ".model." + Utils.directoryToPackage(customizationConfig.getTransformDirectory());
+    }
+
+    public Map<String, AwsQueryCompatibleModel> getAwsQueryCompatible() {
+        return awsQueryCompatible;
     }
 }

--- a/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/service/AwsQueryCompatible.java
+++ b/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/service/AwsQueryCompatible.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2010-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.codegen.model.service;
+
+public class AwsQueryCompatible {
+    private String name;
+    private String code;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/service/ServiceModel.java
+++ b/aws-java-sdk-code-generator/src/main/java/com/amazonaws/codegen/model/service/ServiceModel.java
@@ -31,14 +31,18 @@ public class ServiceModel {
 
     private String documentation;
 
+    private final Map<String, AwsQueryCompatible> awsQueryCompatible;
+
     public ServiceModel(@JsonProperty(value = "metadata", required = true) ServiceMetadata metadata,
                         @JsonProperty(value = "operations", required = true) Map<String, Operation> operations,
                         @JsonProperty(value = "shapes", required = true) Map<String, Shape> shapes,
-                        @JsonProperty(value = "authorizers") Map<String, Authorizer> authorizers) {
+                        @JsonProperty(value = "authorizers") Map<String, Authorizer> authorizers,
+                        @JsonProperty(value = "awsQueryCompatible") Map<String, AwsQueryCompatible> awsQueryCompatible) {
         this.metadata = metadata;
         this.operations = operations;
         this.shapes = shapes;
         this.authorizers = authorizers;
+        this.awsQueryCompatible = awsQueryCompatible;
     }
 
     public ServiceMetadata getMetadata() {
@@ -93,5 +97,9 @@ public class ServiceModel {
 
     public Map<String, Authorizer> getAuthorizers() {
         return authorizers != null ? authorizers : Collections.emptyMap();
+    }
+
+    public Map<String, AwsQueryCompatible> getAwsQueryCompatible() {
+        return awsQueryCompatible;
     }
 }

--- a/aws-java-sdk-code-generator/src/main/resources/macros/syncclientclass/awsquery/ClientInvokeMethodErrorResponseHandlerCreation.ftl
+++ b/aws-java-sdk-code-generator/src/main/resources/macros/syncclientclass/awsquery/ClientInvokeMethodErrorResponseHandlerCreation.ftl
@@ -1,3 +1,3 @@
-<#macro content metadata customizationConfig>
+<#macro content metadata customizationConfig awsQueryCompatible>
     DefaultErrorResponseHandler errorResponseHandler = new DefaultErrorResponseHandler(exceptionUnmarshallersMap, defaultUnmarshaller);
 </#macro>

--- a/aws-java-sdk-code-generator/src/main/resources/macros/syncclientclass/json/ClientInvokeMethodErrorResponseHandlerCreation.ftl
+++ b/aws-java-sdk-code-generator/src/main/resources/macros/syncclientclass/json/ClientInvokeMethodErrorResponseHandlerCreation.ftl
@@ -2,12 +2,19 @@
     Glacier has a special JsonErrorResponseHandler to handle a differently named error type field.
     This macro is overridden in the Glacier client.
 -->
-<#macro content metadata customizationConfig>
+<#macro content metadata customizationConfig awsQueryCompatible>
    HttpResponseHandler<AmazonServiceException> errorResponseHandler =
        protocolFactory.createErrorResponseHandler(
            new JsonErrorResponseMetadata()
            <#if customizationConfig.customErrorCodeFieldName?? >
                .withCustomErrorCodeFieldName("${customizationConfig.customErrorCodeFieldName}")
+           </#if>
+           <#if awsQueryCompatible?? >
+               .withAwsQueryCompatibleErrorMapping(ImmutableMapParameter.<String, String>builder()
+               <#list awsQueryCompatible?keys as key>
+                   .put("${key}", "${awsQueryCompatible[key].code}")
+               </#list>
+               .build())
            </#if>
        );
 </#macro>

--- a/aws-java-sdk-code-generator/src/main/resources/templates/common/SyncClientClassBase.ftl
+++ b/aws-java-sdk-code-generator/src/main/resources/templates/common/SyncClientClassBase.ftl
@@ -39,6 +39,10 @@ import ${metadata.packageName}.${metadata.syncClientBuilderClassName};
 import ${metadata.packageName}.waiters.${metadata.syncInterface}Waiters;
 </#if>
 
+<#if awsQueryCompatible??>
+    import com.amazonaws.util.ImmutableMapParameter;
+</#if>
+
 <#if customizationConfig.serviceClientHoldInputStream>
 import com.amazonaws.util.ServiceClientHolderInputStream;
 </#if>
@@ -418,7 +422,7 @@ public class ${metadata.syncClient} extends AmazonWebServiceClient implements ${
 
         request.setTimeOffset(timeOffset);
 
-        <@ClientInvokeMethodErrorResponseHandlerCreation.content metadata customizationConfig />
+        <@ClientInvokeMethodErrorResponseHandlerCreation.content metadata customizationConfig awsQueryCompatible />
 
         return client.execute(request, responseHandler,
                 errorResponseHandler, executionContext);

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/http/JsonErrorResponseHandler.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/http/JsonErrorResponseHandler.java
@@ -18,6 +18,7 @@ import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.annotation.SdkInternalApi;
 import com.amazonaws.internal.http.ErrorCodeParser;
+import com.amazonaws.internal.http.JsonErrorCodeMapper;
 import com.amazonaws.internal.http.JsonErrorMessageParser;
 import com.amazonaws.protocol.json.JsonContent;
 import com.amazonaws.transform.EnhancedJsonErrorUnmarshaller;
@@ -44,6 +45,7 @@ public class JsonErrorResponseHandler implements HttpResponseHandler<AmazonServi
 
     private final List<JsonErrorUnmarshaller> unmarshallers;
     private final ErrorCodeParser errorCodeParser;
+    private final JsonErrorCodeMapper errorCodeMapper;
     private final JsonErrorMessageParser errorMessageParser;
     private final JsonFactory jsonFactory;
 
@@ -54,12 +56,14 @@ public class JsonErrorResponseHandler implements HttpResponseHandler<AmazonServi
     public JsonErrorResponseHandler(
             List<JsonErrorUnmarshaller> errorUnmarshallers,
             ErrorCodeParser errorCodeParser,
+            JsonErrorCodeMapper errorCodeMapper,
             JsonErrorMessageParser errorMessageParser,
             JsonFactory jsonFactory) {
         this.unmarshallers = errorUnmarshallers;
         this.simpleTypeUnmarshallers = null;
         this.customTypeUnmarshallers = null;
         this.errorCodeParser = errorCodeParser;
+        this.errorCodeMapper = errorCodeMapper;
         this.errorMessageParser = errorMessageParser;
         this.jsonFactory = jsonFactory;
     }
@@ -69,12 +73,14 @@ public class JsonErrorResponseHandler implements HttpResponseHandler<AmazonServi
             Map<Class<?>, Unmarshaller<?, JsonUnmarshallerContext>> simpleTypeUnmarshallers,
             Map<JsonUnmarshallerContext.UnmarshallerType, Unmarshaller<?, JsonUnmarshallerContext>> customTypeUnmarshallers,
             ErrorCodeParser errorCodeParser,
+            JsonErrorCodeMapper errorCodeMapper,
             JsonErrorMessageParser errorMessageParser,
             JsonFactory jsonFactory) {
         this.unmarshallers = errorUnmarshallers;
         this.simpleTypeUnmarshallers = simpleTypeUnmarshallers;
         this.customTypeUnmarshallers = customTypeUnmarshallers;
         this.errorCodeParser = errorCodeParser;
+        this.errorCodeMapper = errorCodeMapper;
         this.errorMessageParser = errorMessageParser;
         this.jsonFactory = jsonFactory;
     }
@@ -100,7 +106,7 @@ public class JsonErrorResponseHandler implements HttpResponseHandler<AmazonServi
             ase.setErrorMessage(errorMessageParser.parseErrorMessage(response, jsonContent.getJsonNode()));
         }
 
-        ase.setErrorCode(errorCode);
+        ase.setErrorCode(errorCodeMapper.mapErrorCode(errorCode));
         ase.setServiceName(response.getRequest().getServiceName());
         ase.setStatusCode(response.getStatusCode());
         ase.setErrorType(getErrorTypeFromStatusCode(response.getStatusCode()));

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/http/JsonErrorCodeMapper.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/http/JsonErrorCodeMapper.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+package com.amazonaws.internal.http;
+
+import com.amazonaws.annotation.SdkInternalApi;
+
+import java.util.Map;
+import java.util.Collections;
+
+@SdkProtectedApi
+public class JsonErrorCodeMapper {
+    private final Map<String, String> awsQueryCompatibleErrorMapping;
+
+    public JsonErrorCodeMapper(Map<String, String> awsQueryCompatibleErrorMapping) {
+        this.awsQueryCompatibleErrorMapping = awsQueryCompatibleErrorMapping == null ? Collections.<String, String>emptyMap() : awsQueryCompatibleErrorMapping;
+    }
+
+    public String mapErrorCode(String errorCode) {
+        if (awsQueryCompatibleErrorMapping == null) return errorCode;
+        return awsQueryCompatibleErrorMapping.getOrDefault(errorCode, errorCode);
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/JsonErrorResponseMetadata.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/JsonErrorResponseMetadata.java
@@ -18,6 +18,7 @@ import com.amazonaws.annotation.NotThreadSafe;
 import com.amazonaws.annotation.SdkProtectedApi;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Contains various metadata needed to create an appropriate {@link com.amazonaws.http.JsonErrorResponseHandler}
@@ -38,6 +39,7 @@ public class JsonErrorResponseMetadata {
      */
     private List<JsonErrorShapeMetadata> errorShapes;
 
+    private Map<String, String> awsQueryCompatibleErrorMapping;
     public String getCustomErrorCodeFieldName() {
         return customErrorCodeFieldName;
     }
@@ -53,6 +55,15 @@ public class JsonErrorResponseMetadata {
 
     public JsonErrorResponseMetadata withErrorShapes(List<JsonErrorShapeMetadata> errorShapes) {
         this.errorShapes = errorShapes;
+        return this;
+    }
+
+    public Map<String, String> getAwsQueryCompatibleErrorMapping() {
+        return awsQueryCompatibleErrorMapping;
+    }
+
+    public JsonErrorResponseMetadata withAwsQueryCompatibleErrorMapping(Map<String, String> awsQueryCompatibleErrorMapping) {
+        this.awsQueryCompatibleErrorMapping = awsQueryCompatibleErrorMapping;
         return this;
     }
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkJsonProtocolFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkJsonProtocolFactory.java
@@ -112,8 +112,7 @@ public class SdkJsonProtocolFactory implements SdkJsonMarshallerFactory {
      */
     public HttpResponseHandler<AmazonServiceException> createErrorResponseHandler(
             JsonErrorResponseMetadata errorResponsMetadata) {
-        return getSdkFactory().createErrorResponseHandler(errorUnmarshallers, errorResponsMetadata
-                .getCustomErrorCodeFieldName());
+        return getSdkFactory().createErrorResponseHandler(errorUnmarshallers, errorResponsMetadata);
     }
 
     @SuppressWarnings("unchecked")

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkStructuredJsonFactory.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkStructuredJsonFactory.java
@@ -55,6 +55,6 @@ public interface SdkStructuredJsonFactory {
      * @param errorUnmarshallers Response unmarshallers to unamrshall the error responses.
      */
     JsonErrorResponseHandler createErrorResponseHandler(
-            List<JsonErrorUnmarshaller> errorUnmarshallers, String customErrorCodeFieldName);
+            List<JsonErrorUnmarshaller> errorUnmarshallers, JsonErrorResponseMetadata jsonErrorResponseMetadata);
 
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkStructuredJsonFactoryImpl.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/protocol/json/SdkStructuredJsonFactoryImpl.java
@@ -17,6 +17,7 @@ package com.amazonaws.protocol.json;
 import com.amazonaws.http.JsonErrorResponseHandler;
 import com.amazonaws.http.JsonResponseHandler;
 import com.amazonaws.internal.http.ErrorCodeParser;
+import com.amazonaws.internal.http.JsonErrorCodeMapper;
 import com.amazonaws.internal.http.JsonErrorCodeParser;
 import com.amazonaws.internal.http.JsonErrorMessageParser;
 import com.amazonaws.transform.JsonErrorUnmarshaller;
@@ -65,17 +66,22 @@ public abstract class SdkStructuredJsonFactoryImpl implements SdkStructuredJsonF
 
     @Override
     public JsonErrorResponseHandler createErrorResponseHandler(
-            final List<JsonErrorUnmarshaller> errorUnmarshallers, String customErrorCodeFieldName) {
+            final List<JsonErrorUnmarshaller> errorUnmarshallers, JsonErrorResponseMetadata jsonErrorResponseMetadata) {
         return new JsonErrorResponseHandler(errorUnmarshallers,
                                             unmarshallers,
                                             customTypeUnmarshallers,
-                                            getErrorCodeParser(customErrorCodeFieldName),
+                                            getErrorCodeParser(jsonErrorResponseMetadata.getCustomErrorCodeFieldName()),
+                                            getErrorCodeMapper(jsonErrorResponseMetadata.getAwsQueryCompatibleErrorMapping()),
                                             JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                                             jsonFactory);
     }
 
     protected ErrorCodeParser getErrorCodeParser(String customErrorCodeFieldName) {
         return new JsonErrorCodeParser(customErrorCodeFieldName);
+    }
+
+    private JsonErrorCodeMapper getErrorCodeMapper(Map<String, String> awsQueryCompatibleErrorMapping) {
+        return new JsonErrorCodeMapper(awsQueryCompatibleErrorMapping);
     }
 
 }

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/http/JsonErrorResponseHandlerTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/http/JsonErrorResponseHandlerTest.java
@@ -17,6 +17,7 @@ package com.amazonaws.http;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.AmazonServiceException.ErrorType;
 import com.amazonaws.DefaultRequest;
+import com.amazonaws.internal.http.JsonErrorCodeMapper;
 import com.amazonaws.internal.http.JsonErrorCodeParser;
 import com.amazonaws.internal.http.JsonErrorMessageParser;
 import com.amazonaws.protocol.json.JsonContent;
@@ -30,6 +31,7 @@ import com.fasterxml.jackson.core.JsonFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.ByteArrayInputStream;
+import java.util.Collections;
 import java.util.Map;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,6 +75,8 @@ public class JsonErrorResponseHandlerTest {
     @Mock
     private JsonErrorCodeParser errorCodeParser;
 
+    private final JsonErrorCodeMapper errorCodeMapper = new JsonErrorCodeMapper(Collections.<String, String>emptyMap());
+
     @Mock
     private Map<Class<?>, Unmarshaller<?, JsonUnmarshallerContext>> simpleTypeUnmarshallers;
 
@@ -93,6 +97,7 @@ public class JsonErrorResponseHandlerTest {
                                                        simpleTypeUnmarshallers,
                                                        customTypeUnmarshallers,
                                                        errorCodeParser,
+                                                       errorCodeMapper,
                                                        JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                                                        new JsonFactory());
     }
@@ -102,6 +107,7 @@ public class JsonErrorResponseHandlerTest {
                                                                                    Exception {
         responseHandler = new JsonErrorResponseHandler(new ArrayList<JsonErrorUnmarshaller>(),
                                                        new JsonErrorCodeParser(),
+                                                       errorCodeMapper,
                                                        JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                                                        new JsonFactory());
 
@@ -264,6 +270,7 @@ public class JsonErrorResponseHandlerTest {
                 simpleTypeUnmarshallers,
                 customTypeUnmarshallers,
                 errorCodeParser,
+                errorCodeMapper,
                 JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                 new JsonFactory());
 
@@ -280,6 +287,7 @@ public class JsonErrorResponseHandlerTest {
                 simpleTypeUnmarshallers,
                 customTypeUnmarshallers,
                 errorCodeParser,
+                errorCodeMapper,
                 JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                 new JsonFactory());
 
@@ -311,6 +319,7 @@ public class JsonErrorResponseHandlerTest {
                 simpleTypeUnmarshallers,
                 customTypeUnmarshallers,
                 errorCodeParser,
+                errorCodeMapper,
                 JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                 new JsonFactory());
 
@@ -342,6 +351,7 @@ public class JsonErrorResponseHandlerTest {
                 simpleTypeUnmarshallers,
                 customTypeUnmarshallers,
                 errorCodeParser,
+                errorCodeMapper,
                 JsonErrorMessageParser.DEFAULT_ERROR_MESSAGE_PARSER,
                 new JsonFactory());
 

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/protocol/json/SdkStructuredIonFactoryTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/protocol/json/SdkStructuredIonFactoryTest.java
@@ -141,7 +141,7 @@ public class SdkStructuredIonFactoryTest {
         List<JsonErrorUnmarshaller> unmarshallers = new LinkedList<JsonErrorUnmarshaller>();
         unmarshallers.add(new InvalidParameterExceptionUnmarshaller(ERROR_TYPE));
 
-        JsonErrorResponseHandler handler = SdkStructuredIonFactory.SDK_ION_BINARY_FACTORY.createErrorResponseHandler(unmarshallers, NO_CUSTOM_ERROR_CODE_FIELD_NAME);
+        JsonErrorResponseHandler handler = SdkStructuredIonFactory.SDK_ION_BINARY_FACTORY.createErrorResponseHandler(unmarshallers, new JsonErrorResponseMetadata());
         return handler.handle(error);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Add awsQueryCompatible to support json wire protocol. 
This is a pre-requisite for migrating services from AWSQuery wire protocol to AWSJson.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
