### PR TITLE
Allow to customize QueueBufferConfig instances

### DIFF
--- a/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/AmazonSQSBufferedAsyncClient.java
+++ b/aws-java-sdk-sqs/src/main/java/com/amazonaws/services/sqs/buffered/AmazonSQSBufferedAsyncClient.java
@@ -379,11 +379,15 @@ public class AmazonSQSBufferedAsyncClient implements AmazonSQSAsync {
     private synchronized QueueBuffer getQBuffer(String qUrl) {
         QueueBuffer toReturn = buffers.get(qUrl);
         if (null == toReturn) {
-            QueueBufferConfig config = new QueueBufferConfig(bufferConfigExemplar);
+            QueueBufferConfig config = createQueueBufferConfig(bufferConfigExemplar);
             toReturn = new QueueBuffer(config, qUrl, realSQS);
             buffers.put(qUrl, toReturn);
         }
         return toReturn;
+    }
+    
+    protected QueueBufferConfig createQueueBufferConfig(QueueBufferConfig bufferConfigExemplar) {
+        return new QueueBufferConfig(bufferConfigExemplar);
     }
 
     class CachingMap extends LinkedHashMap<String, QueueBuffer> {


### PR DESCRIPTION
I would like to use a version of QueueBufferConfig that can be reconfigured. QueueBufferConfig is not final, so with just this small change I can hook what I need to allow things like `maxBatchOpenMs` to be dynamically redefined for existing/new buffers.


*Description of changes:*

Just allow to override QueueBufferConfig copy instantiation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
