### PR TITLE
Match no_proxy environment variable behaviour with other tools

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/ClientConfiguration.java
@@ -1109,7 +1109,16 @@ public class ClientConfiguration {
     private String getNonProxyHostsEnvironment() {
         String nonProxyHosts = getEnvironmentVariableCaseInsensitive("NO_PROXY");
         if (nonProxyHosts != null) {
-            nonProxyHosts = nonProxyHosts.replace(",", "|");
+            String[] nonProxyDomains = nonProxyHosts.split(",|\\|");
+            StringBuilder nonProxyDomainsAndSubDomains = new StringBuilder();
+            for (String nonProxyDomain : nonProxyDomains) {
+              nonProxyDomainsAndSubDomains.append(nonProxyDomain);
+              nonProxyDomainsAndSubDomains.append("|*.");
+              nonProxyDomainsAndSubDomains.append(nonProxyDomain);
+              nonProxyDomainsAndSubDomains.append("|");
+            }
+            nonProxyHosts = nonProxyDomainsAndSubDomains.substring(0,
+              nonProxyDomainsAndSubDomains.length() - 1);
         }
 
         return nonProxyHosts;

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/ClientConfigurationTest.java
@@ -491,9 +491,9 @@ public class ClientConfigurationTest {
         config.setProtocol(Protocol.HTTP);
         assertNull(config.getNonProxyHosts());
         environmentVariableHelper.set("no_proxy", "test1.com");
-        assertEquals("test1.com", config.getNonProxyHosts());
+        assertEquals("test1.com|*.test1.com", config.getNonProxyHosts());
         environmentVariableHelper.set("NO_PROXY", "test2.com");
-        assertEquals("test2.com", config.getNonProxyHosts());
+        assertEquals("test2.com|*.test2.com", config.getNonProxyHosts());
         System.setProperty("http.nonProxyHosts", "test3.com");
         assertEquals("test3.com", config.getNonProxyHosts());
         config.setNonProxyHosts("test4.com");
@@ -505,9 +505,9 @@ public class ClientConfigurationTest {
         assertNull(config.getNonProxyHosts());
         config.setProtocol(Protocol.HTTP);
         environmentVariableHelper.set("no_proxy", "test1.com,test2.com,test3.com");
-        assertEquals("test1.com|test2.com|test3.com", config.getNonProxyHosts());
+        assertEquals("test1.com|*.test1.com|test2.com|*.test2.com|test3.com|*.test3.com", config.getNonProxyHosts());
         environmentVariableHelper.set("no_proxy", "test1.com|test2.com|test3.com");
-        assertEquals("test1.com|test2.com|test3.com", config.getNonProxyHosts());
+        assertEquals("test1.com|*.test1.com|test2.com|*.test2.com|test3.com|*.test3.com", config.getNonProxyHosts());
         environmentVariableHelper.reset();
     }
 


### PR DESCRIPTION
*Description of changes:*

In curl, wget, Ruby, Python, Go and others the no_proxy variable matches subdomains as well as the parent, as described in this article:
https://about.gitlab.com/blog/2021/01/27/we-need-to-talk-no-proxy/

The Java nonProxyHosts setting works differently, needing explicit wildcard characters added as per:
https://docs.oracle.com/javase/8/docs/technotes/guides/net/proxies.html

Especially with path-style URLs for S3 being deprecated it is helpful to be able to match the behaviour of other tools and libraries on hosts when trying to set all S3 buckets in a region to bypass any proxy set.

While this change may impact behaviour, as requests which previously hit a proxy might now be excluded, the original addition of respecting the no_proxy environment variable came in 2019 and was likewise a change in behaviour - as such I believe it is acceptable to make this change even given the potential impact on clients.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
