### PR TITLE
Update StsAuthUtils.java

### DIFF
--- a/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/internal/StsAuthUtils.java
+++ b/aws-java-sdk-sts/src/main/java/com/amazonaws/auth/internal/StsAuthUtils.java
@@ -26,7 +26,7 @@ public class StsAuthUtils {
     }
 
     public static String accountIdFromArn(AssumedRoleUser assumedRoleUser) throws IllegalArgumentException {
-        if (assumedRoleUser == null || assumedRoleUser.getArn() == null) {
+        if (assumedRoleUser == null || assumedRoleUser.getArn() == null || assumedRoleUser.getArn() == "") {
             return null;
         }
 


### PR DESCRIPTION
Do not try to parse accountIdFromArn if the ARN is blank string.

Some backends (specifically MinIO) return empty string as the Arn value instead of ommitting the AssumedRoleUser altogether.
This check handles those cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
