### PR TITLE
Fix credential lookup order

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/DefaultAWSCredentialsProviderChain.java
@@ -35,8 +35,8 @@ import com.amazonaws.auth.profile.ProfileCredentialsProvider;
  * @see EnvironmentVariableCredentialsProvider
  * @see SystemPropertiesCredentialsProvider
  * @see WebIdentityTokenCredentialsProvider
- * @see ProfileCredentialsProvider
  * @see EC2ContainerCredentialsProviderWrapper
+ * @see ProfileCredentialsProvider
  */
 public class DefaultAWSCredentialsProviderChain extends AWSCredentialsProviderChain {
 
@@ -47,8 +47,8 @@ public class DefaultAWSCredentialsProviderChain extends AWSCredentialsProviderCh
         super(new EnvironmentVariableCredentialsProvider(),
               new SystemPropertiesCredentialsProvider(),
               WebIdentityTokenCredentialsProvider.create(),
-              new ProfileCredentialsProvider(),
-              new EC2ContainerCredentialsProviderWrapper());
+              new EC2ContainerCredentialsProviderWrapper(),
+              new ProfileCredentialsProvider());
     }
 
     public static DefaultAWSCredentialsProviderChain getInstance() {


### PR DESCRIPTION
*Description of changes:*

According to the documentation the AWS credentials provider chain will look for credentials in this order:
 <ul>
   <li>Environment Variables -
      <code>AWS_ACCESS_KEY_ID</code> and <code>AWS_SECRET_ACCESS_KEY</code>
      (RECOMMENDED since they are recognized by all the AWS SDKs and CLI except for .NET),
      or <code>AWS_ACCESS_KEY</code> and <code>AWS_SECRET_KEY</code> (only recognized by Java SDK)
   </li>
   <li>Java System Properties - aws.accessKeyId and aws.secretKey</li>
   <li>Web Identity Token credentials from the environment or container</li>
   <li>Credential profiles file at the default location (~/.aws/credentials) shared by all AWS SDKs and the AWS CLI</li>
   <li>Credentials delivered through the Amazon EC2 container service if AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" environment variable is set
   and security manager has permission to access the variable,</li>
   <li>Instance profile credentials delivered through the Amazon EC2 metadata service</li>
 </ul>

But it is calling the Instance profile credentials before the Credentials delivered through the Amazon EC2 container. Fixing the order to be the same stated by documentation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
