### PR TITLE
fix(sec): upgrade junit:junit to 4.13.1

### DIFF
--- a/jmespath-java/pom.xml
+++ b/jmespath-java/pom.xml
@@ -1,6 +1,5 @@
-<?xml version="1.0"?>
-<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>com.amazonaws</groupId>


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in junit:junit 4.12
- [CVE-2020-15250](https://www.oscs1024.com/hd/CVE-2020-15250)


### What did I do？
Upgrade junit:junit from 4.12 to 4.13.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS