### PR TITLE
GitHub Workflows security hardening

### DIFF
--- a/.github/workflows/closed-issue-message.yml
+++ b/.github/workflows/closed-issue-message.yml
@@ -2,8 +2,12 @@ name: Closed Issue Message
 on:
     issues:
        types: [closed]
+permissions: {}
 jobs:
     auto_comment:
+        permissions:
+          issues: write # to comment on issues (aws-actions/closed-issue-message)
+
         runs-on: ubuntu-latest
         steps:
         - uses: aws-actions/closed-issue-message@v1

--- a/.github/workflows/stale-issue.yml
+++ b/.github/workflows/stale-issue.yml
@@ -5,8 +5,13 @@ on:
   schedule:
   - cron: "0 0/3 * * *"
 
+permissions: {}
 jobs:
   cleanup:
+    permissions:
+      issues: write # to label, comment and close issues (aws-actions/stale-issue-cleanup)
+      pull-requests: write # to label, comment and close pull requests (aws-actions/stale-issue-cleanup)
+
     name: Stale issue job
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This PR adds explicit [permissions section](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions) to workflows. This is a security best practice because by default workflows run with [extended set of permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token) (except from `on: pull_request` [from external forks](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)). By specifying any permission explicitly all others are set to none. By using the principle of least privilege the damage a compromised workflow can do (because of an [injection](https://securitylab.github.com/research/github-actions-untrusted-input/) or compromised third party tool or action) is restricted.
It is recommended to have [most strict permissions on the top level](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions) and grant write permissions on [job level](https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs) case by case.