### PR TITLE
Update VersionInfoUtils - Fix deprecation message logic to use OR instead of AND

### DIFF
--- a/aws-java-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
+++ b/aws-java-sdk-core/src/main/java/com/amazonaws/util/VersionInfoUtils.java
@@ -63,7 +63,7 @@ public class VersionInfoUtils {
     private static void printDeprecationAnnouncement() {
         String disableAnnouncementEnvVar = System.getenv(DISABLE_DEPRECATION_ANNOUNCEMENT_ENV_VAR);
         String disableAnnouncementSysProp = System.getProperty(DISABLE_DEPRECATION_ANNOUNCEMENT_SYS_PROP);
-        boolean printDeprecationAnnouncement = !isTrue(disableAnnouncementEnvVar) && !isTrue(disableAnnouncementSysProp);
+        boolean printDeprecationAnnouncement = !isTrue(disableAnnouncementEnvVar) || !isTrue(disableAnnouncementSysProp);
 
         if (printDeprecationAnnouncement) {
             StringBuilder message = new StringBuilder(


### PR DESCRIPTION
Fix deprecation message logic to use OR instead of AND

### Motivation
The deprecation warning message was previously suppressed only if both the environment variable and the system property were set to 'true', due to the use of `&&`.

This PR corrects the condition to use `||`, so the warning is suppressed if **either** the environment variable or the system property is explicitly set to 'true'.

### Changes
- Replaced `&&` with `||` in the deprecation announcement check.
