### PR TITLE
Remove unnecessary blanks

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/internal/ListWithAutoConstructFlag.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/internal/ListWithAutoConstructFlag.java
@@ -36,7 +36,7 @@ public class ListWithAutoConstructFlag<T> extends ArrayList<T> {
           super(c);
     }
 
-    public  ListWithAutoConstructFlag(int initialCapacity) {
+    public ListWithAutoConstructFlag(int initialCapacity) {
         super(initialCapacity);
     }
 

--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/PutObjectRequest.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/model/PutObjectRequest.java
@@ -248,7 +248,7 @@ public class PutObjectRequest extends AbstractPutObjectRequest implements Serial
 
     @Override
     @SuppressWarnings("unchecked")
-    public PutObjectRequest  withFile(File file) {
+    public PutObjectRequest withFile(File file) {
         return super.withFile(file);
     }
 
@@ -260,7 +260,7 @@ public class PutObjectRequest extends AbstractPutObjectRequest implements Serial
 
     @Override
     @SuppressWarnings("unchecked")
-    public PutObjectRequest  withCannedAcl(CannedAccessControlList cannedAcl) {
+    public PutObjectRequest withCannedAcl(CannedAccessControlList cannedAcl) {
         return super.withCannedAcl(cannedAcl);
     }
 
@@ -273,7 +273,7 @@ public class PutObjectRequest extends AbstractPutObjectRequest implements Serial
 
     @Override
     @SuppressWarnings("unchecked")
-    public PutObjectRequest  withInputStream(InputStream inputStream) {
+    public PutObjectRequest withInputStream(InputStream inputStream) {
         return super.withInputStream(inputStream);
     }
 


### PR DESCRIPTION
I found two blanks between type and method name,
so I searched with regex(`\b[a-z]+\b\s{2,}\b[a-z]+\b\(`) and fix them all

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
