### PR TITLE
update: change the default thread pool for AwsAsyncClientBuilder.

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/client/builder/AwsAsyncClientBuilder.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/client/builder/AwsAsyncClientBuilder.java
@@ -23,6 +23,9 @@ import com.amazonaws.regions.AwsRegionProvider;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Base class for all service specific async client builders.
@@ -111,7 +114,8 @@ public abstract class AwsAsyncClientBuilder<Subclass extends AwsAsyncClientBuild
          * @return Default async Executor to use if none is explicitly provided by user.
          */
         private ExecutorService defaultExecutor() {
-            return Executors.newFixedThreadPool(getClientConfiguration().getMaxConnections());
+
+            return new ThreadPoolExecutor(0, getClientConfiguration().getMaxConnections(), 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
         }
     }
 


### PR DESCRIPTION
*Issue #, if available:*

In the case of fixedThreadPool, unnecessary thread occupancy and memory leak can occur. That's why I'm going to change the default thread pool implementation of AwsAsyncClientBuilder.

In my case, the thread did not end after the process of transmitting large amounts of data to SQS, resulting in a memory leak.

![image](https://user-images.githubusercontent.com/26922008/232176135-76073d4e-f3e0-437a-a95f-778b867125f8.png)

![image](https://user-images.githubusercontent.com/26922008/232176138-002fca18-5847-49f9-8db7-6f94b1d28b9a.png)


*Description of changes:*

```java
private ExecutorService defaultExecutor() {
            return new ThreadPoolExecutor(0, getClientConfiguration().getMaxConnections(), 60L, TimeUnit.SECONDS, new LinkedBlockingQueue<Runnable>());
        }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
