### PR TITLE
fix doesBucketsExistV2

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3Client.java
@@ -1403,10 +1403,16 @@ public class AmazonS3Client extends AmazonWebServiceClient implements AmazonS3 {
     public boolean doesBucketExistV2(String bucketName) throws SdkClientException {
         try {
             ValidationUtils.assertStringNotEmpty(bucketName, "bucketName");
-            getBucketAcl(bucketName);
-            return true;
+            List<Bucket> buckets = listBuckets();
+
+            for(int i=0; i<buckets.size(); i++){
+                if (buckets.get(i).getName()==bucketName){
+                    return true;
+                }
+            }
+            return false;
         } catch (AmazonServiceException ase) {
-            // A redirect error or an AccessDenied exception means the bucket exists but it's not in this region
+            // A redirect error or an AccessDenied exception means the bucket exists but it's not in this region,
             // or we don't have permissions to it.
             if ((ase.getStatusCode() == Constants.BUCKET_REDIRECT_STATUS_CODE) || "AccessDenied".equals(ase.getErrorCode())) {
                 return true;


### PR DESCRIPTION
current implementation doesn't make sense and also breaks interoperability with other S3 compatible apis

*Issue #2889 *

*Description of changes:*

Instead of calling ACL apis, we should just list the buckets and check whether the user provided bucket name matches one of the buckets in the list. See #2889  for full details regarding the justification for this change. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
