### PR TITLE
when use v2 signer, get bucket object-lock configuration failed with SignatureDoesNotMatch

### DIFF
--- a/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RestUtils.java
+++ b/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/internal/RestUtils.java
@@ -44,7 +44,7 @@ public class RestUtils {
             "acl", "torrent", "logging", "location", "policy", "requestPayment", "versioning",
             "versions", "versionId", "notification", "uploadId", "uploads", "partNumber", "website",
             "delete", "lifecycle", "tagging", "cors", "restore", "replication", "accelerate",
-            "inventory", "analytics", "metrics",
+            "inventory", "analytics", "metrics", "object-lock",
             ResponseHeaderOverrides.RESPONSE_HEADER_CACHE_CONTROL,
             ResponseHeaderOverrides.RESPONSE_HEADER_CONTENT_DISPOSITION,
             ResponseHeaderOverrides.RESPONSE_HEADER_CONTENT_ENCODING,


### PR DESCRIPTION
when use v2 signer

```
import com.amazonaws.ClientConfiguration;
import com.amazonaws.Protocol;
import com.amazonaws.auth.AWSCredentials;
import com.amazonaws.auth.BasicAWSCredentials;
import com.amazonaws.retry.PredefinedRetryPolicies;
import com.amazonaws.services.s3.AmazonS3;
import com.amazonaws.services.s3.AmazonS3Client;
import com.amazonaws.services.s3.S3ClientOptions;
import com.amazonaws.services.s3.model.*;

import java.util.List;
import java.util.logging.Logger;

public class hello {
    public static Logger getLogger() {
        return logger;
    }
    private static final Logger logger = Logger.getLogger(String.valueOf(hello.class));
    public static void main(String[] args) {
        AWSCredentials credentials = new BasicAWSCredentials("", "");
        ClientConfiguration opts = new ClientConfiguration();
        opts.setSignerOverride("S3SignerType");
//        opts.setSignerOverride("AWSS3V4SignerType");
        opts.setProtocol(Protocol.HTTP);
        opts.setRetryPolicy(PredefinedRetryPolicies.NO_RETRY_POLICY);
        AmazonS3 conn = new AmazonS3Client(credentials, opts);
        conn.setEndpoint("s3.amazonaws.com");
        conn.setS3ClientOptions(new S3ClientOptions().withPathStyleAccess(true));
        GetObjectLockConfigurationRequest request = new GetObjectLockConfigurationRequest();
        request.setBucketName("ylywormtest");
        conn.getObjectLockConfiguration(request);
    }
}
```

```
2023-11-21 17:30:38 DEBUG Sending Request: GET http://s3.amazonaws.com /ylywormtest/ Parameters: ({"object-lock":[null]}Headers: (amz-sdk-invocation-id: f45a7c6e-b194-e1ad-732c-3df03b957b5f, Content-Type: application/octet-stream, User-Agent: aws-sdk-java/1.11.820 Windows_10/10.0 Java_HotSpot(TM)_64-Bit_Server_VM/11.0.2+9-LTS java/11.0.2 vendor/Oracle_Corporation, ) 
2023-11-21 17:30:38 DEBUG Calculated string to sign:
"GET

application/octet-stream
Tue, 21 Nov 2023 09:30:38 GMT
/ylywormtest/"
2023-11-21 17:30:38 DEBUG CookieSpec selected: default
2023-11-21 17:30:38 DEBUG Auth cache not set in the context
2023-11-21 17:30:38 DEBUG Connection request: [route: {}->http://s3.amazonaws.com:80][total kept alive: 1; route allocated: 1 of 50; total allocated: 1 of 50]
2023-11-21 17:30:38 DEBUG Connection leased: [id: 0][route: {}->http://s3.amazonaws.com:80][total kept alive: 0; route allocated: 1 of 50; total allocated: 1 of 50]
2023-11-21 17:30:38 DEBUG http-outgoing-0: set socket timeout to 50000
2023-11-21 17:30:38 DEBUG http-outgoing-0: set socket timeout to 50000
2023-11-21 17:30:38 DEBUG Executing request GET /ylywormtest/?object-lock HTTP/1.1
2023-11-21 17:30:38 DEBUG Proxy auth state: UNCHALLENGED
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> GET /ylywormtest/?object-lock HTTP/1.1
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Host: s3.amazonaws.com
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> amz-sdk-invocation-id: f45a7c6e-b194-e1ad-732c-3df03b957b5f
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> amz-sdk-request: ttl=20231121T093128Z;attempt=1;max=1
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> amz-sdk-retry: 0/0/500
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Authorization: AWS AKIARPFX22UE3RB33VIC:5bJsijdrivBVZPSQXNLi29n9bQg=
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Content-Type: application/octet-stream
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Date: Tue, 21 Nov 2023 09:30:38 GMT
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> User-Agent: aws-sdk-java/1.11.820 Windows_10/10.0 Java_HotSpot(TM)_64-Bit_Server_VM/11.0.2+9-LTS java/11.0.2 vendor/Oracle_Corporation
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Content-Length: 0
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> Connection: Keep-Alive
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "GET /ylywormtest/?object-lock HTTP/1.1[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Host: s3.amazonaws.com[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "amz-sdk-invocation-id: f45a7c6e-b194-e1ad-732c-3df03b957b5f[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "amz-sdk-request: ttl=20231121T093128Z;attempt=1;max=1[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "amz-sdk-retry: 0/0/500[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Authorization: AWS AKIARPFX22UE3RB33VIC:5bJsijdrivBVZPSQXNLi29n9bQg=[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Content-Type: application/octet-stream[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Date: Tue, 21 Nov 2023 09:30:38 GMT[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "User-Agent: aws-sdk-java/1.11.820 Windows_10/10.0 Java_HotSpot(TM)_64-Bit_Server_VM/11.0.2+9-LTS java/11.0.2 vendor/Oracle_Corporation[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Content-Length: 0[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "Connection: Keep-Alive[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 >> "[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "HTTP/1.1 403 Forbidden[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "x-amz-request-id: G5F3K9JXCV611DE5[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "x-amz-id-2: Wh4VE4N2swGQUcT5ALmNPrnYH1Sfj8v9pd1sJpB4Z0HrQ9LjVooHsczBTHnz9yYahTjHeHbSsbA=[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "Content-Type: application/xml[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "Transfer-Encoding: chunked[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "Date: Tue, 21 Nov 2023 09:30:38 GMT[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "Server: AmazonS3[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "36f[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "<?xml version="1.0" encoding="UTF-8"?>[\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we calculated does not match the signature you provided. Check your key and signing method.</Message><AWSAccessKeyId>AKIARPFX22UE3RB33VIC</AWSAccessKeyId><StringToSign>GET[\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "[\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "application/octet-stream[\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "Tue, 21 Nov 2023 09:30:38 GMT[\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "/ylywormtest/?object-lock</StringToSign><SignatureProvided>5bJsijdrivBVZPSQXNLi29n9bQg=</SignatureProvided><StringToSignBytes>47 45 54 0a 0a 61 70 70 6c 69 63 61 74 69 6f 6e 2f 6f 63 74 65 74 2d 73 74 72 65 61 6d 0a 54 75 65 2c 20 32 31 20 4e 6f 76 20 32 30 32 33 20 30 39 3a 33 30 3a 33 38 20 47 4d 54 0a 2f 79 6c 79 77 6f 72 6d 74 65 73 74 2f 3f 6f 62 6a 65 63 74 2d 6c 6f 63 6b</StringToSignBytes><RequestId>G5F3K9JXCV611DE5</RequestId><HostId>Wh4VE4N2swGQUcT5ALmNPrnYH1Sfj8v9pd1sJpB4Z0HrQ9LjVooHsczBTHnz9yYahTjHeHbSsbA=</HostId></Error>[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "0[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << "[\r][\n]"
2023-11-21 17:30:38 DEBUG http-outgoing-0 << HTTP/1.1 403 Forbidden
2023-11-21 17:30:38 DEBUG http-outgoing-0 << x-amz-request-id: G5F3K9JXCV611DE5
2023-11-21 17:30:38 DEBUG http-outgoing-0 << x-amz-id-2: Wh4VE4N2swGQUcT5ALmNPrnYH1Sfj8v9pd1sJpB4Z0HrQ9LjVooHsczBTHnz9yYahTjHeHbSsbA=
2023-11-21 17:30:38 DEBUG http-outgoing-0 << Content-Type: application/xml
2023-11-21 17:30:38 DEBUG http-outgoing-0 << Transfer-Encoding: chunked
2023-11-21 17:30:38 DEBUG http-outgoing-0 << Date: Tue, 21 Nov 2023 09:30:38 GMT
2023-11-21 17:30:38 DEBUG http-outgoing-0 << Server: AmazonS3
```

the server use /ylywormtest/?object-lock in string to sign,but client use /ylywormtest/ , that make signature not match

