### PR TITLE
Removing the jackson backward incompatible dependency on class (only present on jackson 2.12 onwards)

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/EC2MetadataUtils.java
@@ -29,7 +29,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import java.net.URI;
 import java.util.Arrays;
@@ -85,7 +84,7 @@ public class EC2MetadataUtils {
     static {
         mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         try {
-            mapper.setPropertyNamingStrategy(PropertyNamingStrategies.UPPER_CAMEL_CASE);
+            mapper.setPropertyNamingStrategy(PropertyNamingStrategy.UPPER_CAMEL_CASE);
         } catch (LinkageError e) {
             // If a customer is using an older Jackson version than 2.12.x, fall back to the old (deprecated)
             // name for the same property that might cause deadlocks.


### PR DESCRIPTION

*Issue #, if available:* AWS-java-sdk-core is incompatible with jackson 2.10.5 and older 

*Description of changes:*

Hello,
Creating the PR to make Aws-java-sdk core backward compatible with the older jackson version. Unfortunately com.fasterxml.jackson.databind.PropertyNamingStrategies is not present on jackson version 2.10.5 backwards and it makes the aws lib incompatible with older version of jackson.
Tested the change on local env. Other Unit tests are already covering the change.

Can you please review ?

Thank you

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
