### PR TITLE
Backport EKS Pod Identity support into ContainerCredentialsProvider

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/auth/ContainerCredentialsProvider.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/auth/ContainerCredentialsProvider.java
@@ -18,9 +18,12 @@ import com.amazonaws.SdkClientException;
 import com.amazonaws.internal.CredentialsEndpointProvider;
 import com.amazonaws.retry.internal.CredentialsEndpointRetryPolicy;
 
+import java.io.IOException;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.UnknownHostException;
+import java.nio.file.Files;
+import java.nio.file.FileSystems;
 import java.util.*;
 
 /**
@@ -43,10 +46,20 @@ public class ContainerCredentialsProvider implements AWSCredentialsProvider {
 
     static final String CONTAINER_AUTHORIZATION_TOKEN = "AWS_CONTAINER_AUTHORIZATION_TOKEN";
 
+    static final String CONTAINER_AUTHORIZATION_TOKEN_FILE = "AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE";
+
+    static final String AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE = "AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE";
+
+    private static final String ECS_CONTAINER_HOST = "169.254.170.2";
+    private static final String EKS_CONTAINER_HOST_IPV6 = "[fd00:ec2::23]";
+    private static final String EKS_CONTAINER_HOST_IPV4 = "169.254.170.23";
+    private static final List<String> VALID_LOOP_BACK_IPV4 = Arrays.asList(ECS_CONTAINER_HOST, EKS_CONTAINER_HOST_IPV4);
+    private static final List<String> VALID_LOOP_BACK_IPV6 = Arrays.asList(EKS_CONTAINER_HOST_IPV6);
+
     private static final String HTTPS = "https";
 
     /** Default endpoint to retrieve the Amazon ECS Credentials. */
-    private static final String ECS_CREDENTIALS_ENDPOINT = "http://169.254.170.2";
+    private static final String ECS_CREDENTIALS_ENDPOINT = "http://" + ECS_CONTAINER_HOST;
 
     private final ContainerCredentialsFetcher credentialsFetcher;
 
@@ -125,6 +138,15 @@ public class ContainerCredentialsProvider implements AWSCredentialsProvider {
             if (System.getenv(CONTAINER_AUTHORIZATION_TOKEN) != null) {
                 return Collections.singletonMap("Authorization", System.getenv(CONTAINER_AUTHORIZATION_TOKEN));
             }
+            if (System.getenv(CONTAINER_AUTHORIZATION_TOKEN_FILE) != null) {
+                String tokenFile = System.getenv(CONTAINER_AUTHORIZATION_TOKEN_FILE);
+                try {
+                    byte[] tokenBytes = Files.readAllBytes(FileSystems.getDefault().getPath(tokenFile));
+                    return Collections.singletonMap("Authorization", new String(tokenBytes, "UTF-8"));
+                } catch (IOException e) {
+                    throw new SdkClientException(String.format("Cannot fetch credentials from container - failed to read %s", tokenFile));
+                }
+            }
             return new HashMap<String, String>();
         }
 
@@ -151,7 +173,7 @@ public class ContainerCredentialsProvider implements AWSCredentialsProvider {
                     }
                 }
 
