### PR TITLE
remove whitespace from cloudfront signed URL policy

### DIFF
--- a/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/util/SignerUtils.java
+++ b/aws-java-sdk-cloudfront/src/main/java/com/amazonaws/services/cloudfront/util/SignerUtils.java
@@ -70,7 +70,7 @@ public class SignerUtils {
      */
     public static String buildCustomPolicy(String resourcePath,
             Date expiresOn, Date activeFrom, String ipAddress) {
-        return "{\"Statement\": [{"
+        return "{\"Statement\":[{"
                 + "\"Resource\":\""
                 + resourcePath
                 + "\""


### PR DESCRIPTION
I removed a whitespace character from the string used to create a policy for Cloudfront signed URLs.
According to the Docs and the Troubleshooting guide: https://aws.amazon.com/premiumsupport/knowledge-center/cloudfront-troubleshoot-signed-url-cookies/ there should not be whitespace characters in there as the validation will fail.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
