### PR TITLE
Update buildspecs for GenerateJavadocs with apt-key add

### DIFF
--- a/release-resources/buildspecs/generate-java-docs.yml
+++ b/release-resources/buildspecs/generate-java-docs.yml
@@ -6,6 +6,7 @@ phases:
     runtime-versions:
       java: "$JAVA_RUNTIME"
     commands:
+      - curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add -
       - apt-get update
       - pip install awscli --upgrade --user
       - pip install rsa


### PR DESCRIPTION
*Description of changes:*
Update buildspecs for GenerateJavadocs with apt-key add

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
