### PR TITLE
Update netty to 4.1.124 to avoid High CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -455,7 +455,7 @@
       <cucumber.guice.version>4.2.3</cucumber.guice.version>
       <unitils.version>3.3</unitils.version>
       <!-- Netty is used by Kinesis Video -->
-      <netty.version>4.1.118.Final</netty.version>
+      <netty.version>4.1.124.Final</netty.version>
       <versions-maven-plugin.version>2.13.0</versions-maven-plugin.version>
   </properties>
   <dependencyManagement>


### PR DESCRIPTION
*Description of changes:*
Fix [CVE-2025-55163](https://www.cve.org/CVERecord?id=CVE-2025-55163) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