-                return addresses.length > 0 && allAllowed;
+                return addresses.length > 0 && (allAllowed || isMetadataServiceEndpoint(host));
 
             } catch (UnknownHostException e) {
                 throw new SdkClientException(String.format("host (%s) could not be resolved to an IP address.", host), e);
@@ -160,6 +182,19 @@ public class ContainerCredentialsProvider implements AWSCredentialsProvider {
 
         private boolean isLoopbackAddress(InetAddress inetAddress) {
             return inetAddress.isLoopbackAddress();
+        }
+
+        private boolean isMetadataServiceEndpoint(String host) {
+            String mode = System.getenv(AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE);
+            if ("IPV6".equalsIgnoreCase(mode)) {
+                return VALID_LOOP_BACK_IPV6.contains(host);
+            }
+            return VALID_LOOP_BACK_IPV4.contains(host);
+        }
+
+        @Override
+        public CredentialsEndpointRetryPolicy getRetryPolicy() {
+            return ContainerCredentialsRetryPolicy.getInstance();
         }
     }
 

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/FullUriCredentialsEndpointProviderIntegrationTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/FullUriCredentialsEndpointProviderIntegrationTest.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017. Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ * http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazonaws.auth;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasEntry;
+
+import com.amazonaws.auth.ContainerCredentialsProvider.FullUriCredentialsEndpointProvider;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import utils.EnvironmentVariableHelper;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Map;
+
+public class FullUriCredentialsEndpointProviderIntegrationTest {
+
+    private static final EnvironmentVariableHelper helper = new EnvironmentVariableHelper();
+    private static final FullUriCredentialsEndpointProvider sut = new FullUriCredentialsEndpointProvider();
+
+private static String fileName = "tokenFile";
+
+    private static String data = "hello authorized world!";
+
+    private static File file = null;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        file = File.createTempFile(String.valueOf(System.currentTimeMillis()),
+                fileName);
+
+        FileWriter fw = null;
+        try {
+            fw = new FileWriter(file);
+            fw.write(data);
+        } finally {
+            fw.close();
+        }
+    }
+
+    @AfterClass
+    public static void tearDown() throws Exception {
+        helper.reset();
+
+        if (file != null) {
+            file.delete();
+        }
+    }
+
+    @Test
+    public void authorizationHeaderIsPresentIfEnvironmentVariableSet() {
+        helper.set(ContainerCredentialsProvider.CONTAINER_AUTHORIZATION_TOKEN_FILE, file.getAbsolutePath());
+        Map<String, String> headers = sut.getHeaders();
+        assertThat(headers.size(), equalTo(1));
+        assertThat(headers, hasEntry("Authorization", "hello authorized world!"));
+    }
+
+}

--- a/aws-java-sdk-core/src/test/java/com/amazonaws/auth/FullUriCredentialsEndpointProviderTest.java
+++ b/aws-java-sdk-core/src/test/java/com/amazonaws/auth/FullUriCredentialsEndpointProviderTest.java
@@ -53,10 +53,36 @@ public class FullUriCredentialsEndpointProviderTest {
 
         assertThat(sut.getCredentialsEndpoint().toString(), equalTo(fullUri));
     }
+
     @Test
     public void theLoopbackAddressIpv6IsAlsoAcceptable() throws URISyntaxException {
         String fullUri = "http://[::1]:9851/endpoint";
         helper.set(ContainerCredentialsProvider.CONTAINER_CREDENTIALS_FULL_URI, fullUri);
+
+        assertThat(sut.getCredentialsEndpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test
+    public void theEcsAddressIsAlsoAcceptable() throws URISyntaxException {
+        String fullUri = "http://169.254.170.2/endpoint";
+        helper.set(ContainerCredentialsProvider.CONTAINER_CREDENTIALS_FULL_URI, fullUri);
+
+        assertThat(sut.getCredentialsEndpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test
+    public void theEksAddressIpv4IsAlsoAcceptable() throws URISyntaxException {
+        String fullUri = "http://169.254.170.23/endpoint";
+        helper.set(ContainerCredentialsProvider.CONTAINER_CREDENTIALS_FULL_URI, fullUri);
+
+        assertThat(sut.getCredentialsEndpoint().toString(), equalTo(fullUri));
+    }
+
+    @Test
+    public void theEksAddressIpv6IsAlsoAcceptable() throws URISyntaxException {
+        String fullUri = "http://[fd00:ec2::23]/endpoint";
+        helper.set(ContainerCredentialsProvider.CONTAINER_CREDENTIALS_FULL_URI, fullUri);
+        helper.set(ContainerCredentialsProvider.AWS_EC2_METADATA_SERVICE_ENDPOINT_MODE, "IPV6");
 
         assertThat(sut.getCredentialsEndpoint().toString(), equalTo(fullUri));
     }


### PR DESCRIPTION
*Issue #, if available:* #3062

*Description of changes:*
Added support for the AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE environment variable in the FullUriCredentialsEndpointProvider, which is the required method of obtaining the authorization token when using the EKS Pod Identity feature. Moreover, the allowed hosts validation has been extended to include the ECS and EKS host IPs, which should be allowed for http (not https) traffic.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
