### PR TITLE
Support alternate date formats in StateMachine.fromJson().

### DIFF
--- a/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/DateModule.java
+++ b/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/DateModule.java
@@ -14,6 +14,7 @@
  */
 package com.amazonaws.services.stepfunctions.builder.internal;
 
+import com.amazonaws.util.DateUtils;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.DeserializationContext;
@@ -59,7 +60,7 @@ public class DateModule {
     }
 
     public static Date fromJson(String jsonText) {
-        return FORMATTER.parseDateTime(jsonText).toDate();
+        return DateUtils.parseISO8601Date(jsonText);
     }
 
 }

--- a/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilderTest.java
+++ b/aws-java-sdk-stepfunctions/src/test/java/com/amazonaws/services/stepfunctions/builder/StepFunctionBuilderTest.java
@@ -667,4 +667,18 @@ public class StepFunctionBuilderTest {
         StateMachine.fromJson("{");
     }
 
+    @Test
+    public void stateMachineFromJson_JsonWithTimestampWithFractionalSeconds_DoesNotThrowException() {
+        StateMachine.fromJson(
+            "{\"StartAt\":\"TestTime\",\"States\":{\"TestTime\":{\"Type\":\"Wait\",\"Timestamp\":\"2016-03-14T01:59:00.000Z\",\"End\":true}}}"
+        );
+    }
+
+    @Test
+    public void stateMachineFromJson_JsonWithTimestampWithoutFractionalSeconds_DoesNotThrowException() {
+        StateMachine.fromJson(
+            "{\"StartAt\":\"TestTime\",\"States\":{\"TestTime\":{\"Type\":\"Wait\",\"Timestamp\":\"2016-03-14T01:59:00Z\",\"End\":true}}}"
+        );
+    }
+
 }


### PR DESCRIPTION
**Issue:** #2130

**Issue Being Resolved**

Currently, this code:
```
StateMachine.fromJson("""
  {
    "StartAt": "TestTime",
    "States": {
      "TestTime": {
        "Type": "Wait",
        "Timestamp": "2016-03-14T01:59:00Z",
        "End": true
      }
    }
  }
  """);
```
fails with the error message `java.lang.IllegalArgumentException: Invalid format: "2016-03-14T01:59:00Z" is malformed at "Z"`.

However, this code:
```
StateMachine.fromJson("""
  {
    "StartAt": "TestTime",
    "States": {
      "TestTime": {
        "Type": "Wait",
        "Timestamp": "2016-03-14T01:59:00.000Z",
        "End": true
      }
    }
  }
  """);
```
works.

This is because we [currently](https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-stepfunctions/src/main/java/com/amazonaws/services/stepfunctions/builder/internal/DateModule.java#L62) use:
```
org.joda.time.format.ISODateTimeFormat.dateTime().parseDateTime()
```
to parse dates found in JSON.

According to the AWS Step Functions [documentation](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-wait-state.html) for the wait state: 
```
Timestamps must conform to the RFC3339 profile of ISO 8601, 
with the further restrictions that an uppercase T must separate the date and time portions, 
and an uppercase Z must denote that a numeric time zone offset is not present, 
for example, 2024-08-18T17:33:00Z.
```

The RFC3339 profile of ISO 8601 allows fractional seconds to be optional and the example given in the AWS documentation does not include any partial seconds.  Therefore, we should support dates without fractional seconds.

**Proposed Solution**
This PR changes the date parsing logic to use `com.amazonaws.util.DateUtils.parseISO8601Date(...)` to parse dates during JSON deserialization.  This method supports both the date format with fractional seconds and without fractional seconds.

This PR does **not** change the JSON serialization format of dates.

**Test Cases**
I have added test cases to demonstrate that the solution works with both date formats, however, these test cases may have limited value since I have not changed any date parsing logic used during JSON deserialization.  I am happy to remove them upon request.

**Confirmation**
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
