### PR TITLE
Possible fix for aws profile assumeRole from ec2InstanceRole issues:

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/BasicProfile.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/BasicProfile.java
@@ -116,4 +116,7 @@ public class BasicProfile {
     public boolean isProcessBasedProfile() {
         return getCredentialProcess() != null;
     }
+    public String getCredentialSource() {
+        return getPropertyValue(ProfileKeyConstants.CREDENTIAL_SOURCE);
+    }
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/CredentialSourceType.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/CredentialSourceType.java
@@ -1,0 +1,22 @@
+package com.amazonaws.auth.profile.internal;
+
+import com.amazonaws.annotation.SdkInternalApi;
+
+@SdkInternalApi
+public enum CredentialSourceType {
+    EC2_INSTANCE_METADATA,
+    ECS_CONTAINER,
+    ENVIRONMENT;
+
+    public static CredentialSourceType parse(String value) {
+        if (value.equalsIgnoreCase("Ec2InstanceMetadata")) {
+            return EC2_INSTANCE_METADATA;
+        } else if (value.equalsIgnoreCase("EcsContainer")) {
+            return ECS_CONTAINER;
+        } else if (value.equalsIgnoreCase("Environment")) {
+            return ENVIRONMENT;
+        }
+
+        throw new IllegalArgumentException(String.format("%s is not a valid credential_source", value));
+    }
+}

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/ProfileKeyConstants.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/ProfileKeyConstants.java
@@ -79,4 +79,9 @@ public class ProfileKeyConstants {
      * Absolute path to a JWT file containing a web identity token.
      */
     public static final String WEB_IDENTITY_TOKEN = "web_identity_token_file";
+    
+    /**
+     * A source to obtain credentials from.
+     */
+    public static final String CREDENTIAL_SOURCE = "credential_source";
 }

--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/ProfileStaticCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/profile/internal/ProfileStaticCredentialsProvider.java
@@ -14,68 +14,110 @@
  */
 package com.amazonaws.auth.profile.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 import com.amazonaws.SdkClientException;
 import com.amazonaws.annotation.Immutable;
 import com.amazonaws.annotation.SdkInternalApi;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AWSCredentialsProviderChain;
 import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.auth.BasicSessionCredentials;
+import com.amazonaws.auth.ContainerCredentialsProvider;
+import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
+import com.amazonaws.auth.InstanceProfileCredentialsProvider;
+import com.amazonaws.auth.SystemPropertiesCredentialsProvider;
 import com.amazonaws.internal.StaticCredentialsProvider;
 import com.amazonaws.util.StringUtils;
 
 /**
- * Serves credentials defined in a {@link BasicProfile}. Does validation that both access key and
- * secret key exists and are non empty.
+ * Serves credentials defined in a {@link BasicProfile}. Does validation that
+ * both access key and secret key exists and are non empty.
  */
 @SdkInternalApi
 @Immutable
 public class ProfileStaticCredentialsProvider implements AWSCredentialsProvider {
 
-    private final BasicProfile profile;
-    private final AWSCredentialsProvider credentialsProvider;
+	private final BasicProfile profile;
+	private final AWSCredentialsProvider credentialsProvider;
 
-    public ProfileStaticCredentialsProvider(BasicProfile profile) {
-        this.profile = profile;
-        this.credentialsProvider = new StaticCredentialsProvider(fromStaticCredentials());
+	
+    /**
+     * The raw properties in this profile.
+     */
+    private final Map<String, String> properties;
+
+	public ProfileStaticCredentialsProvider(BasicProfile profile) {
+		this.profile = profile;
+		this.properties = profile.getProperties();
+        boolean hasCredentialSource = properties.containsKey(ProfileKeyConstants.CREDENTIAL_SOURCE);
+
+		if (hasCredentialSource) {
+			CredentialSourceType credentialSource = CredentialSourceType.parse(profile.getCredentialSource());
+			this.credentialsProvider  = credentialSourceCredentialProvider(credentialSource);
+		} else {
+			this.credentialsProvider = new StaticCredentialsProvider(fromStaticCredentials());
+		}
+	}
+
+	@Override
+	public AWSCredentials getCredentials() {
+		return credentialsProvider.getCredentials();
+	}
+
+	@Override
+	public void refresh() {
+		// No Op
+	}
+
+	private AWSCredentials fromStaticCredentials() {
+		if (StringUtils.isNullOrEmpty(profile.getAwsAccessIdKey())) {
+			throw new SdkClientException(
+					String.format("Unable to load credentials into profile [%s]: AWS Access Key ID is not specified.",
+							profile.getProfileName()));
+		}
+		if (StringUtils.isNullOrEmpty(profile.getAwsSecretAccessKey())) {
+			throw new SdkClientException(String.format(
+					"Unable to load credentials into profile [%s]: AWS Secret Access Key is not specified.",
+					profile.getAwsSecretAccessKey()));
+		}
+
+		if (profile.getAwsSessionToken() == null) {
+			return new BasicAWSCredentials(profile.getAwsAccessIdKey(), profile.getAwsSecretAccessKey());
+		} else {
+			if (profile.getAwsSessionToken().isEmpty()) {
+				throw new SdkClientException(
+						String.format("Unable to load credentials into profile [%s]: AWS Session Token is empty.",
+								profile.getProfileName()));
+			}
+
+			return new BasicSessionCredentials(profile.getAwsAccessIdKey(), profile.getAwsSecretAccessKey(),
+					profile.getAwsSessionToken());
+		}
+	}
+
+	private AWSCredentialsProvider credentialSourceCredentialProvider(CredentialSourceType credentialSource) {
+		switch (credentialSource) {
+		case ECS_CONTAINER:
+			return new ContainerCredentialsProvider();
+		case EC2_INSTANCE_METADATA:
+			return InstanceProfileCredentialsProvider.getInstance();
+		case ENVIRONMENT:
+			List<AWSCredentialsProvider> credProviders = new ArrayList<AWSCredentialsProvider>();
+			credProviders.add(new EnvironmentVariableCredentialsProvider());
+			credProviders.add(new SystemPropertiesCredentialsProvider());
+			return new AWSCredentialsProviderChain(credProviders);
+		default:
+			throw noSourceCredentialsException();
+		}
+	}
+
+    private IllegalStateException noSourceCredentialsException() {
+        String error = String.format("The source profile of '%s', but that source profile has no "
+                                     + "credentials configured.", profile.getProfileName());
+        return new IllegalStateException(error);
     }
-
-    @Override
-    public AWSCredentials getCredentials() {
-        return credentialsProvider.getCredentials();
-    }
-
-    @Override
-    public void refresh() {
-        // No Op
-    }
-
-    private AWSCredentials fromStaticCredentials() {
-        if (StringUtils.isNullOrEmpty(profile.getAwsAccessIdKey())) {
-            throw new SdkClientException(String.format(
-                    "Unable to load credentials into profile [%s]: AWS Access Key ID is not specified.",
-                    profile.getProfileName()));
-        }
-        if (StringUtils.isNullOrEmpty(profile.getAwsSecretAccessKey())) {
-            throw new SdkClientException(String.format(
-                    "Unable to load credentials into profile [%s]: AWS Secret Access Key is not specified.",
-                    profile.getAwsSecretAccessKey()));
-        }
-
-        if (profile.getAwsSessionToken() == null) {
-            return new BasicAWSCredentials(profile.getAwsAccessIdKey(),
-                                           profile.getAwsSecretAccessKey());
-        } else {
-            if (profile.getAwsSessionToken().isEmpty()) {
-                throw new SdkClientException(String.format(
-                        "Unable to load credentials into profile [%s]: AWS Session Token is empty.",
-                        profile.getProfileName()));
-            }
-
-            return new BasicSessionCredentials(profile.getAwsAccessIdKey(),
-                                               profile.getAwsSecretAccessKey(),
-                                               profile.getAwsSessionToken());
-        }
-    }
-
 }


### PR DESCRIPTION
Possible fix for aws profile assumeRole from ec2InstanceRole issues:

https://github.com/aws/aws-sdk-java/issues/1521
https://github.com/aws/aws-sdk-java/issues/1713

*Issue #, if available:*
#1521 and #1713 

*Description of changes: *
This code change is a possible solution to resolve using AWS Profile files not correctly utilizing credential_source such as Ec2InstanceMetadata and being forced to only utilize AccessKey/Secret. I have tested with AWS's official version of the Redshift JDBC Driver and it does work and solve the problem of not being able to utilize credential_source. I was able to successfully test with AWS's Redshift JDBC Driver using Ec2InstanceMetadata and utilized assumeRole operation to use a different role both in the local account and in a cross account methodology.

Example of what did not work with aws-java-sdk v1 before this fix.

[default]
credential_source=Ec2InstanceMetadata
region=us-east-1
output=json

[redshift_iam]
role_arn=arn:aws:iam::xxxxxxxxxxxx:role/xxxx-data-dev-idmc-poc
region=us-east-1
source_profile=default
output=json

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
